### PR TITLE
fix(event-processor): surface blocked re-applications under canonical + skip unhandled events

### DIFF
--- a/event-processor/src/billie_servicing/handlers/identity.py
+++ b/event-processor/src/billie_servicing/handlers/identity.py
@@ -29,9 +29,14 @@ from .sanitize import safe_str
 
 logger = structlog.get_logger()
 
-# Projection tables that carry a (customer_id_string, customer_id_id) pair we
-# re-point to the canonical customer.
-_REATTRIBUTE_TABLES = ("conversations", "applications", "loan_accounts")
+# Projection tables that carry a denormalised customer_id_string column we
+# re-point directly to the canonical customer. The applications table is NOT in
+# this list — it links to the customer only by the customer_id_id relationship
+# (it has no customer_id_string column), so it is re-pointed by ref below.
+# Putting it here made every re-attribution UPDATE raise
+# ``column "customer_id_string" does not exist`` and roll back the whole
+# transaction, so no records ever moved and the event hit the DLQ.
+_STRING_KEYED_TABLES = ("conversations", "loan_accounts")
 
 
 async def resolve_canonical_customer_id(target: Any, customer_id: str | None) -> str | None:
@@ -94,16 +99,22 @@ async def _merge_identity(
 
     log.info("Processing customer.identity event — re-attributing to canonical")
 
-    # Resolve the canonical customers row reference (may be None if the canonical
-    # customer row hasn't been projected yet — the string column still re-buckets
-    # the monitoring grid, and the ref backfills on the next canonical event).
+    # Resolve both customers-row references. canonical_ref may be None if the
+    # canonical customer row hasn't been projected yet — the string column still
+    # re-buckets the monitoring grid, and the ref backfills on the next canonical
+    # event. alias_ref is needed to re-point `applications`, which links to the
+    # customer only by customer_id_id (it has no customer_id_string column).
     canonical_ref = await pool.fetchval(
         "SELECT id FROM customers WHERE customer_id = $1", canonical_id
+    )
+    alias_ref = await pool.fetchval(
+        "SELECT id FROM customers WHERE customer_id = $1", alias_id
     )
     now = datetime.now(timezone.utc)
 
     async with pool.acquire() as conn, conn.transaction():
-        for table in _REATTRIBUTE_TABLES:
+        # String-keyed projections carry customer_id_string + customer_id_id.
+        for table in _STRING_KEYED_TABLES:
             await conn.execute(
                 f"UPDATE {table} "
                 f"SET customer_id_string = $1, customer_id_id = $2 "
@@ -111,6 +122,17 @@ async def _merge_identity(
                 canonical_id,
                 canonical_ref,
                 alias_id,
+            )
+        # applications has no customer_id_string — re-point it by the customer_id_id
+        # relationship. Only when both refs resolve: if the canonical row isn't
+        # projected yet we'd otherwise NULL the link (applications has no string
+        # fallback), so leave it on the alias row — now tombstoned via merged_into —
+        # until a later canonical event re-points it.
+        if alias_ref is not None and canonical_ref is not None:
+            await conn.execute(
+                "UPDATE applications SET customer_id_id = $1 WHERE customer_id_id = $2",
+                canonical_ref,
+                alias_ref,
             )
         # Tombstone/redirect the orphan customers row created under the alias.
         await conn.execute(

--- a/event-processor/src/billie_servicing/handlers/reapplication.py
+++ b/event-processor/src/billie_servicing/handlers/reapplication.py
@@ -24,10 +24,21 @@ import asyncpg
 import structlog
 
 from ..db import coerce_date, upsert, upsert_conversation
-from .identity import resolve_canonical_customer_id
+from .identity import _merge_identity, resolve_canonical_customer_id
 from .sanitize import parse_payload, safe_str
 
 logger = structlog.get_logger()
+
+# Block reasons that reflect a confident match to a single canonical identity —
+# only these re-attribute the blocked journey's records onto the canonical
+# customer so the app surfaces in the canonical's application list. DEFAULT-DENY
+# everything else (PEP, ID_VERIFICATION, SERVICEABILITY, ACCOUNT_CONDUCT,
+# IDENTITY_CONFLICT and any unknown future value): record the block only.
+# IDENTITY_CONFLICT is excluded on purpose — strong-vs-strong means the canonical
+# is ambiguous, so auto-merging could attribute an application to the WRONG
+# person. Mis-merging two people in the servicing view is worse than a missing
+# app; start conservative and expand this allowlist deliberately.
+_REATTRIBUTE_BLOCK_REASONS = frozenset({"ACTIVE_LOAN", "PRIOR_DEFAULT"})
 
 
 async def handle_reapplication_blocked(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
@@ -109,5 +120,43 @@ async def handle_reapplication_blocked(pool: asyncpg.Pool, event: dict[str, Any]
         )
     else:
         log.warning("Re-application block event without customer id — no customer mirror")
+
+    # Surface the blocked application under the canonical customer. A blocked
+    # returning customer never gets a customer.identity.linked.v1 (halted
+    # journeys stay evidence-only upstream), so without this the conversation /
+    # application stays under the journey id — invisible in the canonical's
+    # application list. Reuse _merge_identity (the same UPDATE-by-alias the
+    # linked/merged path uses) so re-attribution semantics and idempotency stay
+    # identical. Runs AFTER the conversation seed above so that row is moved too.
+    journey_id = (
+        safe_str(payload.get("journey_customer_id") or event.get("usr"), "journey_customer_id")
+        or None
+    )
+    block_canonical_id = (
+        safe_str(payload.get("canonical_customer_id"), "canonical_customer_id") or None
+    )
+    if (
+        reason in _REATTRIBUTE_BLOCK_REASONS
+        and journey_id
+        and block_canonical_id
+        and block_canonical_id != journey_id
+    ):
+        # Idempotent: _merge_identity UPDATEs WHERE customer_id_string =
+        # journey_id, so a redelivery finds the rows already on the canonical and
+        # matches nothing. CRM-local attribution only — no write-back to the
+        # upstream identity:canonical / identity:aliases keys.
+        await _merge_identity(
+            pool,
+            canonical_id=block_canonical_id,
+            alias_id=journey_id,
+            kind="reapplication_blocked",
+        )
+        log.info(
+            "Re-attributed blocked journey records to canonical",
+            journey_customer_id=journey_id,
+            canonical_customer_id=block_canonical_id,
+        )
+    elif reason not in _REATTRIBUTE_BLOCK_REASONS:
+        log.debug("Block reason not in re-attribution allowlist — block recorded only")
 
     log.info("Re-application block recorded")

--- a/event-processor/src/billie_servicing/processor.py
+++ b/event-processor/src/billie_servicing/processor.py
@@ -548,16 +548,21 @@ class EventProcessor:
                 await self.redis.xack(stream, settings.consumer_group, message_id)
                 return
 
-            # Parse with appropriate SDK
-            parsed_event = self._parse_event(event_type, sanitized)
-
-            # Get handler
+            # Get handler. Look this up BEFORE parsing: the external stream carries
+            # many event types the CRM doesn't consume, and the typed SDK parsers
+            # (e.g. parse_customer_message) are strict allowlists that raise
+            # UnsupportedEventTypeError on unknown types. Parsing an event we have
+            # no handler for is wasted work that would otherwise crash and DLQ
+            # perfectly benign events (e.g. customer.contact.verified.v1).
             handler = self.handlers.get(event_type)
             if not handler:
                 print(f"   ⚠️  No handler for event type: {event_type}")
                 log.warning("No handler registered for event type")
                 await self.redis.xack(stream, settings.consumer_group, message_id)
                 return
+
+            # Parse with appropriate SDK (only for events we will actually handle)
+            parsed_event = self._parse_event(event_type, sanitized)
 
             # Execute handler (writes to Postgres via the asyncpg pool)
             await handler(self.pool, parsed_event)

--- a/event-processor/tests/test_identity_handlers.py
+++ b/event-processor/tests/test_identity_handlers.py
@@ -11,7 +11,10 @@ from billie_servicing.handlers.identity import (
     handle_customer_identity_merged,
 )
 
-_REATTRIBUTE_TABLES = ("conversations", "applications", "loan_accounts")
+# conversations + loan_accounts carry a denormalised customer_id_string column;
+# the applications table links to the customer ONLY by the customer_id_id
+# relationship (no customer_id_string column exists on it).
+_STRING_KEYED_TABLES = ("conversations", "loan_accounts")
 
 
 def _last_update_call(mock_pool, table):
@@ -20,9 +23,10 @@ def _last_update_call(mock_pool, table):
 
 
 @pytest.mark.asyncio
-async def test_linked_reattributes_all_tables_to_canonical(mock_pool):
-    """AC-C2/AC-C3: conversations, applications and accounts move alias→canonical."""
-    mock_pool.set_fetchval("canonical-ref-uuid")  # SELECT id FROM customers ...
+async def test_linked_reattributes_string_keyed_tables_to_canonical(mock_pool):
+    """AC-C2/AC-C3: conversations and loan_accounts move alias→canonical by string."""
+    # fetchval 1: canonical ref, fetchval 2: alias ref.
+    mock_pool.set_fetchval_sequence(["canonical-ref-uuid", "alias-ref-uuid"])
 
     event = {
         "typ": "customer.identity.linked.v1",
@@ -32,13 +36,37 @@ async def test_linked_reattributes_all_tables_to_canonical(mock_pool):
     }
     await handle_customer_identity_linked(mock_pool, event)
 
-    for table in _REATTRIBUTE_TABLES:
+    for table in _STRING_KEYED_TABLES:
         upd = mock_pool.last_update(table)
         assert upd is not None, f"no UPDATE recorded for {table}"
         assert upd["customer_id_string"] == "A"
         assert upd["customer_id_id"] == "canonical-ref-uuid"
         call = _last_update_call(mock_pool, table)
         assert call.where["customer_id_string"] == "B"
+
+
+@pytest.mark.asyncio
+async def test_linked_reattributes_applications_by_ref_not_string(mock_pool):
+    """applications has no customer_id_string column — re-point it by the
+    customer_id_id relationship. Including it in the string-keyed UPDATE made the
+    whole re-attribution transaction raise ``column "customer_id_string" does not
+    exist`` and roll back, so nothing moved and the event hit the DLQ.
+    """
+    # fetchval 1: canonical ref, fetchval 2: alias ref.
+    mock_pool.set_fetchval_sequence(["canonical-ref-uuid", "alias-ref-uuid"])
+
+    await handle_customer_identity_linked(
+        mock_pool, {"payload": {"journey_id": "B", "canonical_id": "A"}}
+    )
+
+    appl = _last_update_call(mock_pool, "applications")
+    assert appl is not None, "no UPDATE recorded for applications"
+    # Must NEVER reference customer_id_string (the column doesn't exist here).
+    assert "customer_id_string" not in appl.values, appl.values
+    assert "customer_id_string" not in appl.where, appl.where
+    # Re-pointed by the customer_id_id ref (alias ref → canonical ref).
+    assert appl.values.get("customer_id_id") == "canonical-ref-uuid"
+    assert appl.where.get("customer_id_id") == "alias-ref-uuid"
 
 
 @pytest.mark.asyncio

--- a/event-processor/tests/test_processor_unhandled_skip.py
+++ b/event-processor/tests/test_processor_unhandled_skip.py
@@ -1,0 +1,93 @@
+"""Unhandled-event skip regression for EventProcessor._process_message.
+
+The external stream `inbox:billie-servicing` carries many event types the CRM
+does not consume. Such events should hit the "No handler registered" path and
+be ACK'd (skipped) cleanly.
+
+Regression (BTB demo): the handler lookup happened *after* `_parse_event`, and
+`_parse_event` routes any `customer.*` type into the typed customers SDK, which
+is a strict allowlist (`parse_customer_message`). An unhandled customer-domain
+event like `customer.contact.verified.v1` therefore raised
+`UnsupportedEventTypeError` during parse — before the no-handler skip could run —
+so the message was retried and finally moved to the DLQ instead of being
+skipped. The handler lookup must happen *before* parsing.
+"""
+
+import json
+import sys
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture
+def make_processor(monkeypatch):
+    # notifications/aging SDKs aren't in the local dev venv; the customers SDK
+    # IS installed, and this test exercises the real customers-SDK parse path.
+    if "billie_notifications_events" not in sys.modules:
+        parent = types.ModuleType("billie_notifications_events")
+        submod = types.ModuleType("billie_notifications_events.parser")
+        submod.parse_notification_event = lambda *a, **k: None
+        parent.parser = submod
+        monkeypatch.setitem(sys.modules, "billie_notifications_events", parent)
+        monkeypatch.setitem(sys.modules, "billie_notifications_events.parser", submod)
+    if "billie_aging_events" not in sys.modules:
+        aging = types.ModuleType("billie_aging_events")
+        aging.parse_aging_event = lambda *a, **k: None
+        monkeypatch.setitem(sys.modules, "billie_aging_events", aging)
+
+    import billie_servicing.processor as procmod
+
+    monkeypatch.setattr(procmod, "_check_tls_urls", lambda *a, **k: None)
+
+    proc = procmod.EventProcessor(
+        redis_url="redis://localhost:6379",
+        database_uri="postgresql://localhost/test",
+    )
+    proc.redis = AsyncMock()
+    proc.redis.exists = AsyncMock(return_value=0)
+    proc.redis.set = AsyncMock()
+    proc.redis.xack = AsyncMock()
+    proc.redis.xadd = AsyncMock()  # DLQ writes go here — must NOT be called
+    proc.pool = AsyncMock()
+    proc.handlers = {}  # nothing registered for the incoming type
+    # NOTE: _parse_event is the REAL method — this test proves the routing/parse
+    # order, so it must not be stubbed.
+    return proc
+
+
+STREAM = "inbox:billie-servicing"
+
+
+def _customer_event(event_type: str):
+    """A realistic Redis message for an unhandled customer-domain event."""
+    envelope = {
+        "conv": "c1",
+        "agt": "customerService",
+        "usr": "4A8C91AB",
+        "seq": "0",
+        "cls": "obs",
+        "typ": event_type,
+        "msg_type": event_type,
+        "payload": json.dumps({"customer_id": "CUST-1"}),
+    }
+    fields = {k.encode(): v.encode() for k, v in envelope.items()}
+    return (b"msg-1", fields)
+
+
+@pytest.mark.asyncio
+async def test_unhandled_customer_event_is_skipped_not_dlqd(make_processor):
+    proc = make_processor
+
+    # delivery_count well under max_retries: a crash here would simply leave the
+    # message pending (no ack), not DLQ — so asserting ACK is what proves the skip.
+    await proc._process_message(
+        _customer_event("customer.contact.verified.v1"), STREAM, delivery_count=1
+    )
+
+    # Skipped cleanly: ACK'd exactly once, never sent to the DLQ.
+    proc.redis.xack.assert_awaited_once()
+    proc.redis.xadd.assert_not_awaited()
+    # No dedup key for a skipped (unhandled) event.
+    proc.redis.set.assert_not_awaited()

--- a/event-processor/tests/test_reapplication_and_identity_verification.py
+++ b/event-processor/tests/test_reapplication_and_identity_verification.py
@@ -115,6 +115,165 @@ class TestReapplicationBlocked:
         assert mock_pool.last_insert("customers")["customer_id"] == "22F0652F"
 
 
+class TestReapplicationBlockedReattribution:
+    """A blocked returning customer never gets a ``customer.identity.linked.v1``
+    (halted journeys stay evidence-only upstream), so the block lands under the
+    journey id and is invisible in the canonical customer's application list.
+
+    The handler re-points the journey's records onto the canonical — but ONLY
+    for reasons that reflect a confident single-canonical identity match
+    (``ACTIVE_LOAN``, ``PRIOR_DEFAULT``). Everything else default-denies and
+    records the block only, because mis-merging two people in the servicing
+    view is worse than a missing app.
+    """
+
+    JOURNEY = "4A8C91AB"  # BLOCK_PAYLOAD journey_customer_id
+    CANONICAL = "22F0652F"  # BLOCK_PAYLOAD canonical_customer_id
+
+    def _event(self, reason: str, **overrides: object) -> dict:
+        payload = dict(BLOCK_PAYLOAD)
+        payload["reason"] = reason
+        payload.update(overrides)
+        return {
+            "typ": "application.reapplication_blocked.v1",
+            "usr": self.JOURNEY,
+            "payload": payload,
+        }
+
+    @staticmethod
+    def _string_reattributions(mock_pool, table):
+        """UPDATEs that re-point <table>'s customer_id_string (alias→canonical)."""
+        return [
+            c
+            for c in mock_pool.calls_against(table)
+            if c.op == "UPDATE" and "customer_id_string" in c.values
+        ]
+
+    @staticmethod
+    def _ref_reattributions(mock_pool, table):
+        """UPDATEs that re-point <table> by the customer_id_id ref only (applications
+        has no customer_id_string column)."""
+        return [
+            c
+            for c in mock_pool.calls_against(table)
+            if c.op == "UPDATE"
+            and "customer_id_id" in c.values
+            and "customer_id_string" not in c.values
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("reason", ["ACTIVE_LOAN", "PRIOR_DEFAULT"])
+    async def test_confident_reason_reattributes_all_tables(self, mock_pool, reason):
+        # fetchvals in order: resolve merged_into (mirror), canonical ref, alias ref.
+        mock_pool.set_fetchval_sequence([None, "canon-ref", "alias-ref"])
+        await handle_reapplication_blocked(mock_pool, self._event(reason))
+
+        # conversations + loan_accounts re-point by customer_id_string.
+        for table in ("conversations", "loan_accounts"):
+            ups = self._string_reattributions(mock_pool, table)
+            assert ups, f"expected string re-attribution UPDATE for {table} (reason={reason})"
+            assert ups[-1].values["customer_id_string"] == self.CANONICAL
+            assert ups[-1].where["customer_id_string"] == self.JOURNEY
+        # applications has no customer_id_string — re-pointed by the customer_id_id ref.
+        appls = self._ref_reattributions(mock_pool, "applications")
+        assert appls, f"expected ref re-attribution UPDATE for applications (reason={reason})"
+        assert appls[-1].values["customer_id_id"] == "canon-ref"
+        assert appls[-1].where["customer_id_id"] == "alias-ref"
+
+    @pytest.mark.asyncio
+    async def test_confident_reason_tombstones_journey_customer_row(self, mock_pool):
+        mock_pool.set_fetchval(None)
+        await handle_reapplication_blocked(mock_pool, self._event("ACTIVE_LOAN"))
+
+        tombstones = [
+            c
+            for c in mock_pool.calls_against("customers")
+            if c.op == "UPDATE" and "merged_into" in c.values
+        ]
+        assert tombstones, "expected merged_into tombstone on the journey customer row"
+        assert tombstones[-1].values["merged_into"] == self.CANONICAL
+        assert tombstones[-1].where["customer_id"] == self.JOURNEY
+
+    @pytest.mark.asyncio
+    async def test_identity_conflict_records_block_but_does_not_reattribute(self, mock_pool):
+        # Strong-vs-strong: the canonical is ambiguous, so auto-merging could
+        # attribute the app to the WRONG person — record the block only.
+        mock_pool.set_fetchval(None)
+        await handle_reapplication_blocked(mock_pool, self._event("IDENTITY_CONFLICT"))
+
+        # Block still recorded …
+        conv = mock_pool.last_insert("conversations")
+        assert conv["reapplication_block_reason"] == "IDENTITY_CONFLICT"
+        assert mock_pool.last_insert("customers")["customer_id"] == self.CANONICAL
+        # … but nothing re-attributed.
+        assert not mock_pool.updates_to("conversations")
+        assert not mock_pool.calls_against("applications")
+        assert not mock_pool.calls_against("loan_accounts")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reason",
+        ["PEP", "ID_VERIFICATION", "SERVICEABILITY", "ACCOUNT_CONDUCT", "FUTURE_UNKNOWN_REASON"],
+    )
+    async def test_non_allowlisted_reasons_do_not_reattribute(self, mock_pool, reason):
+        mock_pool.set_fetchval(None)
+        await handle_reapplication_blocked(mock_pool, self._event(reason))
+        assert not mock_pool.updates_to("conversations")
+        assert not mock_pool.calls_against("applications")
+        assert not mock_pool.calls_against("loan_accounts")
+
+    @pytest.mark.asyncio
+    async def test_canonical_equals_journey_is_noop(self, mock_pool):
+        # Recognised but same id as the journey → nothing to re-point even with
+        # an allowlisted reason.
+        mock_pool.set_fetchval(None)
+        event = self._event("ACTIVE_LOAN", journey_customer_id=self.CANONICAL)
+        event["usr"] = self.CANONICAL
+        await handle_reapplication_blocked(mock_pool, event)
+
+        assert not mock_pool.updates_to("conversations")
+        assert not mock_pool.calls_against("applications")
+        assert not mock_pool.calls_against("loan_accounts")
+
+    @pytest.mark.asyncio
+    async def test_redelivery_is_idempotent(self, mock_pool):
+        # Per delivery the handler issues: resolve merged_into, canonical ref, alias ref.
+        seq = [None, "canon-ref", "alias-ref"]
+        mock_pool.set_fetchval_sequence(seq + seq)
+        event = self._event("ACTIVE_LOAN")
+        await handle_reapplication_blocked(mock_pool, event)
+        await handle_reapplication_blocked(mock_pool, event)
+
+        # Re-attribution targets the alias on every delivery, so the real-DB second
+        # run matches no rows (they already moved on the first) — a no-op. The mock
+        # is stateless, so we assert the statement shape that guarantees that.
+        for table in ("conversations", "loan_accounts"):
+            ups = self._string_reattributions(mock_pool, table)
+            assert ups, f"no string re-attribution UPDATE for {table}"
+            assert all(c.where["customer_id_string"] == self.JOURNEY for c in ups)
+            assert all(c.values["customer_id_string"] == self.CANONICAL for c in ups)
+        appls = self._ref_reattributions(mock_pool, "applications")
+        assert appls, "no ref re-attribution UPDATE for applications"
+        assert all(c.where["customer_id_id"] == "alias-ref" for c in appls)
+        assert all(c.values["customer_id_id"] == "canon-ref" for c in appls)
+
+    @pytest.mark.asyncio
+    async def test_existing_block_projections_preserved_alongside_reattribution(self, mock_pool):
+        mock_pool.set_fetchval(None)
+        await handle_reapplication_blocked(mock_pool, self._event("ACTIVE_LOAN"))
+
+        # Conversation block fields still seeded …
+        conv = mock_pool.last_insert("conversations")
+        assert conv["reapplication_block_reason"] == "ACTIVE_LOAN"
+        assert conv["application_number"] == "A3CD3461-11F"
+        assert conv["reapplication_block_canonical_customer_id"] == self.CANONICAL
+        # … and the canonical "blocked until…" customer mirror still written.
+        cust = mock_pool.last_insert("customers")
+        assert cust["customer_id"] == self.CANONICAL
+        assert cust["reapplication_block_reason"] == "ACTIVE_LOAN"
+        assert cust["reapplication_block_application_number"] == "A3CD3461-11F"
+
+
 class TestFinalDecisionDetail:
     @pytest.mark.asyncio
     async def test_block_decline_stores_detail(self, mock_pool):


### PR DESCRIPTION
## Summary

Two event-processor fixes surfaced while diagnosing why a returning, blocked customer's application didn't appear under their canonical record in demo.

### 1. Surface reapplication-blocked apps under the canonical customer (+ fix shared re-attribution bug)

- Extend `handle_reapplication_blocked` to re-attribute the journey's records onto the canonical customer when the block reason is a confident single-canonical match (`ACTIVE_LOAN`, `PRIOR_DEFAULT`), reusing `_merge_identity`. All other reasons (`IDENTITY_CONFLICT`, `PEP`, `ID_VERIFICATION`, `SERVICEABILITY`, `ACCOUNT_CONDUCT`, unknown) default-deny — record the block only — so an ambiguous match can't misattribute an application to the wrong person.
- **Fix a pre-existing bug in `_merge_identity`** that broke *all* re-attribution (the existing `customer.identity.linked`/`merged` path included): it ran `UPDATE applications SET customer_id_string = …`, but `applications` has no `customer_id_string` column — it links to the customer only by the `customer_id_id` relationship. Postgres rejected the column at plan time and rolled back the whole transaction, so `conversations`/`loan_accounts` never moved and the event hit the DLQ. Applications are now re-pointed by `customer_id_id`; `conversations`/`loan_accounts` stay on `customer_id_string`.

### 2. Skip unhandled event types before SDK parse

The external stream carries many event types the CRM doesn't consume. The handler lookup happened *after* `_parse_event`, which routes `customer.*` types into the strict customers SDK allowlist — so a benign unhandled event like `customer.contact.verified.v1` raised `UnsupportedEventTypeError` during parse and was retried into the DLQ. Move the handler lookup *before* parsing.

## Evidence (demo)

Diagnosed via the demo Redis stream + DLQ:
- `customer.identity.linked.v1` and `application.reapplication_blocked.v1` were stuck unacked / DLQ'd with `column "customer_id_string" does not exist`.
- `customer.contact.verified.v1` × 26 in the DLQ with `Unsupported event type`.

## Tests

- TDD throughout. `_merge_identity` now has explicit coverage that `applications` is re-pointed by `customer_id_id` and never references `customer_id_string`; the reason allowlist is pinned (deny `IDENTITY_CONFLICT` et al.).
- New regression test for the unhandled-event skip path.
- Full Python suite: **177 passing** (excludes 2 files that need the notifications/aging SDKs, absent in the local venv).

## Deploy note

On redeploy, the processor reclaims the stuck `pending` events and reprocesses them with the fix, moving the blocked application onto the canonical customer. The 8 previously DLQ'd `customer.identity.linked.v1` events from earlier test runs can be replayed from `dlq:billie-servicing` if those conversations matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
