### PR TITLE
fix(event-processor): drop billieChat `rec` field before aging SDK parse

### DIFF
--- a/event-processor/src/billie_servicing/processor.py
+++ b/event-processor/src/billie_servicing/processor.py
@@ -651,8 +651,15 @@ class EventProcessor:
             return parse_notification_event(sdk_data)
 
         elif event_type.startswith("loan.aging."):
-            # Use aging SDK (aging-v1.1.0+ — typed Pydantic payload + envelope)
-            return parse_aging_event(sdk_data)
+            # Use aging SDK (aging-v1.1.0+ — typed Pydantic payload + envelope).
+            # `rec` is a billieChat routing field (a recipients list) this
+            # projection never reads. The aging SDK envelope mistypes it as
+            # `str`, so the sanitized list value (`[]` for broadcast scheduler
+            # events) fails Pydantic validation and DLQs every aging event. Drop
+            # it — the SDK falls back to its "" default. Other SDKs (accounts /
+            # customers) correctly type `rec` as a list, so this is aging-only.
+            aging_data = {k: v for k, v in sdk_data.items() if k != "rec"}
+            return parse_aging_event(aging_data)
 
         else:
             # Chat/conversation events — sanitize envelope so payload JSON string

--- a/event-processor/tests/test_processor_routing.py
+++ b/event-processor/tests/test_processor_routing.py
@@ -61,6 +61,48 @@ def test_reapplication_blocked_routes_to_envelope_dict(make_processor):
     assert parsed["payload"]["application_number"] == "A1"
 
 
+def test_aging_event_drops_billiechat_rec_routing_field(make_processor, monkeypatch):
+    """`rec` is a billieChat routing field (a recipients list) the aging
+    projection never reads. The aging SDK envelope mistypes it as `str`, so the
+    sanitized list value (`[]` for broadcast scheduler events) fails Pydantic
+    validation and DLQs *every* aging event. The processor must not hand `rec`
+    to the aging parser — it should fall back to the SDK's "" default.
+    """
+    import billie_servicing.processor as procmod
+
+    captured: dict = {}
+
+    def _capture(data):
+        captured["data"] = data
+        return None
+
+    monkeypatch.setattr(procmod, "parse_aging_event", _capture)
+
+    proc = make_processor
+    sanitized = {
+        "typ": "loan.aging.updated.v1",
+        "conv": "c1",
+        # the broker sends `rec` as a JSON-string list (broadcast => [])
+        "rec": "[]",
+        "payload": json.dumps(
+            {
+                "event_id": "age_1",
+                "timestamp": "2026-06-17T00:01:00Z",
+                "account_id": "acc_1",
+                "dpd": 2,
+                "bucket": "early_arrears",
+            }
+        ),
+    }
+
+    proc._parse_event("loan.aging.updated.v1", sanitized)
+
+    # `rec` must not reach the aging SDK as a list — its str-typed envelope
+    # rejects it. The payload (what the handler actually reads) is untouched.
+    assert not isinstance(captured["data"].get("rec"), list)
+    assert captured["data"]["payload"]["account_id"] == "acc_1"
+
+
 def test_other_application_events_still_use_customers_sdk(make_processor):
     # Precedence guard: a different application.* type must NOT be captured by the
     # exact-match reapplication_blocked branch — it stays on the customers-SDK


### PR DESCRIPTION
## Summary
- Every `loan.aging.updated.v1` event was being moved to the DLQ (191 of 325 demo DLQ entries) — the aging projection's `loan_accounts.aging_*` columns (arrears bucket / DPD) were never updated.
- Root cause: the aging SDK envelope (`ParsedAgingEvent` / `LedgerMessage`) types `rec` as `str`, but the platform sends `rec` as a recipients **list** (`[]` for broadcast scheduler events). `sanitize_envelope` JSON-parses it to a list (correct for the accounts/customers SDKs, which type it `Optional[List[str]]`), which then fails the aging SDK's strict `str` validation: `Input should be a valid string [input_value=[], input_type=list]`.
- `rec` is billieChat routing the CRM never reads, so the aging branch of `_parse_event` now drops it before `parse_aging_event`; the SDK falls back to its `""` default. Aging-only — other SDKs still receive `rec`.
- No SDK change required. (Upstream follow-up worth filing: `aging` + `notifications` SDKs mistype `rec` as `str`; `notifications` silently stores a meaningless `"[]"`.)

## Test Plan
- [x] New regression test `test_aging_event_drops_billiechat_rec_routing_field` — fails on the old code (`rec` is `[]`), passes now.
- [x] Verified against the **real** aging SDK + a **real** DLQ payload: reproduces the exact `EventValidationError` before, parses cleanly after (`rec` → `""`).
- [x] Full event-processor suite: 183 passed. The 2 `test_payload_size` failures are **pre-existing and unrelated** (a sync-`MagicMock` used in an `await` — confirmed by stashing this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)