### PR TITLE
chore(event-processor): bump billie-customers-events to v2.1.0 (BTB-120)

### DIFF
--- a/event-processor/pyproject.toml
+++ b/event-processor/pyproject.toml
@@ -17,7 +17,7 @@ structlog = "^24.0"
 # Billie Event SDKs - installed from GitHub
 # Note: Requires GITHUB_TOKEN environment variable
 billie-accounts-events = {git = "https://github.com/BillieLoans/billie-event-sdks.git", subdirectory = "packages/accounts", tag = "accounts-v2.2.0"}
-billie-customers-events = {git = "https://github.com/BillieLoans/billie-event-sdks.git", subdirectory = "packages/customers", tag = "customers-v2.0.0"}
+billie-customers-events = {git = "https://github.com/BillieLoans/billie-event-sdks.git", subdirectory = "packages/customers", tag = "customers-v2.1.0"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"

--- a/event-processor/requirements.txt
+++ b/event-processor/requirements.txt
@@ -9,7 +9,7 @@ email-validator==2.2.0
 # Billie Event SDKs
 # Install event sdks directly from git repo
 git+https://${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@accounts-v2.8.0#subdirectory=packages/accounts
-git+https://${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@customers-v2.0.0#subdirectory=packages/customers
+git+https://${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@customers-v2.1.0#subdirectory=packages/customers
 git+https://${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@ledger-v1.1.0#subdirectory=packages/ledger
 git+https://${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@notifications-v1.1.1#subdirectory=packages/notifications
 git+https://${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@aging-v1.1.0#subdirectory=packages/aging


### PR DESCRIPTION
## Summary
- Bump `billie-customers-events` pin `customers-v2.0.0` → `customers-v2.1.0` in `event-processor/requirements.txt` and `event-processor/pyproject.toml`
- Picks up the new `CustomerIdentityLinkedV1` / `CustomerIdentityMergedV1` models required by the identity re-attribution handlers merged in #7

Release: https://github.com/BillieLoans/billie-event-sdks/releases/tag/customers-v2.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)