### PR TITLE
BTB-120: re-attribute returning customers to canonical (event processor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ event-processor/src/billie_servicing/__pycache__/*
 event-processor/src/billie_servicing/handlers/__pycache__/*
 event-processor/src/billie_servicing/__pycache__
 event-processor/src/billie_servicing/handlers/__pycache__
+event-processor/.venv/*

--- a/event-processor/src/billie_servicing/handlers/__init__.py
+++ b/event-processor/src/billie_servicing/handlers/__init__.py
@@ -12,6 +12,10 @@ from .customer import (
     handle_customer_changed,
     handle_customer_verified,
 )
+from .identity import (
+    handle_customer_identity_linked,
+    handle_customer_identity_merged,
+)
 from .conversation import (
     handle_conversation_started,
     handle_utterance,
@@ -58,6 +62,8 @@ __all__ = [
     # Customer handlers
     "handle_customer_changed",
     "handle_customer_verified",
+    "handle_customer_identity_linked",
+    "handle_customer_identity_merged",
     # Conversation handlers
     "handle_conversation_started",
     "handle_utterance",

--- a/event-processor/src/billie_servicing/handlers/identity.py
+++ b/event-processor/src/billie_servicing/handlers/identity.py
@@ -1,0 +1,108 @@
+"""Customer identity link/merge handlers (BTB-120).
+
+Consumes ``customer.identity.linked.v1`` / ``customer.identity.merged.v1`` —
+which reach ``inbox:billie-servicing`` via billieChat routing — and
+re-attributes a returning customer's records from the alias id (the journey id,
+or the dropped canonical) to the surviving canonical id, then tombstones the
+orphan ``customers`` row that was created under the alias.
+
+The payloads are small and fixed (see ``billie_customers_events``
+``CustomerIdentityLinkedV1`` / ``CustomerIdentityMergedV1``: ``journey_id`` /
+``canonical_id`` and ``merged_canonical_id`` / ``canonical_id``) so we read them
+straight from the envelope rather than coupling to a specific SDK version.
+
+Idempotent: the re-attribution UPDATEs match the alias id, so a second delivery
+finds no alias rows left to move, and the ``merged_into`` tombstone is a fixed
+write. Processor-level dedup also guards exact redelivery.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import asyncpg
+import structlog
+
+from .sanitize import safe_str
+
+logger = structlog.get_logger()
+
+# Projection tables that carry a (customer_id_string, customer_id_id) pair we
+# re-point to the canonical customer.
+_REATTRIBUTE_TABLES = ("conversations", "applications", "loan_accounts")
+
+
+def _extract_payload(event: dict[str, Any]) -> dict[str, Any]:
+    """Return the event payload as a dict (it may arrive as a JSON string)."""
+    payload = event.get("payload", {})
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (ValueError, TypeError):
+            payload = {}
+    return payload if isinstance(payload, dict) else {}
+
+
+async def handle_customer_identity_linked(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
+    """Handle ``customer.identity.linked.v1`` (AC-C1/AC-C2)."""
+    payload = _extract_payload(event)
+    await _merge_identity(
+        pool,
+        canonical_id=safe_str(payload.get("canonical_id"), "canonical_id"),
+        alias_id=safe_str(payload.get("journey_id"), "journey_id"),
+        kind="linked",
+    )
+
+
+async def handle_customer_identity_merged(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
+    """Handle ``customer.identity.merged.v1`` (AC-C1/AC-C2)."""
+    payload = _extract_payload(event)
+    await _merge_identity(
+        pool,
+        canonical_id=safe_str(payload.get("canonical_id"), "canonical_id"),
+        alias_id=safe_str(payload.get("merged_canonical_id"), "merged_canonical_id"),
+        kind="merged",
+    )
+
+
+async def _merge_identity(
+    pool: asyncpg.Pool, canonical_id: str, alias_id: str, kind: str
+) -> None:
+    """Re-attribute alias records to the canonical and tombstone the alias row."""
+    log = logger.bind(canonical_id=canonical_id, alias_id=alias_id, kind=kind)
+    if not canonical_id or not alias_id or canonical_id == alias_id:
+        log.debug("Identity merge no-op (missing ids or self-link)")
+        return
+
+    log.info("Processing customer.identity event — re-attributing to canonical")
+
+    # Resolve the canonical customers row reference (may be None if the canonical
+    # customer row hasn't been projected yet — the string column still re-buckets
+    # the monitoring grid, and the ref backfills on the next canonical event).
+    canonical_ref = await pool.fetchval(
+        "SELECT id FROM customers WHERE customer_id = $1", canonical_id
+    )
+    now = datetime.now(timezone.utc)
+
+    async with pool.acquire() as conn, conn.transaction():
+        for table in _REATTRIBUTE_TABLES:
+            await conn.execute(
+                f"UPDATE {table} "
+                f"SET customer_id_string = $1, customer_id_id = $2 "
+                f"WHERE customer_id_string = $3",
+                canonical_id,
+                canonical_ref,
+                alias_id,
+            )
+        # Tombstone/redirect the orphan customers row created under the alias.
+        await conn.execute(
+            "UPDATE customers SET merged_into = $1, updated_at = $2 "
+            "WHERE customer_id = $3",
+            canonical_id,
+            now,
+            alias_id,
+        )
+
+    log.info("Re-attributed alias records to canonical and tombstoned alias row")

--- a/event-processor/src/billie_servicing/main.py
+++ b/event-processor/src/billie_servicing/main.py
@@ -19,6 +19,9 @@ from .handlers import (
     # Customer handlers
     handle_customer_changed,
     handle_customer_verified,
+    # Identity link/merge handlers (BTB-120)
+    handle_customer_identity_linked,
+    handle_customer_identity_merged,
     # Conversation handlers
     handle_conversation_started,
     handle_utterance,
@@ -104,6 +107,15 @@ def setup_handlers(processor: EventProcessor) -> None:
     processor.register_handler("customer.created.v1", handle_customer_changed)
     processor.register_handler("customer.updated.v1", handle_customer_changed)
     processor.register_handler("customer.verified.v1", handle_customer_verified)
+
+    # Identity link/merge — re-attribute returning customers to the canonical
+    # id and tombstone the orphan alias row (BTB-120).
+    processor.register_handler(
+        "customer.identity.linked.v1", handle_customer_identity_linked
+    )
+    processor.register_handler(
+        "customer.identity.merged.v1", handle_customer_identity_merged
+    )
 
     # =========================================================================
     # Conversation/Chat events (manual parsing - from worker.ts)

--- a/event-processor/src/billie_servicing/processor.py
+++ b/event-processor/src/billie_servicing/processor.py
@@ -603,6 +603,13 @@ class EventProcessor:
             # Use accounts SDK
             return parse_account_message(sdk_data)
 
+        elif event_type.startswith("customer.identity."):
+            # BTB-120 link/merge events carry a small fixed payload
+            # (journey_id/canonical_id or merged_canonical_id/canonical_id).
+            # Parse the envelope directly so this path stays independent of the
+            # installed customers SDK version; the handler reads the payload dict.
+            return sanitize_envelope(sanitized)
+
         elif event_type.startswith("customer.") or event_type.startswith("application."):
             # Use customers SDK
             payload = parse_customer_message(sdk_data)

--- a/event-processor/tests/test_identity_handlers.py
+++ b/event-processor/tests/test_identity_handlers.py
@@ -1,0 +1,107 @@
+"""BTB-120: customer.identity.linked/merged.v1 re-attribution in the CRM
+event processor (AC-C1/AC-C2/AC-C3/AC-C4)."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from billie_servicing.handlers.identity import (
+    handle_customer_identity_linked,
+    handle_customer_identity_merged,
+)
+
+_REATTRIBUTE_TABLES = ("conversations", "applications", "loan_accounts")
+
+
+def _last_update_call(mock_pool, table):
+    updates = [c for c in mock_pool.calls_against(table) if c.op == "UPDATE"]
+    return updates[-1] if updates else None
+
+
+@pytest.mark.asyncio
+async def test_linked_reattributes_all_tables_to_canonical(mock_pool):
+    """AC-C2/AC-C3: conversations, applications and accounts move alias→canonical."""
+    mock_pool.set_fetchval("canonical-ref-uuid")  # SELECT id FROM customers ...
+
+    event = {
+        "typ": "customer.identity.linked.v1",
+        "conv": "identity-B",
+        "usr": "B",
+        "payload": {"journey_id": "B", "canonical_id": "A"},
+    }
+    await handle_customer_identity_linked(mock_pool, event)
+
+    for table in _REATTRIBUTE_TABLES:
+        upd = mock_pool.last_update(table)
+        assert upd is not None, f"no UPDATE recorded for {table}"
+        assert upd["customer_id_string"] == "A"
+        assert upd["customer_id_id"] == "canonical-ref-uuid"
+        call = _last_update_call(mock_pool, table)
+        assert call.where["customer_id_string"] == "B"
+
+
+@pytest.mark.asyncio
+async def test_linked_tombstones_alias_customer_row(mock_pool):
+    """AC-C2/AC-C4: the orphan customers row is redirected via merged_into."""
+    mock_pool.set_fetchval("canonical-ref-uuid")
+
+    await handle_customer_identity_linked(
+        mock_pool,
+        {"payload": {"journey_id": "B", "canonical_id": "A"}},
+    )
+
+    cust = mock_pool.last_update("customers")
+    assert cust is not None
+    assert cust["merged_into"] == "A"
+    call = _last_update_call(mock_pool, "customers")
+    assert call.where["customer_id"] == "B"
+
+
+@pytest.mark.asyncio
+async def test_merged_event_folds_dropped_canonical(mock_pool):
+    """AC-C1: customer.identity.merged.v1 re-attributes merged_canonical_id."""
+    mock_pool.set_fetchval(None)  # canonical row not yet projected
+
+    await handle_customer_identity_merged(
+        mock_pool,
+        {
+            "typ": "customer.identity.merged.v1",
+            "payload": {"canonical_id": "A", "merged_canonical_id": "Z"},
+        },
+    )
+
+    assert mock_pool.last_update("customers")["merged_into"] == "A"
+    conv = _last_update_call(mock_pool, "conversations")
+    assert conv.where["customer_id_string"] == "Z"
+    # customer_id_id is set to NULL when the canonical row isn't projected yet.
+    assert conv.values["customer_id_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_self_link_is_noop(mock_pool):
+    """AC-B7 mirror: journey == canonical writes nothing."""
+    await handle_customer_identity_linked(
+        mock_pool, {"payload": {"journey_id": "A", "canonical_id": "A"}}
+    )
+    assert mock_pool.calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_ids_is_noop(mock_pool):
+    """A malformed payload (no canonical) is a safe no-op."""
+    await handle_customer_identity_linked(
+        mock_pool, {"payload": {"journey_id": "B"}}
+    )
+    assert mock_pool.calls == []
+
+
+@pytest.mark.asyncio
+async def test_payload_as_json_string(mock_pool):
+    """The payload may arrive as a JSON string; it is still parsed."""
+    mock_pool.set_fetchval("ref")
+    await handle_customer_identity_linked(
+        mock_pool,
+        {"payload": json.dumps({"journey_id": "B", "canonical_id": "A"})},
+    )
+    assert mock_pool.last_update("customers")["merged_into"] == "A"

--- a/src/collections/Customers.ts
+++ b/src/collections/Customers.ts
@@ -31,6 +31,20 @@ export const Customers: CollectionConfig = {
       },
     },
     {
+      // BTB-120: when a returning customer is recognised, the thin customers row
+      // created under the pre-link (alias) id is tombstoned/redirected here to
+      // the surviving canonical customerId. Set by the Python event processor on
+      // customer.identity.linked.v1 / .merged.v1.
+      name: 'mergedInto',
+      type: 'text',
+      index: true,
+      admin: {
+        description:
+          'If set, this customer record was merged into the canonical customerId shown here (returning-customer de-duplication).',
+        readOnly: true,
+      },
+    },
+    {
       name: 'title',
       type: 'text',
       admin: {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -185,6 +185,10 @@ export interface Customer {
   id: string;
   customerId: string;
   /**
+   * If set, this customer record was merged into the canonical customerId shown here (returning-customer de-duplication).
+   */
+  mergedInto?: string | null;
+  /**
    * Mr, Mrs, Ms, Dr, etc.
    */
   title?: string | null;
@@ -1332,6 +1336,7 @@ export interface MediaSelect<T extends boolean = true> {
  */
 export interface CustomersSelect<T extends boolean = true> {
   customerId?: T;
+  mergedInto?: T;
   title?: T;
   preferredName?: T;
   firstName?: T;


### PR DESCRIPTION
## Summary

Part of BTB-120 (returning-customer de-duplication). Adds a CRM event-processor handler for `customer.identity.linked.v1` / `customer.identity.merged.v1` (these already reach `inbox:billie-servicing`).

## Changes
- **New `handlers/identity.py`** — on link/merge, re-attributes `conversations`, `applications` and `loan_accounts` from the alias id to the canonical (`customer_id_string` + `customer_id_id`) and tombstones the orphan `customers` row via a new `mergedInto` field. Idempotent (re-attribution matches the alias id; processor-level dedup guards redelivery).
- Registered the two handlers in `main.py`; `_parse_event` short-circuits `customer.identity.*` so it doesn't go through the customers SDK parser (keeps it independent of the installed SDK version — the payload is read directly).
- **`Customers` collection**: added `mergedInto` field (+ regenerated `payload-types.ts`).
- Tests: `tests/test_identity_handlers.py` (re-attribution, tombstone, merged-event, self-link/missing-id no-ops, JSON-string payload). Full suite 144 pass.

## Notes
The conversation monitoring grid re-buckets automatically because re-attribution rewrites `customer_id_string` to the canonical (AC-C3). Switching the handler onto the SDK parser is optional follow-up once `customers-v2.1.0` is published.

https://claude.ai/code/session_01ACgWfY5jpFVWxGcNfpQSy7

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACgWfY5jpFVWxGcNfpQSy7)_