### PR TITLE
fix(servicing): refresh affordance, auto-refresh, working close button, right-pane wrapping

### DIFF
--- a/src/components/ServicingView/AccountPanel/AccountSummaryBar.module.css
+++ b/src/components/ServicingView/AccountPanel/AccountSummaryBar.module.css
@@ -24,4 +24,10 @@
 .menuItem { display: block; width: 100%; text-align: left; padding: 8px 10px; font-size: 12.5px; border: none; background: none; border-radius: 5px; cursor: pointer; color: var(--theme-text, #374151); }
 .menuItem:hover:not(:disabled) { background: var(--theme-elevation-50, #f4f5f7); }
 .menuItem:disabled { opacity: 0.5; cursor: not-allowed; }
-.refresh, .close { background: none; border: none; cursor: pointer; font-size: 14px; color: var(--theme-elevation-600, #6b7280); }
+.iconRow { display: flex; align-items: center; gap: 4px; }
+.iconBtn { display: inline-flex; align-items: center; justify-content: center; width: 32px; height: 32px; padding: 0; background: var(--theme-elevation-0, #fff); border: 1px solid var(--theme-elevation-150, #d6dae1); border-radius: 6px; cursor: pointer; line-height: 1; color: var(--theme-elevation-600, #6b7280); transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease; }
+.iconBtn:hover:not(:disabled) { background: var(--theme-elevation-50, #f4f5f7); color: var(--theme-text, #374151); border-color: var(--theme-elevation-250, #c2c8d0); }
+.iconBtn:disabled { opacity: 0.55; cursor: not-allowed; }
+.iconBtn svg { display: block; }
+.spinning .refreshIcon { animation: summaryRefreshSpin 0.7s linear infinite; transform-origin: center; }
+@keyframes summaryRefreshSpin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }

--- a/src/components/ServicingView/AccountPanel/AccountSummaryBar.tsx
+++ b/src/components/ServicingView/AccountPanel/AccountSummaryBar.tsx
@@ -127,11 +127,62 @@ export const AccountSummaryBar: React.FC<AccountSummaryBarProps> = (props) => {
             </div>
           )}
         </div>
-        {props.onRefresh && (
-          <button type="button" className={styles.refresh} onClick={props.onRefresh} disabled={props.isRefreshing} aria-label="Refresh data" data-testid="refresh-account-data">⟳</button>
-        )}
-        {props.showClose && props.onClose && (
-          <button type="button" className={styles.close} onClick={props.onClose} aria-label="Close account panel" data-testid="close-account-panel">✕</button>
+        {(props.onRefresh || (props.showClose && props.onClose)) && (
+          <div className={styles.iconRow}>
+            {props.onRefresh && (
+              <button
+                type="button"
+                className={`${styles.iconBtn} ${props.isRefreshing ? styles.spinning : ''}`}
+                onClick={props.onRefresh}
+                disabled={props.isRefreshing}
+                aria-label="Refresh data"
+                title="Refresh data"
+                data-testid="refresh-account-data"
+              >
+                <svg
+                  className={styles.refreshIcon}
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="23 4 23 10 17 10" />
+                  <polyline points="1 20 1 14 7 14" />
+                  <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+                </svg>
+              </button>
+            )}
+            {props.showClose && props.onClose && (
+              <button
+                type="button"
+                className={styles.iconBtn}
+                onClick={props.onClose}
+                aria-label="Close account panel"
+                title="Close"
+                data-testid="close-account-panel"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/src/components/ServicingView/Communications/styles.module.css
+++ b/src/components/ServicingView/Communications/styles.module.css
@@ -13,19 +13,21 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 20px;
+  gap: 10px;
+  padding: 14px 16px;
   border-bottom: 1px solid var(--theme-elevation-150, #e5e7eb);
   background: var(--theme-elevation-50, #f9fafb);
 }
 
 .panelTitle {
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 600;
   color: var(--theme-text, #1a1a1a);
-  display: flex;
-  align-items: center;
-  gap: 8px;
   margin: 0;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .headerActions {
@@ -46,6 +48,8 @@
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .addNoteBtn:hover {
@@ -230,6 +234,7 @@
   border-radius: 4px;
   font-size: 11px;
   font-weight: 500;
+  white-space: nowrap;
 }
 
 .badgeSent {

--- a/src/components/ServicingView/ContactNotes/ContactNoteCard.tsx
+++ b/src/components/ServicingView/ContactNotes/ContactNoteCard.tsx
@@ -206,7 +206,7 @@ export const ContactNoteCard: React.FC<ContactNoteCardProps> = ({
           {hasPreviousVersions && (
             <span className={`${styles.badge} ${styles.badgeAmendment}`}>AMENDED</span>
           )}
-          <span className={`${styles.badge} ${styles.badgeTopic}`}>{topicLabel}</span>
+          {/* Topic is shown once in the meta row below — keep the header light. */}
           <span className={styles.noteTimestamp}>{timestamp}</span>
         </div>
       </div>

--- a/src/components/ServicingView/ContactNotes/styles.module.css
+++ b/src/components/ServicingView/ContactNotes/styles.module.css
@@ -2,7 +2,7 @@
 .panel { border: 1px solid var(--theme-elevation-150, #e5e7eb); border-radius: 8px; overflow: hidden; margin-top: 24px; }
 .panelHeader { display: flex; align-items: center; justify-content: space-between; padding: 16px 20px; border-bottom: 1px solid var(--theme-elevation-150, #e5e7eb); background: var(--theme-elevation-50, #f9fafb); }
 .panelTitle { font-size: 16px; font-weight: 600; color: var(--theme-text, #1a1a1a); display: flex; align-items: center; gap: 8px; margin: 0; }
-.addNoteBtn { display: inline-flex; align-items: center; gap: 6px; padding: 8px 14px; background: var(--theme-success-500, #2563eb); color: white; border: none; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; }
+.addNoteBtn { display: inline-flex; align-items: center; gap: 6px; padding: 8px 14px; background: var(--theme-success-500, #2563eb); color: white; border: none; border-radius: 6px; font-size: 13px; font-weight: 500; cursor: pointer; white-space: nowrap; flex-shrink: 0; }
 .addNoteBtn:hover { background: var(--theme-success-600, #1d4ed8); }
 .filtersBar { display: flex; gap: 8px; padding: 12px 20px; border-bottom: 1px solid var(--theme-elevation-150, #e5e7eb); background: var(--theme-elevation-50, #f9fafb); }
 .filterSelect { padding: 6px 10px; border: 1px solid var(--theme-elevation-200, #d1d5db); border-radius: 6px; font-size: 13px; color: var(--theme-text, #1a1a1a); background: var(--theme-elevation-0, #fff); cursor: pointer; }
@@ -13,11 +13,11 @@
 .noteCardAmended .noteBody,
 .noteCardAmended .noteBodyRich { opacity: 0.65; }
 .noteCardHeader { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 4px; }
-.noteCardHeaderRight { display: flex; align-items: center; gap: 8px; }
-.noteTypeLabel { display: flex; align-items: center; gap: 6px; font-size: 13px; font-weight: 500; color: var(--theme-text, #1a1a1a); }
+.noteCardHeaderRight { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+.noteTypeLabel { display: flex; align-items: center; gap: 6px; font-size: 13px; font-weight: 500; color: var(--theme-text, #1a1a1a); white-space: nowrap; }
 .noteTimestamp { font-size: 12px; color: var(--theme-elevation-600, #6b7280); white-space: nowrap; }
 .noteBadges { display: flex; gap: 6px; margin-bottom: 8px; flex-wrap: wrap; }
-.badge { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; }
+.badge { display: inline-flex; align-items: center; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; white-space: nowrap; }
 .badgeAmended { background: #fef3c7; color: #92400e; }
 .badgeAmendment { background: #dbeafe; color: #1e40af; }
 .badgeTopic { background: var(--theme-elevation-100, #f3f4f6); color: var(--theme-elevation-700, #374151); }
@@ -44,11 +44,11 @@
 .bodyTruncated { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
 .showMoreBtn { background: none; border: none; color: var(--theme-success-500, #2563eb); font-size: 12px; cursor: pointer; padding: 2px 0; margin-top: 4px; }
 .noteDivider { border: none; border-top: 1px solid var(--theme-elevation-100, #f0f0f0); margin: 10px 0; }
-.noteFooter { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--theme-elevation-600, #6b7280); }
-.noteLinkedAccount { display: flex; align-items: center; gap: 4px; }
-.noteAccountLinkBtn { display: inline-flex; align-items: center; gap: 4px; background: none; border: none; color: var(--theme-success-500, #2563eb); font-size: 12px; cursor: pointer; padding: 0; text-decoration: underline; }
-.noteAuthor { flex: 1; }
-.amendBtn { background: none; border: none; color: var(--theme-success-500, #2563eb); font-size: 12px; cursor: pointer; padding: 0; }
+.noteFooter { display: flex; align-items: center; gap: 8px; row-gap: 6px; flex-wrap: wrap; font-size: 12px; color: var(--theme-elevation-600, #6b7280); }
+.noteLinkedAccount { display: flex; align-items: center; gap: 4px; white-space: nowrap; }
+.noteAccountLinkBtn { display: inline-flex; align-items: center; gap: 4px; background: none; border: none; color: var(--theme-success-500, #2563eb); font-size: 12px; cursor: pointer; padding: 0; text-decoration: underline; white-space: nowrap; }
+.noteAuthor { flex: 1; white-space: nowrap; }
+.amendBtn { background: none; border: none; color: var(--theme-success-500, #2563eb); font-size: 12px; cursor: pointer; padding: 0; white-space: nowrap; }
 .amendBtn:hover { text-decoration: underline; }
 .noteLinkBtn { background: none; border: none; color: var(--theme-success-500, #2563eb); font-size: 12px; cursor: pointer; padding: 0; text-decoration: underline; }
 

--- a/src/components/ServicingView/ServicingView.tsx
+++ b/src/components/ServicingView/ServicingView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useMemo, useEffect } from 'react'
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { useQueryClient } from '@tanstack/react-query'
 import { useCustomer, type LoanAccountData } from '@/hooks/queries/useCustomer'
@@ -69,7 +69,7 @@ const CustomerNotFound: React.FC = () => {
  */
 export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
   const queryClient = useQueryClient()
-  const { data: customer, isLoading, isError, isFetching: isCustomerFetching, refetch: refetchCustomer } = useCustomer(customerId)
+  const { data: customer, isLoading, isError, refetch: refetchCustomer } = useCustomer(customerId)
   const [isRefreshing, setIsRefreshing] = useState(false)
 
   // Track this customer view for "Recent Customers" feature
@@ -122,9 +122,24 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
     [customer?.vulnerableFlag, accounts, selectedAccountId, hasPendingWriteOff]
   )
 
+  // Auto-select runs ONCE per mount (the component fully remounts on customer
+  // navigation via window.location). Without this guard the effect re-fires
+  // whenever selection is cleared — e.g. the close button setting it to null,
+  // or the 30s background poll handing back a new `accounts` reference — and
+  // immediately re-selects the top account, defeating both.
+  const hasAutoSelectedRef = useRef(false)
+
   // Auto-select top-triaged account or account from URL query parameter
   useEffect(() => {
     if (accounts.length === 0) return
+    if (hasAutoSelectedRef.current) return
+
+    // A selection already exists (e.g. user clicked before this ran): record
+    // that initial selection is settled and never override it.
+    if (selectedAccountId) {
+      hasAutoSelectedRef.current = true
+      return
+    }
 
     // Check for account selection in URL query parameter
     if (typeof window !== 'undefined') {
@@ -133,8 +148,9 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
       if (accountIdParam) {
         // Find account by loanAccountId
         const account = accounts.find((a) => a.loanAccountId === accountIdParam)
-        if (account && !selectedAccountId) {
+        if (account) {
           setSelectedAccountId(account.loanAccountId)
+          hasAutoSelectedRef.current = true
           // Clean up URL by removing query parameter
           urlParams.delete('accountId')
           const newUrl = `${window.location.pathname}${urlParams.toString() ? `?${urlParams.toString()}` : ''}`
@@ -147,10 +163,11 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
     // Auto-select the top-triaged account (in-arrears first, then pending,
     // then active; falling back to the most recently closed) when nothing
     // is selected and no ?accountId= param applied above.
-    if (!selectedAccountId && accounts.length > 0) {
-      const { active, closed } = sortAccountsForRail(accounts)
-      const top = active[0] ?? closed[0]
-      if (top) setSelectedAccountId(top.loanAccountId)
+    const { active, closed } = sortAccountsForRail(accounts)
+    const top = active[0] ?? closed[0]
+    if (top) {
+      setSelectedAccountId(top.loanAccountId)
+      hasAutoSelectedRef.current = true
     }
   }, [accounts, selectedAccountId])
 
@@ -274,9 +291,6 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
     }
   }, [activeTab, selectedAccountId, refetchCustomer, queryClient])
 
-  // Combined refreshing state
-  const isFetchingData = isRefreshing || isCustomerFetching
-
   // Error state
   if (isError) {
     return (
@@ -368,7 +382,7 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
               onBulkWaive={handleBulkWaive}
               feesCount={feesCount}
               onRefresh={handleRefresh}
-              isRefreshing={isFetchingData}
+              isRefreshing={isRefreshing}
               onRequestWriteOff={handleOpenWriteOff}
               hasPendingWriteOff={hasPendingWriteOff}
               onDisburseLoan={handleOpenDisburseLoan}

--- a/src/hooks/queries/useCustomer.ts
+++ b/src/hooks/queries/useCustomer.ts
@@ -149,6 +149,11 @@ export function useCustomer(customerId: string) {
     queryFn: () => fetchCustomer(customerId),
     enabled: !!customerId,
     staleTime: 60_000, // 1 minute - customer data doesn't change often
+    // Light background poll so out-of-band changes (other staff, or the event
+    // processor projecting an inbound payment/fee) surface without a manual
+    // refresh. Paused while the tab is hidden to avoid needless load.
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
     retry: false, // Don't retry on 404
   })
 

--- a/tests/unit/ui/servicing-view-layout.test.tsx
+++ b/tests/unit/ui/servicing-view-layout.test.tsx
@@ -1,6 +1,6 @@
 // tests/unit/ui/servicing-view-layout.test.tsx
 import { describe, test, expect, afterEach, vi } from 'vitest'
-import { render, screen, cleanup, within } from '@testing-library/react'
+import { render, screen, cleanup, within, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import type { LoanAccountData } from '@/hooks/queries/useCustomer'
@@ -80,5 +80,15 @@ describe('ServicingView cockpit layout', () => {
     // its account number appears in the summary bar. (Scoped because the rail also
     // lists the same account number.)
     expect(within(summaryBar).getByText('over')).toBeInTheDocument()
+  })
+
+  test('close button dismisses the detail panel instead of re-selecting an account', () => {
+    renderWithClient(<ServicingView customerId="CUST-1" />)
+    // Multi-account customer, so the close (deselect) control is shown.
+    fireEvent.click(screen.getByTestId('close-account-panel'))
+    // The panel should collapse to the empty state — auto-select must NOT
+    // immediately re-pick the top-triaged account.
+    expect(screen.queryByTestId('account-summary-bar')).not.toBeInTheDocument()
+    expect(screen.getByText('Select an account from the list.')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

UX polish on the servicing cockpit's account detail panel and right-hand Communications pane, plus a real bug fix for the panel close button.

**Account detail header**
- Replaced the hairline `⟳`/`✕` glyphs (which rendered tiny regardless of container size) with properly sized 18px stroked **SVG icon buttons** — 32px hit area, hover state; the refresh icon spins while a refresh is in flight.
- Added a **30s background poll** to `useCustomer` (`refetchIntervalInBackground: false`, so it pauses when the tab is hidden) so out-of-band changes — another staff member, or the event processor projecting an inbound payment/fee — surface without a manual refresh.
- Decoupled the refresh spinner/disabled state from the background poll, so the icon only reacts to **user-initiated** refreshes (no pulsing every 30s).

**Close button (bug fix)**
- The close (✕) button did nothing visible: the auto-select effect depended on `selectedAccountId` and re-fired whenever it cleared, instantly re-selecting the top account. The new poll made it worse (each poll hands back a fresh `accounts` reference). Auto-select now runs **once per mount** via a ref guard. Safe because the view fully remounts on customer navigation (`window.location.href`).

**Communications / contact-note right pane**
- Fixed mid-phrase word wrapping ("+ Add Note", "General Enquiry", "By Rohan Sharp", the "(1)" count) by keeping atomic labels on one line and letting their containers wrap between elements.
- Removed the **duplicate topic badge** from the note-card header (still shown once in the meta row), de-cluttering the header.

## Test Plan
- [x] `pnpm test:int` — full unit + integration suite green (1553 passed, 2 pre-existing skips)
- [x] New regression test: close button dismisses the detail panel instead of re-selecting
- [ ] Manual: open a multi-account customer → bigger refresh icon, spins on click; close button returns to empty detail state; right pane labels no longer break mid-word; topic badge appears once