### PR TITLE
Fix repayment-schedule projection: jsonb encoding, status enum, dedup boundary

### DIFF
--- a/event-processor/src/billie_servicing/handlers/account.py
+++ b/event-processor/src/billie_servicing/handlers/account.py
@@ -11,6 +11,7 @@ Handles events:
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -476,8 +477,11 @@ async def handle_schedule_updated(pool: asyncpg.Pool, parsed_event: Any) -> None
                     if getattr(payment, "amount_remaining", None) is not None
                     else None
                 )
+                # linked_transaction_ids is a jsonb column. asyncpg needs a JSON
+                # *string* for jsonb (no list/dict codec is registered) — passing a
+                # raw Python list raises DataError. Serialise it like db.merge_jsonb.
                 linked_ids = (
-                    list(payment.linked_transaction_ids)
+                    json.dumps(list(payment.linked_transaction_ids))
                     if getattr(payment, "linked_transaction_ids", None)
                     else None
                 )

--- a/event-processor/src/billie_servicing/handlers/account.py
+++ b/event-processor/src/billie_servicing/handlers/account.py
@@ -39,6 +39,18 @@ CLOSURE_REASON_STATUS_MAP = {
     "ADMIN_CLOSED": "paid_off",
 }
 
+# SDK PaymentStatus → Payload repayment-schedule enum
+# (enum_loan_accounts_repayment_schedule_payments_status: scheduled/paid/partial/missed).
+# Keyed by the upper-cased status member; already-Payload values map to themselves.
+SCHEDULE_PAYMENT_STATUS_MAP = {
+    "PENDING": "scheduled",
+    "SCHEDULED": "scheduled",
+    "PARTIAL": "partial",
+    "PAID": "paid",
+    "OVERDUE": "missed",
+    "MISSED": "missed",
+}
+
 
 def _normalise_status(value: Any, default: str = "PENDING") -> str:
     """Strip the ``EnumName.MEMBER`` prefix that some Pydantic enums stringify with."""
@@ -461,10 +473,12 @@ async def handle_schedule_updated(pool: asyncpg.Pool, parsed_event: Any) -> None
 
             for payment in payment_updates:
                 payment_number = int(payment.payment_number)
-                new_status = (str(payment.status).lower() if payment.status else "scheduled")
-                # Map the SDK string status onto the Payload select enum.
-                if "." in new_status:
-                    new_status = new_status.split(".")[-1]
+                # Map the SDK PaymentStatus (PENDING/PARTIAL/PAID/OVERDUE) onto the
+                # Payload repayment-schedule enum (scheduled/partial/paid/missed).
+                # Unknown values fall back to 'scheduled' so the upsert never fails
+                # the enum check.
+                raw_status = _normalise_status(payment.status, "PENDING").upper()
+                new_status = SCHEDULE_PAYMENT_STATUS_MAP.get(raw_status, "scheduled")
 
                 paid_date = coerce_date(getattr(payment, "paid_date", None))
                 amount_paid = (

--- a/event-processor/src/billie_servicing/processor.py
+++ b/event-processor/src/billie_servicing/processor.py
@@ -535,12 +535,16 @@ class EventProcessor:
             stream_label = "internal" if stream == settings.internal_stream else "external"
             print(f"📥 [{stream_label}] Received event: {event_type} (id: {logical_event_id})")
 
-            # Atomic dedup: SET NX returns True if key was set (not a duplicate)
+            # Dedup marks SUCCESSFUL processing, so we only CHECK here and SET it
+            # after the handler succeeds (below). Setting it up front would suppress
+            # the retry of a message whose handler failed — the failed message stays
+            # pending, but on redelivery the dedup key would make it look like a
+            # duplicate and get ACK'd without ever being processed. Handlers are
+            # idempotent (ON CONFLICT upserts), so reprocessing is safe.
             dedup_key = f"dedup:{stream}:{message_id_str}"
-            is_new = await self.redis.set(dedup_key, "1", nx=True, ex=settings.dedup_ttl_seconds)
-            if not is_new:
+            if await self.redis.exists(dedup_key):
                 print(f"   ⏭️  Skipping duplicate event")
-                log.debug("Duplicate event, skipping")
+                log.debug("Duplicate event, skipping (already processed)")
                 await self.redis.xack(stream, settings.consumer_group, message_id)
                 return
 
@@ -558,7 +562,10 @@ class EventProcessor:
             # Execute handler (writes to Postgres via the asyncpg pool)
             await handler(self.pool, parsed_event)
 
-            # ACK after successful write
+            # Mark as processed (dedup) only AFTER the write succeeds, then ACK.
+            # On failure the handler raises before this line, so no dedup key is
+            # written and the pending message can be retried cleanly.
+            await self.redis.set(dedup_key, "1", ex=settings.dedup_ttl_seconds)
             await self.redis.xack(stream, settings.consumer_group, message_id)
 
             print(f"   ✅ Processed successfully")

--- a/event-processor/tests/test_handlers.py
+++ b/event-processor/tests/test_handlers.py
@@ -354,6 +354,31 @@ class TestScheduleUpdatedHandler:
         # guard for the schedule-allocation linkage bug.
         assert isinstance(row["linked_transaction_ids"], str)
         assert json.loads(row["linked_transaction_ids"]) == ["TXN-001"]
+
+    @pytest.mark.asyncio
+    async def test_sdk_status_values_map_to_payload_enum(self, mock_pool):
+        # SDK PaymentStatus (PENDING/OVERDUE/PAID/PARTIAL) must map onto the
+        # Payload enum (scheduled/missed/paid/partial). Regression for the
+        # enum-mismatch crash: invalid input value ... status: "pending".
+        mock_pool.set_fetchval("parent-uuid")
+        event = MagicMock()
+        event.payload = MagicMock()
+        event.payload.account_id = "ACC-TEST-001"
+        event.payload.schedule_id = "SCHED-001"
+        event.payload.payments = [
+            self._make_payment(1, "PENDING"),
+            self._make_payment(2, "OVERDUE"),
+            self._make_payment(3, "PAID", amount_paid=Decimal("50.00")),
+            self._make_payment(4, "PARTIAL", amount_paid=Decimal("25.00"), amount_remaining=Decimal("25.00")),
+        ]
+
+        await handle_schedule_updated(mock_pool, event)
+
+        rows = {
+            r["payment_number"]: r["status"]
+            for r in mock_pool.inserts_into("loan_accounts_repayment_schedule_payments")
+        }
+        assert rows == {1: "scheduled", 2: "missed", 3: "paid", 4: "partial"}
         # Conflict target is the composite natural key.
         call = [c for c in mock_pool.calls_against("loan_accounts_repayment_schedule_payments")
                 if c.op == "INSERT"][0]

--- a/event-processor/tests/test_handlers.py
+++ b/event-processor/tests/test_handlers.py
@@ -10,6 +10,7 @@ inspect the parsed call stream on ``mock_pool`` rather than asserting on
 Mongo-style update_one shapes.
 """
 
+import json
 from datetime import datetime
 from decimal import Decimal
 from unittest.mock import MagicMock
@@ -348,6 +349,11 @@ class TestScheduleUpdatedHandler:
         assert row["status"] == "paid"
         assert row["amount_paid"] == 145.00
         assert row["amount_remaining"] == 0
+        # linked_transaction_ids feeds a jsonb column — it must be a JSON string,
+        # not a raw Python list (asyncpg raises DataError otherwise). Regression
+        # guard for the schedule-allocation linkage bug.
+        assert isinstance(row["linked_transaction_ids"], str)
+        assert json.loads(row["linked_transaction_ids"]) == ["TXN-001"]
         # Conflict target is the composite natural key.
         call = [c for c in mock_pool.calls_against("loan_accounts_repayment_schedule_payments")
                 if c.op == "INSERT"][0]
@@ -394,6 +400,7 @@ class TestScheduleUpdatedHandler:
         assert row["status"] == "partial"
         assert row["amount_paid"] == 75.00
         assert row["amount_remaining"] == 70.00
+        assert json.loads(row["linked_transaction_ids"]) == ["TXN-001", "TXN-002"]
 
     @pytest.mark.asyncio
     async def test_missed_payment(self, mock_pool):

--- a/event-processor/tests/test_processor_dedup.py
+++ b/event-processor/tests/test_processor_dedup.py
@@ -1,0 +1,101 @@
+"""Transactional-boundary tests for EventProcessor._process_message.
+
+Regression for the dedup/ack ordering bug: the dedup key used to be written
+*before* the handler ran, so a message whose handler failed could never be
+retried — on redelivery the dedup key made it look like a duplicate and it was
+ACK'd without ever being processed. The dedup key must be written only *after*
+the handler succeeds.
+"""
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def make_processor(monkeypatch):
+    # The notifications/aging Billie SDKs aren't installed in the local dev venv;
+    # the processor only needs them inside _parse_event (which these tests bypass).
+    # Stub any that are missing so the module imports cleanly.
+    if "billie_notifications_events" not in sys.modules:
+        parent = types.ModuleType("billie_notifications_events")
+        submod = types.ModuleType("billie_notifications_events.parser")
+        submod.parse_notification_event = lambda *a, **k: None
+        parent.parser = submod
+        monkeypatch.setitem(sys.modules, "billie_notifications_events", parent)
+        monkeypatch.setitem(sys.modules, "billie_notifications_events.parser", submod)
+    if "billie_aging_events" not in sys.modules:
+        aging = types.ModuleType("billie_aging_events")
+        aging.parse_aging_event = lambda *a, **k: None
+        monkeypatch.setitem(sys.modules, "billie_aging_events", aging)
+
+    import billie_servicing.processor as procmod
+
+    # Neutralise the URL/TLS guard so construction needs no real config.
+    monkeypatch.setattr(procmod, "_check_tls_urls", lambda *a, **k: None)
+
+    def _factory(handler):
+        proc = procmod.EventProcessor(
+            redis_url="redis://localhost:6379",
+            database_uri="postgresql://localhost/test",
+        )
+        proc.redis = AsyncMock()
+        proc.redis.exists = AsyncMock(return_value=0)
+        proc.redis.set = AsyncMock()
+        proc.redis.xack = AsyncMock()
+        proc.pool = AsyncMock()
+        proc.handlers = {"acct.test.v1": handler}
+        # Bypass real SDK parsing — we only care about the dedup/ack flow.
+        proc._parse_event = MagicMock(return_value=object())
+        return proc
+
+    return _factory
+
+
+STREAM = "inbox:test"
+MESSAGE = (b"msg-1", {b"msg_type": b"acct.test.v1"})
+
+
+@pytest.mark.asyncio
+async def test_dedup_written_after_successful_handler(make_processor):
+    from billie_servicing.config import settings
+
+    handler = AsyncMock()
+    proc = make_processor(handler)
+
+    await proc._process_message(MESSAGE, STREAM, delivery_count=1)
+
+    handler.assert_awaited_once()
+    proc.redis.set.assert_awaited_once_with(
+        "dedup:inbox:test:msg-1", "1", ex=settings.dedup_ttl_seconds
+    )
+    proc.redis.xack.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_handler_writes_no_dedup_and_no_ack(make_processor):
+    # The crux: a failed handler must leave the message retryable — no dedup key
+    # (so the retry isn't suppressed as a duplicate) and no ACK (stays pending).
+    handler = AsyncMock(side_effect=RuntimeError("boom"))
+    proc = make_processor(handler)
+
+    await proc._process_message(MESSAGE, STREAM, delivery_count=1)
+
+    handler.assert_awaited_once()
+    proc.redis.set.assert_not_awaited()
+    proc.redis.xack.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_already_processed_message_is_skipped(make_processor):
+    handler = AsyncMock()
+    proc = make_processor(handler)
+    proc.redis.exists = AsyncMock(return_value=1)  # dedup key present => done before
+
+    await proc._process_message(MESSAGE, STREAM, delivery_count=1)
+
+    handler.assert_not_awaited()
+    proc.redis.set.assert_not_awaited()
+    proc.redis.xack.assert_awaited_once()


### PR DESCRIPTION
## Summary
Three stacked bugs stopped `account.schedule.updated.v1` from ever updating a repayment instalment's allocation — the partial-paid amount and linked-transaction chip never appeared in the CRM even though the events were flowing.

1. **jsonb encoding** — the handler bound a raw Python list to the `linked_transaction_ids` `jsonb` column; asyncpg has no list→jsonb codec, so it raised `DataError: expected str, got list`. Now `json.dumps`-encoded (matching `db.merge_jsonb`).
2. **status enum** — the handler lower-cased the SDK `PaymentStatus` (`PENDING`/`PARTIAL`/`PAID`/`OVERDUE`) and wrote it straight to the Payload enum (`scheduled`/`paid`/`partial`/`missed`), so `pending`/`overdue` failed the enum check (surfaced once #1 was fixed). Added `SCHEDULE_PAYMENT_STATUS_MAP` (`PENDING→scheduled`, `OVERDUE→missed`, …; unknown→`scheduled`).
3. **dedup / ack boundary** — the dedup key was `SET NX` *before* the handler ran, so a message whose handler failed stayed pending but its dedup key persisted (24h TTL); on redelivery it was treated as a duplicate and ACK'd without processing — one failure permanently suppressed retries. The dedup key is now written **only after** the handler succeeds (check up front, set immediately before `XACK`). Safe because handlers are idempotent `ON CONFLICT` upserts.

## Test plan
- [x] `tests/test_handlers.py` — regression asserts: `linked_transaction_ids` is JSON-serialised; SDK statuses map to the Payload enum.
- [x] `tests/test_processor_dedup.py` (new) — dedup written after success; **failed handler writes no dedup + no ack**; already-processed skips + acks.
- [x] Runnable handler + processor suites: **40 passing**. (Two unrelated processor test files can't collect locally due to a missing optional `billie_notifications_events` dep — pre-existing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)