### PR TITLE
feat(accounts): ingest commencement_date from account.created.v1 (BTB-158)

### DIFF
--- a/docs/superpowers/specs/2026-06-17-disbursement-cutoff-triage-design.md
+++ b/docs/superpowers/specs/2026-06-17-disbursement-cutoff-triage-design.md
@@ -41,6 +41,14 @@ The **cut-off deadline** for the "today" bucket is 15:00 `Australia/Sydney` on t
 
 ## Data dependency (build prerequisite)
 
+> **VERIFIED 2026-06-17 (Task 0):** `opened_date` is **NOT** the commencement date. The producer
+> `billie-platform-services` (`src/services/accountsService/commands.py:123`) sets
+> `opened_date=datetime.now()` at account-creation time; `account.created.v1` carries no commencement
+> field. billieChat's `commencement_date` is cached in `ExecutionPlanCache` but never passed into
+> account creation. **Conclusion: Phase 5 is REQUIRED** — the `openedDate` fallback is semantically
+> wrong (buckets on account-creation time, not loan start date). Recommended fix: source the real
+> commencement date (see options below). Until then the feature is demo-only, NOT prod-ready.
+
 `commencement_date` is **not in the CRM today.** Confirmed: the event processor reads only `inbox:billie-servicing` + `…:internal` (not `chatLedger`), and no CRM code references `commencement`, `execution_plan`, or `offer_valid_until`.
 
 Resolve in this order (this decides build effort — do it **first**):

--- a/event-processor/requirements.txt
+++ b/event-processor/requirements.txt
@@ -14,7 +14,7 @@ email-validator==2.2.0
 # ("could not read Password ... No such device or address"). Keep the
 # x-access-token: prefix. Applies to both `pip install -r` (pip expands ${...})
 # and the Docker subst-sdk-requirements.py path.
-git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@accounts-v2.8.0#subdirectory=packages/accounts
+git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@accounts-v2.9.0#subdirectory=packages/accounts
 git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@customers-v2.1.0#subdirectory=packages/customers
 git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@ledger-v1.1.0#subdirectory=packages/ledger
 git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@notifications-v1.1.1#subdirectory=packages/notifications

--- a/event-processor/src/billie_servicing/handlers/account.py
+++ b/event-processor/src/billie_servicing/handlers/account.py
@@ -106,6 +106,10 @@ async def handle_account_created(pool: asyncpg.Pool, parsed_event: Any) -> None:
         "created_at": now,
     }
 
+    commencement_date = getattr(payload, "commencement_date", None)
+    if commencement_date is not None:
+        values["commencement_date"] = coerce_date(commencement_date)
+
     signed_url = getattr(payload, "signed_loan_agreement_url", None)
     if signed_url is not None:
         values["signed_loan_agreement_url"] = str(signed_url) if signed_url else None
@@ -213,6 +217,13 @@ async def handle_account_updated(pool: asyncpg.Pool, parsed_event: Any) -> None:
                 new_balance=current_balance_value,
                 delta=delta,
             )
+
+    # Only update commencement_date when the field is present AND non-None —
+    # don't overwrite an existing value with None on unrelated account.updated.v1
+    # events (mirrors how signed_loan_agreement_url is handled via hasattr).
+    _commencement_date = getattr(payload, "commencement_date", None)
+    if _commencement_date is not None:
+        update_doc["commencement_date"] = coerce_date(_commencement_date)
 
     if hasattr(payload, "signed_loan_agreement_url"):
         update_doc["signed_loan_agreement_url"] = (

--- a/event-processor/tests/test_handlers.py
+++ b/event-processor/tests/test_handlers.py
@@ -11,8 +11,9 @@ Mongo-style update_one shapes.
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, date
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -180,6 +181,96 @@ class TestAccountHandlers:
             assert doc["account_status"] == expected_status, (
                 f"{sdk_status} → expected {expected_status}, got {doc['account_status']}"
             )
+
+    @pytest.mark.asyncio
+    async def test_handle_account_created_stores_commencement_date(self, mock_pool):
+        """account.created.v1 with commencement_date writes it to the projection.
+
+        Uses SimpleNamespace to simulate the accounts-v2.9.0 SDK field without
+        requiring the actual (yet-unreleased) package to be installed.
+        """
+        payload = SimpleNamespace(
+            account_id="ACC-CD-001",
+            account_number="ACC-CD-001",
+            customer_id="CUS-CD-001",
+            status="ACTIVE",
+            loan_amount=Decimal("500.00"),
+            loan_fee=Decimal("80.00"),
+            loan_total_payable=Decimal("580.00"),
+            current_balance=Decimal("580.00"),
+            opened_date="2026-06-18",
+            commencement_date=date(2026, 6, 19),
+            # signed_loan_agreement_url absent → getattr returns None → not written
+        )
+        event = SimpleNamespace(payload=payload)
+
+        await handle_account_created(mock_pool, event)
+
+        doc = mock_pool.last_insert("loan_accounts")
+        assert doc is not None
+        assert doc["loan_account_id"] == "ACC-CD-001"
+        # commencement_date must be present in the insert values
+        assert "commencement_date" in doc
+        assert doc["commencement_date"] is not None
+
+    @pytest.mark.asyncio
+    async def test_handle_account_created_without_commencement_date(self, mock_pool):
+        """account.created.v1 without commencement_date (old SDK) silently skips the field."""
+        payload = SimpleNamespace(
+            account_id="ACC-CD-002",
+            account_number="ACC-CD-002",
+            customer_id="CUS-CD-002",
+            status="ACTIVE",
+            loan_amount=Decimal("300.00"),
+            loan_fee=Decimal("50.00"),
+            loan_total_payable=Decimal("350.00"),
+            current_balance=Decimal("350.00"),
+            opened_date="2026-06-18",
+            # commencement_date attribute absent — simulates accounts-v2.8.0
+        )
+        event = SimpleNamespace(payload=payload)
+
+        await handle_account_created(mock_pool, event)
+
+        doc = mock_pool.last_insert("loan_accounts")
+        assert doc is not None
+        assert doc["loan_account_id"] == "ACC-CD-002"
+        # Field must NOT be written when absent (getattr returns None)
+        assert "commencement_date" not in doc
+
+    @pytest.mark.asyncio
+    async def test_handle_account_updated_sets_commencement_date_when_present(self, mock_pool):
+        """account.updated.v1 with commencement_date updates the column."""
+        event = MagicMock()
+        event.payload = MagicMock()
+        event.payload.account_id = "ACC-CD-003"
+        event.payload.current_balance = None
+        event.payload.status = None
+        event.payload.commencement_date = date(2026, 6, 20)
+
+        await handle_account_updated(mock_pool, event)
+
+        update = mock_pool.last_update("loan_accounts")
+        assert update is not None
+        assert "commencement_date" in update
+        assert update["commencement_date"] is not None
+
+    @pytest.mark.asyncio
+    async def test_handle_account_updated_skips_commencement_date_when_none(self, mock_pool):
+        """account.updated.v1 does NOT overwrite commencement_date with None on unrelated updates."""
+        event = MagicMock()
+        event.payload = MagicMock()
+        event.payload.account_id = "ACC-CD-004"
+        event.payload.current_balance = None
+        event.payload.status = None
+        # commencement_date is None (field present but empty) — must not overwrite
+        event.payload.commencement_date = None
+
+        await handle_account_updated(mock_pool, event)
+
+        update = mock_pool.last_update("loan_accounts")
+        assert update is not None
+        assert "commencement_date" not in update
 
     @pytest.mark.asyncio
     async def test_handle_schedule_created_writes_parent_and_payments(self, mock_pool):

--- a/src/collections/LoanAccounts.ts
+++ b/src/collections/LoanAccounts.ts
@@ -299,6 +299,16 @@ export const LoanAccounts: CollectionConfig = {
       },
     },
     {
+      name: 'commencementDate',
+      type: 'date',
+      index: true,
+      admin: {
+        readOnly: true,
+        description:
+          'Authoritative loan start date (= disbursement/value date) from account.created.v1 commencement_date, computed upstream with the 3pm-AEST cut-off + public-holiday logic. Bucket key for disbursement triage.',
+      },
+    },
+    {
       name: 'signedLoanAgreementUrl',
       type: 'text',
       admin: {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -929,6 +929,10 @@ export interface LoanAccount {
    */
   sdkStatus?: string | null;
   /**
+   * Authoritative loan start date (= disbursement/value date) from account.created.v1 commencement_date, computed upstream with the 3pm-AEST cut-off + public-holiday logic. Bucket key for disbursement triage.
+   */
+  commencementDate?: string | null;
+  /**
    * S3 URI for signed loan agreement document (from SDK: signed_loan_agreement_url, accounts-v2.7.0+)
    */
   signedLoanAgreementUrl?: string | null;
@@ -1771,6 +1775,7 @@ export interface LoanAccountsSelect<T extends boolean = true> {
       };
   accountStatus?: T;
   sdkStatus?: T;
+  commencementDate?: T;
   signedLoanAgreementUrl?: T;
   closure?:
     | T


### PR DESCRIPTION
## Summary

- Adds `commencementDate` as a top-level indexed `date` field on the `LoanAccounts` Payload collection — the field `getCommencementDate()` (in `src/lib/disbursement-cutoff.ts`) already reads `account.commencementDate`, so once this lands the accessor uses the real upstream value rather than the `loanTerms.openedDate` fallback.
- Python event-processor `handle_account_created` stores `commencement_date` defensively via `getattr(payload, "commencement_date", None)` — safe on existing accounts-v2.8.0 events.
- `handle_account_updated` only writes `commencement_date` when the field is present **and non-None** (mirrors the `signed_loan_agreement_url` pattern — prevents clobbering the value on unrelated updates).
- Bumps the accounts SDK pin: `accounts-v2.8.0` → `accounts-v2.9.0`.
- Regenerates `src/payload-types.ts` (`commencementDate?: string | null` on `LoanAccount`).
- Four new pytest tests; all passing (see test results below).

## Stack / merge order

> **This PR is stacked on `feat/btb-158-disbursement-cutoff-triage`.** Review and merge that PR first; merge this one after.

## Release ordering

> **Deploy the event-processor ONLY after `accounts-v2.9.0` is tagged** on `BillieLoans/billie-event-sdks`. The Payload/Next.js side (`commencementDate` field) is safe to deploy at any time — the column will simply be NULL for accounts created before the SDK ships. The Python handler uses `getattr` so it will not crash on old events even if deployed early; it just won't populate the field.

## Migration status — DEFERRED (no local Postgres)

The `commencement_date` column requires a Payload migration for migrate-enabled deploys (prod/staging via Neon). It could not be generated in this environment (no `DATABASE_URI`).

**Remaining step before deploying to prod/staging:**

```bash
# From the repo root, with DATABASE_URI pointing at a local Postgres:
make -C infra/fly pg-migrate-create ENV=dev NAME=loan_accounts_commencement_date
```

Commit the generated migration file before deploying. Dev and test environments use `push: true` and do **not** require this step.

## Test results

### Python (pytest)
```
tests/test_handlers.py::TestAccountHandlers::test_handle_account_created_stores_commencement_date PASSED
tests/test_handlers.py::TestAccountHandlers::test_handle_account_created_without_commencement_date PASSED
tests/test_handlers.py::TestAccountHandlers::test_handle_account_updated_sets_commencement_date_when_present PASSED
tests/test_handlers.py::TestAccountHandlers::test_handle_account_updated_skips_commencement_date_when_none PASSED

4 passed, 37 deselected in 0.61s
```

### TypeScript
```
pnpm exec tsc --noEmit 2>&1 | grep -E "LoanAccounts|payload-types|disbursement-cutoff"
# (no output — no new errors in changed files)
```

## Test plan

- [ ] Run `pnpm exec vitest run tests/unit/disbursement-cutoff.test.ts --config ./vitest.config.mts` — accessor tests pass
- [ ] Run `cd event-processor && python3 -m pytest tests/test_handlers.py -v` — all handlers tests pass
- [ ] After `accounts-v2.9.0` is tagged: bump installed SDK locally, confirm `commencement_date` is set on a fresh `account.created.v1` fixture
- [ ] Generate and review the Payload migration before deploying to staging/prod
- [ ] Post-deploy: verify `commencementDate` is populated on newly disbursed accounts and the disbursement triage queue buckets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EkfjzYeSqEQVrgYtWSrVn