### PR TITLE
BTB-154: surface PRIOR_SERIOUS_ARREARS block reason in CRM

### DIFF
--- a/event-processor/src/billie_servicing/handlers/reapplication.py
+++ b/event-processor/src/billie_servicing/handlers/reapplication.py
@@ -38,7 +38,14 @@ logger = structlog.get_logger()
 # is ambiguous, so auto-merging could attribute an application to the WRONG
 # person. Mis-merging two people in the servicing view is worse than a missing
 # app; start conservative and expand this allowlist deliberately.
-_REATTRIBUTE_BLOCK_REASONS = frozenset({"ACTIVE_LOAN", "PRIOR_DEFAULT"})
+#
+# PRIOR_SERIOUS_ARREARS (BTB-154) is account-history-derived — it fires off the
+# resolved canonical's own prior closed-loan aging (ever reached late_arrears /
+# default, then cured), the same confident single-identity basis as
+# PRIOR_DEFAULT — so it re-attributes too.
+_REATTRIBUTE_BLOCK_REASONS = frozenset(
+    {"ACTIVE_LOAN", "PRIOR_DEFAULT", "PRIOR_SERIOUS_ARREARS"}
+)
 
 
 async def handle_reapplication_blocked(pool: asyncpg.Pool, event: dict[str, Any]) -> None:

--- a/event-processor/tests/test_reapplication_and_identity_verification.py
+++ b/event-processor/tests/test_reapplication_and_identity_verification.py
@@ -122,9 +122,9 @@ class TestReapplicationBlockedReattribution:
 
     The handler re-points the journey's records onto the canonical — but ONLY
     for reasons that reflect a confident single-canonical identity match
-    (``ACTIVE_LOAN``, ``PRIOR_DEFAULT``). Everything else default-denies and
-    records the block only, because mis-merging two people in the servicing
-    view is worse than a missing app.
+    (``ACTIVE_LOAN``, ``PRIOR_DEFAULT``, ``PRIOR_SERIOUS_ARREARS``). Everything
+    else default-denies and records the block only, because mis-merging two
+    people in the servicing view is worse than a missing app.
     """
 
     JOURNEY = "4A8C91AB"  # BLOCK_PAYLOAD journey_customer_id
@@ -162,7 +162,9 @@ class TestReapplicationBlockedReattribution:
         ]
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("reason", ["ACTIVE_LOAN", "PRIOR_DEFAULT"])
+    @pytest.mark.parametrize(
+        "reason", ["ACTIVE_LOAN", "PRIOR_DEFAULT", "PRIOR_SERIOUS_ARREARS"]
+    )
     async def test_confident_reason_reattributes_all_tables(self, mock_pool, reason):
         # fetchvals in order: resolve merged_into (mirror), canonical ref, alias ref.
         mock_pool.set_fetchval_sequence([None, "canon-ref", "alias-ref"])

--- a/src/collections/Conversations.ts
+++ b/src/collections/Conversations.ts
@@ -255,7 +255,7 @@ export const Conversations: CollectionConfig = {
           type: 'text',
           admin: {
             description:
-              'Block reason enum: ACTIVE_LOAN, PRIOR_DEFAULT, PEP, ID_VERIFICATION, SERVICEABILITY, ACCOUNT_CONDUCT, IDENTITY_CONFLICT',
+              'Block reason enum: ACTIVE_LOAN, PRIOR_DEFAULT, PRIOR_SERIOUS_ARREARS, PEP, ID_VERIFICATION, SERVICEABILITY, ACCOUNT_CONDUCT, IDENTITY_CONFLICT',
           },
         },
         {

--- a/src/collections/Customers.ts
+++ b/src/collections/Customers.ts
@@ -297,7 +297,7 @@ export const Customers: CollectionConfig = {
           type: 'text',
           admin: {
             description:
-              'Block reason enum: ACTIVE_LOAN, PRIOR_DEFAULT, PEP, ID_VERIFICATION, SERVICEABILITY, ACCOUNT_CONDUCT, IDENTITY_CONFLICT',
+              'Block reason enum: ACTIVE_LOAN, PRIOR_DEFAULT, PRIOR_SERIOUS_ARREARS, PEP, ID_VERIFICATION, SERVICEABILITY, ACCOUNT_CONDUCT, IDENTITY_CONFLICT',
           },
         },
         {

--- a/src/hooks/queries/useCustomer.ts
+++ b/src/hooks/queries/useCustomer.ts
@@ -102,7 +102,11 @@ export interface CustomerData {
   /** Active re-application block mirrored from the blocking application (BTB-135). */
   reapplicationBlock?: {
     reason?: string | null
-    /** null = permanent (PEP, PRIOR_DEFAULT, IDENTITY_CONFLICT) or while-loan-open (ACTIVE_LOAN) */
+    /**
+     * null = permanent (PEP, PRIOR_DEFAULT, IDENTITY_CONFLICT) or while-loan-open
+     * (ACTIVE_LOAN); a dated value for the decline windows and PRIOR_SERIOUS_ARREARS
+     * (BTB-154 — cured serious arrears/default, 12 months from loan closure).
+     */
     blockedUntil?: string | null
     blockedAt?: string | null
     applicationNumber?: string | null

--- a/src/lib/reapplicationBlock.ts
+++ b/src/lib/reapplicationBlock.ts
@@ -6,6 +6,9 @@
  * - `blockedUntil` is the inclusive end of the exclusion window.
  * - `blockedUntil = null` means permanent (PEP, PRIOR_DEFAULT, IDENTITY_CONFLICT)
  *   or ongoing-state (ACTIVE_LOAN — blocked while the loan is open).
+ * - dated windows carry a non-null `blockedUntil`: the decline windows
+ *   (ID_VERIFICATION, SERVICEABILITY, ACCOUNT_CONDUCT) and PRIOR_SERIOUS_ARREARS
+ *   (BTB-154 — cured serious-arrears/default, 12 months from loan closure).
  */
 
 import { formatDateOnly } from '@/lib/formatters'
@@ -14,6 +17,7 @@ import { formatDateOnly } from '@/lib/formatters'
 const BLOCK_REASON_LABELS: Record<string, string> = {
   ACTIVE_LOAN: 'Active loan',
   PRIOR_DEFAULT: 'Prior default',
+  PRIOR_SERIOUS_ARREARS: 'Prior serious arrears',
   PEP: 'PEP',
   ID_VERIFICATION: 'ID verification',
   SERVICEABILITY: 'Serviceability',

--- a/src/lib/schemas/conversations.ts
+++ b/src/lib/schemas/conversations.ts
@@ -102,7 +102,11 @@ export const ReapplicationBlockSchema = z.object({
   sourceApplicationNumber: z.string().nullable().optional(),
   sourceAccountId: z.string().nullable().optional(),
   sourceDecidedAt: z.union([z.string(), z.date()]).nullable().optional(),
-  /** null = permanent (PEP, PRIOR_DEFAULT, IDENTITY_CONFLICT) or while-loan-open (ACTIVE_LOAN) */
+  /**
+   * null = permanent (PEP, PRIOR_DEFAULT, IDENTITY_CONFLICT) or while-loan-open
+   * (ACTIVE_LOAN); a dated value for the decline windows and PRIOR_SERIOUS_ARREARS
+   * (BTB-154 — cured serious arrears/default, 12 months from loan closure).
+   */
   blockedUntil: z.union([z.string(), z.date()]).nullable().optional(),
   blockedAt: z.union([z.string(), z.date()]).nullable().optional(),
   canonicalCustomerId: z.string().nullable().optional(),

--- a/tests/unit/lib/reapplication-block.test.ts
+++ b/tests/unit/lib/reapplication-block.test.ts
@@ -18,6 +18,7 @@ describe('formatBlockReason', () => {
     expect(formatBlockReason('SERVICEABILITY')).toBe('Serviceability')
     expect(formatBlockReason('ACCOUNT_CONDUCT')).toBe('Account conduct')
     expect(formatBlockReason('IDENTITY_CONFLICT')).toBe('Identity conflict')
+    expect(formatBlockReason('PRIOR_SERIOUS_ARREARS')).toBe('Prior serious arrears')
   })
 
   it('falls back to the raw value for unknown enums', () => {
@@ -45,6 +46,17 @@ describe('formatBlockedUntil', () => {
 
   it('null window is while-loan-open for ACTIVE_LOAN', () => {
     expect(formatBlockedUntil({ reason: 'ACTIVE_LOAN', blockedUntil: null })).toBe('while loan open')
+  })
+
+  it('PRIOR_SERIOUS_ARREARS is a dated window, not permanent (BTB-154)', () => {
+    // Cured serious arrears/default carries a 12-month blockedUntil from
+    // closure — it must render as a date, never "permanent".
+    expect(
+      formatBlockedUntil({
+        reason: 'PRIOR_SERIOUS_ARREARS',
+        blockedUntil: '2027-06-10T01:02:21+00:00',
+      }),
+    ).toBe('until 10 June 2027')
   })
 })
 


### PR DESCRIPTION
## What & why

[BTB-154](https://billie-team.atlassian.net/browse/BTB-154) adds a new returning-customer decline reason in **billieChat** — `PRIOR_SERIOUS_ARREARS`: a customer whose prior loan ever reached `late_arrears` (15+ DPD) or `default` and then *cured* is blocked from re-applying for **12 months from the loan's closure date**. That work is already merged in billieChat; the reason now flows to the CRM via `application.reapplication_blocked.v1`.

The block reason is stored opaquely (free-text column — **no migration**), but the staff-facing display didn't know the new value, and the re-attribution allowlist didn't include it. This PR closes those gaps.

## Changes

**Display (`4621cdb`)**
- `src/lib/reapplicationBlock.ts` — add `PRIOR_SERIOUS_ARREARS: 'Prior serious arrears'` to `BLOCK_REASON_LABELS` so the decision banner / attention strip render a friendly label instead of the raw enum; clarify the `blockedUntil` header doc.
- `src/collections/Conversations.ts`, `src/collections/Customers.ts` — add the reason to the `reapplicationBlock.reason` admin field descriptions.
- `src/lib/schemas/conversations.ts`, `src/hooks/queries/useCustomer.ts` — correct the stale "permanent" comments: `PRIOR_SERIOUS_ARREARS` is a **dated** 12-month window (non-null `blockedUntil`), not one of the permanent reasons.
- `tests/unit/lib/reapplication-block.test.ts` — cover the new label and assert it renders as a dated window (never "permanent").

**Re-attribution (`8289431`)**
- `event-processor/.../handlers/reapplication.py` — add `PRIOR_SERIOUS_ARREARS` to `_REATTRIBUTE_BLOCK_REASONS`. Like `ACTIVE_LOAN`/`PRIOR_DEFAULT`, it is account-history-derived (it fires off the resolved canonical customer's own prior closed-loan aging), i.e. the same confident single-identity match — so the blocked returning-customer's application is re-pointed onto their canonical record and surfaces in the servicing view's application list, rather than staying invisible under the journey id.
- Extended the existing parametrized re-attribution test to cover the new reason; it's deliberately kept out of the non-allowlisted (record-only) set.

This re-attribution behaviour was a deliberate product decision (the allowlist comment says to expand it deliberately) — confirmed for inclusion.

## Scope / non-impact
- **No DB migration** — `reapplication_block_reason` is free-text.
- **No event/routing changes**, **no `payload-types` regen**.
- `billie-platform-services` and `billie-event-sdks` need no changes — they already emit/define every field BTB-154 relies on.

## Testing notes
- `event-processor` handler passes `ruff` cleanly; both Python files compile.
- I could not execute the suites in the authoring environment (CRM vitest boots a Postgres testcontainer — no Docker available; the event-processor's `asyncpg`/`structlog` deps weren't installed). Please run `pnpm test:int` and `cd event-processor && pytest` in CI / locally to confirm. The added cases ride existing, already-green code paths.

https://claude.ai/code/session_017BPVDq1pZsQMz64SnfsUxh

---
_Generated by [Claude Code](https://claude.ai/code/session_017BPVDq1pZsQMz64SnfsUxh)_