### PR TITLE
Fix 14 pre-existing failing unit tests (stale tests, not product bugs)

### DIFF
--- a/tests/unit/api/dashboard.test.ts
+++ b/tests/unit/api/dashboard.test.ts
@@ -61,6 +61,11 @@ describe('Dashboard Schema', () => {
         },
       ],
       pendingDisbursementsCount: 1,
+      moneyFlowsToday: {
+        paymentsExpected: { count: 3, totalAmount: 750, totalAmountFormatted: '$750.00' },
+        paymentsReceived: { count: 2, totalAmount: 500, totalAmountFormatted: '$500.00' },
+        disbursed: { count: 1, totalAmount: 7000, totalAmountFormatted: '$7,000.00' },
+      },
       systemStatus: {
         ledger: 'online',
         latencyMs: 45,

--- a/tests/unit/ui/assessment-views.test.tsx
+++ b/tests/unit/ui/assessment-views.test.tsx
@@ -8,11 +8,22 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { render as rtlRender, screen, fireEvent, cleanup } from '@testing-library/react'
 import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AssessmentPanel } from '@/components/ConversationDetailView/AssessmentPanel'
 import { AssessmentDetailView } from '@/components/ConversationDetailView/AssessmentDetailView'
 import type { ConversationDetail } from '@/lib/schemas/conversations'
+
+// AssessmentPanel renders StatementFileViewer, which uses React Query. The app
+// shell provides a QueryClient in production; wrap every render here so the
+// hooks have one. (The statement query is disabled when no slot is selected.)
+const render = (ui: React.ReactElement) =>
+  rtlRender(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      {ui}
+    </QueryClientProvider>,
+  )
 
 vi.mock('next/link', () => ({
   default: ({ children, href, ...props }: React.PropsWithChildren<{ href: string; [k: string]: unknown }>) => (

--- a/tests/unit/ui/sortable-table.test.tsx
+++ b/tests/unit/ui/sortable-table.test.tsx
@@ -331,7 +331,10 @@ describe('SortableTable', () => {
         />,
       )
 
-      expect(screen.getByTestId('header-name')).toHaveAttribute('aria-sort', 'ascending')
+      expect(screen.getByTestId('header-name').closest('[role="columnheader"]')).toHaveAttribute(
+        'aria-sort',
+        'ascending',
+      )
     })
 
     it('should update aria-sort when direction changes', () => {
@@ -348,7 +351,10 @@ describe('SortableTable', () => {
       // Click to toggle to descending
       fireEvent.click(screen.getByTestId('header-name'))
 
-      expect(screen.getByTestId('header-name')).toHaveAttribute('aria-sort', 'descending')
+      expect(screen.getByTestId('header-name').closest('[role="columnheader"]')).toHaveAttribute(
+        'aria-sort',
+        'descending',
+      )
     })
 
     it('should have role attributes for table structure', () => {


### PR DESCRIPTION
## Summary
Fixes the 14 unit-test failures that were red on `main`. **All three were stale tests — the production code was correct in every case**, so the fixes align the tests with current behaviour (nothing weakened, no product changes).

1. **`dashboard.test.ts` (4)** — `DashboardResponseSchema` requires `moneyFlowsToday` (added in `cc09ac6`; the API route produces + `.parse()`s it), but the test's `validResponse` fixture predated it, so every `safeParse` returned `success: false`. Added the field to the fixture.
2. **`sortable-table.test.tsx` (2)** — `SortableTable` correctly sets `aria-sort` on the `role="columnheader"` element (per ARIA); the test asserted on the inner `<button>` (which carries `data-testid="header-name"`) where `aria-sort` is absent → `null`. Now asserts on the columnheader via `.closest()`.
3. **`assessment-views.test.tsx` (8)** — `AssessmentPanel` renders `StatementFileViewer` → `useStatementFile`/`useQuery` (added in `5c395ba`); the test rendered without a `QueryClient` (provided by the app shell in production), throwing `No QueryClient set`. Wrapped renders in a `QueryClientProvider` (the statement query is `enabled`-gated off with no slot, so it stays inert).

## Test plan
- [x] The 3 files: **68/68 pass** (was 14 failed / 54 passed).
- [x] Full suite `pnpm test:int`: **1545 passed, 2 skipped, 0 failed** (exit 0) — no regressions.

> Aside (not addressed here): running a *single* test file locally exits non-zero even when green — a global-teardown artifact of the testcontainer setup (a known-green untouched file reproduces it). The full `pnpm test:int` exits 0, so CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)