### PR TITLE
feat(applications): surface identity-recognition context for review-kind re-application halts

### DIFF
--- a/event-processor/src/billie_servicing/handlers/reapplication.py
+++ b/event-processor/src/billie_servicing/handlers/reapplication.py
@@ -17,6 +17,7 @@ Two projections:
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from typing import Any
 
@@ -58,6 +59,14 @@ async def handle_reapplication_blocked(pool: asyncpg.Pool, event: dict[str, Any]
     application_number = safe_str(payload.get("application_number"), "application_number")
     reason = payload.get("reason")
 
+    # A halt is one of two kinds — "block" (a confirmed eligibility block) or
+    # "review" (held as a probable returning customer, carrying the
+    # identity-recognition match context). The recognition blob is projected
+    # verbatim into a jsonb column; asyncpg has no dict→jsonb codec, so serialise
+    # it to a JSON string here (None stays NULL — older events omit it).
+    recognition = payload.get("recognition")
+    recognition_json = json.dumps(recognition) if recognition is not None else None
+
     log = logger.bind(
         conversation_id=conversation_id,
         application_number=application_number,
@@ -87,6 +96,12 @@ async def handle_reapplication_blocked(pool: asyncpg.Pool, event: dict[str, Any]
                 "reapplication_block_canonical_customer_id": payload.get(
                     "canonical_customer_id"
                 ),
+                # Halt kind + the identity-recognition match context.
+                "reapplication_block_disposition_kind": payload.get("disposition_kind"),
+                "reapplication_block_manual_review_candidate": payload.get(
+                    "manual_review_candidate"
+                ),
+                "reapplication_block_recognition": recognition_json,
             },
             # Identifying columns only seed a fresh row — never overwrite an
             # existing one (identity merges may have re-pointed customer_id_string).

--- a/event-processor/tests/test_reapplication_and_identity_verification.py
+++ b/event-processor/tests/test_reapplication_and_identity_verification.py
@@ -31,6 +31,41 @@ BLOCK_PAYLOAD = {
     "blocked_at": "2026-06-10T07:08:40.123456+00:00",
 }
 
+# A review-kind halt — NOT a confirmed block. The applicant was flagged
+# as a probable returning customer and auto-held for manual review, carrying the
+# identity-recognition match context.
+REVIEW_PAYLOAD = {
+    "application_number": "B68196E0-0A6",
+    "conversation_id": "aa11bb22-cc33-dd44-ee55-ff6677889900",
+    "journey_customer_id": "4A8C91AB",
+    "canonical_customer_id": None,
+    "reason": "review",
+    "stop_message": "Thanks for sending that through! We just need to take a closer look...",
+    "blocked_until": None,
+    "blocked_at": "2026-06-18T04:15:30Z",
+    "disposition_kind": "review",
+    "manual_review_candidate": True,
+    "recognition": {
+        "band": "review",
+        "posterior": 0.989831,
+        "case_id": "4494ed09-25c3-4095-9dc5-a34f5e6db584",
+        "candidates": [
+            {
+                "candidate_id": "C5C7DD3A",
+                "posterior": 0.98,
+                "concealment": False,
+                "per_signal_bits": {
+                    "email": 10.0,
+                    "bank": 8.94,
+                    "address": 5.0,
+                    "name": -5.06,
+                    "dob": -5.64,
+                },
+            }
+        ],
+    },
+}
+
 
 class TestReapplicationBlocked:
     @pytest.mark.asyncio
@@ -113,6 +148,38 @@ class TestReapplicationBlocked:
 
         assert not mock_pool.inserts_into("conversations")
         assert mock_pool.last_insert("customers")["customer_id"] == "22F0652F"
+
+    @pytest.mark.asyncio
+    async def test_writes_review_disposition_and_recognition(self, mock_pool):
+        event = {
+            "typ": "application.reapplication_blocked.v1",
+            "usr": "4A8C91AB",
+            "payload": dict(REVIEW_PAYLOAD),
+        }
+        await handle_reapplication_blocked(mock_pool, event)
+
+        doc = mock_pool.last_insert("conversations")
+        assert doc is not None
+        assert doc["reapplication_block_reason"] == "review"
+        assert doc["reapplication_block_disposition_kind"] == "review"
+        assert doc["reapplication_block_manual_review_candidate"] is True
+        # recognition is stored verbatim as a JSON string — asyncpg has no
+        # dict→jsonb codec, so the handler json.dumps it for the jsonb column.
+        stored = doc["reapplication_block_recognition"]
+        assert isinstance(stored, str)
+        assert json.loads(stored) == REVIEW_PAYLOAD["recognition"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_block_payload_omits_recognition_fields(self, mock_pool):
+        # Older events carry none of the recognition fields — they must project as
+        # NULL, never crash, and never fabricate a recognition blob.
+        event = {"typ": "application.reapplication_blocked.v1", "payload": dict(BLOCK_PAYLOAD)}
+        await handle_reapplication_blocked(mock_pool, event)
+
+        doc = mock_pool.last_insert("conversations")
+        assert doc["reapplication_block_disposition_kind"] is None
+        assert doc["reapplication_block_manual_review_candidate"] is None
+        assert doc["reapplication_block_recognition"] is None
 
 
 class TestReapplicationBlockedReattribution:

--- a/src/collections/Conversations.ts
+++ b/src/collections/Conversations.ts
@@ -300,6 +300,28 @@ export const Conversations: CollectionConfig = {
           type: 'text',
           admin: { description: 'Resolved identity shared by all linked journeys' },
         },
+        // A halt is one of two kinds. "block" = a confirmed eligibility block
+        // (active loan / default / …). "review" = NOT a confirmed block —
+        // flagged as a probable returning customer and auto-held for manual
+        // review, carrying the identity-match context below.
+        {
+          name: 'dispositionKind',
+          type: 'text',
+          admin: { description: 'Halt kind: "block" (confirmed) or "review" (held for review)' },
+        },
+        {
+          name: 'manualReviewCandidate',
+          type: 'checkbox',
+          admin: { description: 'Whether this halt is a manual-review candidate' },
+        },
+        {
+          name: 'recognition',
+          type: 'json',
+          admin: {
+            description:
+              'Identity-recognition match context for a review halt (band, posterior, case_id, candidates with per-signal evidence). Stored verbatim from the event.',
+          },
+        },
       ],
     },
     {

--- a/src/components/ConversationDetailView/DecisionBanner/index.tsx
+++ b/src/components/ConversationDetailView/DecisionBanner/index.tsx
@@ -1,14 +1,23 @@
 'use client'
 
 import Link from 'next/link'
-import type { ConversationDetail } from '@/lib/schemas/conversations'
+import type { ConversationDetail, RecognitionCandidate } from '@/lib/schemas/conversations'
 import {
   formatBlockReason,
   formatBlockedUntil,
   isBlockDeclineReason,
 } from '@/lib/reapplicationBlock'
+import {
+  type SignalEntry,
+  formatPosterior,
+  formatSignalBits,
+  groupSignalBits,
+  signalLabel,
+} from '@/lib/recognition'
 import { formatDateOnly } from '@/lib/formatters'
 import styles from './styles.module.css'
+
+type ReapplicationBlock = NonNullable<ConversationDetail['reapplicationBlock']>
 
 export interface DecisionBannerProps {
   conversation: ConversationDetail
@@ -26,11 +35,25 @@ export interface DecisionBannerProps {
  *   rich detail from application.reapplication_blocked.v1 (the causal "why"),
  *   including the exclusion window, the prior decline that caused it, and the
  *   exact stop message the customer saw.
+ * - Review halt      → indigo. A "review"-kind re-application halt is
+ *   NOT a decline: the applicant was flagged as a probable returning customer
+ *   and auto-held for manual review. Rendered on its own axis (before the
+ *   decision states) with the identity-recognition match context — see
+ *   {@link ReviewHalt}.
  */
 export function DecisionBanner({ conversation }: DecisionBannerProps) {
   const { finalDecision, decisionDetail, reapplicationBlock, sourceConversationId } = conversation
 
   const decision = finalDecision?.toUpperCase() ?? null
+
+  // A "review" halt is NOT a decline — the applicant was flagged as a probable
+  // returning customer and auto-held for manual review. Surface it on
+  // its own axis, before the credit-decision states, so it renders whatever the
+  // (usually absent) decision is.
+  if (reapplicationBlock?.dispositionKind === 'review') {
+    return <ReviewHalt block={reapplicationBlock} />
+  }
+
   const block = reapplicationBlock?.reason ? reapplicationBlock : null
   const isBlockDecline = Boolean(block) || isBlockDeclineReason(decisionDetail?.reason)
 
@@ -141,6 +164,102 @@ export function DecisionBanner({ conversation }: DecisionBannerProps) {
           )}
         </div>
       )}
+    </div>
+  )
+}
+
+/**
+ * ReviewHalt — the indigo "under review" panel for a review-kind halt. Unlike a
+ * confirmed block (red), this isn't a decision: the applicant looks like a
+ * returning customer and was auto-held. We surface the match confidence, the
+ * case reference, and a per-candidate evidence breakdown so a reviewer can tell
+ * a genuine returning customer from shared/duplicate contact details.
+ */
+function ReviewHalt({ block }: { block: ReapplicationBlock }) {
+  const recognition = block.recognition
+  const candidates = recognition?.candidates ?? []
+
+  return (
+    <div className={`${styles.banner} ${styles.review}`} data-testid="decision-banner">
+      <span className={styles.headline}>⚑ Flagged for manual review</span>
+      <span className={styles.subhead}>
+        Not yet reviewed — auto-held as a probable returning customer
+      </span>
+      <div className={styles.detail}>
+        {recognition?.posterior != null && (
+          <div className={styles.detailRow}>
+            <span className={styles.detailLabel}>Match confidence</span>
+            <span className={styles.detailValue}>
+              {formatPosterior(recognition.posterior)}
+              {recognition.band && <span className={styles.bandTag}>{recognition.band} band</span>}
+            </span>
+          </div>
+        )}
+        {recognition?.case_id && (
+          <div className={styles.detailRow}>
+            <span className={styles.detailLabel}>Case</span>
+            <span className={`${styles.detailValue} ${styles.mono}`}>{recognition.case_id}</span>
+          </div>
+        )}
+
+        {candidates.length > 0 && (
+          <div className={styles.matches}>
+            <span className={styles.matchesHeading}>Potential matches</span>
+            {candidates.map((candidate, i) => (
+              <CandidateRow key={candidate.candidate_id ?? i} candidate={candidate} />
+            ))}
+          </div>
+        )}
+
+        {block.stopMessage && (
+          <div className={styles.detailRow}>
+            <span className={styles.detailLabel}>Customer saw</span>
+            <span className={`${styles.detailValue} ${styles.stopMessage}`}>
+              “{block.stopMessage}”
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CandidateRow({ candidate }: { candidate: RecognitionCandidate }) {
+  const { core, corroborating } = groupSignalBits(candidate.per_signal_bits)
+
+  return (
+    <div className={styles.candidate}>
+      <div className={styles.candidateHead}>
+        <span className={styles.mono}>{candidate.candidate_id ?? '—'}</span>
+        <span className={styles.candidateScore}>{formatPosterior(candidate.posterior)}</span>
+        {candidate.concealment && (
+          <span className={styles.concealment} title="Applicant appears to be concealing identity">
+            ⚠ Concealment
+          </span>
+        )}
+      </div>
+      {core.length > 0 && <SignalGroup label="Identity core" signals={core} />}
+      {corroborating.length > 0 && <SignalGroup label="Corroborating" signals={corroborating} />}
+    </div>
+  )
+}
+
+function SignalGroup({ label, signals }: { label: string; signals: SignalEntry[] }) {
+  return (
+    <div className={styles.signalGroup}>
+      <span className={styles.signalGroupLabel}>{label}</span>
+      <div className={styles.chips}>
+        {signals.map((s) => (
+          <span
+            key={s.signal}
+            data-testid={`signal-chip-${s.signal}`}
+            className={`${styles.chip} ${styles[s.sign]}`}
+          >
+            <span className={styles.chipLabel}>{signalLabel(s.signal)}</span>
+            <span className={styles.chipBits}>{formatSignalBits(s.bits)}</span>
+          </span>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/ConversationDetailView/DecisionBanner/styles.module.css
+++ b/src/components/ConversationDetailView/DecisionBanner/styles.module.css
@@ -81,6 +81,144 @@
   font-weight: 400;
 }
 
+/* Review halt — "under review", a distinct axis from the decision states.
+   Indigo so it never reads as declined (red) or referred (amber). */
+.review {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+  color: #3730a3;
+}
+
+.subhead {
+  font-size: 12px;
+  font-weight: 500;
+  opacity: 0.8;
+  margin-top: -4px;
+}
+
+.review .detailLabel {
+  color: #4338ca;
+  opacity: 0.8;
+}
+
+.review .detailValue {
+  color: #312e81;
+}
+
+.bandTag {
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(67, 56, 202, 0.12);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.matches {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.matchesHeading {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #4338ca;
+  opacity: 0.85;
+}
+
+.candidate {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid #c7d2fe;
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.candidateHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.candidateScore {
+  margin-left: auto;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.concealment {
+  font-size: 11px;
+  font-weight: 600;
+  color: #b45309;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 999px;
+  padding: 1px 6px;
+}
+
+.signalGroup {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.signalGroupLabel {
+  flex: 0 0 84px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #4338ca;
+  opacity: 0.75;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 500;
+  border: 1px solid transparent;
+}
+
+.chipBits {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.chip.agrees {
+  background: #ecfdf5;
+  border-color: #a7f3d0;
+  color: #15803d;
+}
+
+.chip.disagrees {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.chip.neutral {
+  background: #f3f4f6;
+  border-color: #e5e7eb;
+  color: #6b7280;
+}
+
 /* Dark mode */
 :global([data-theme='dark']) .pending {
   background: #1f2937;
@@ -113,4 +251,53 @@
 
 :global([data-theme='dark']) .detailValue {
   color: #fecaca;
+}
+
+:global([data-theme='dark']) .review {
+  background: rgba(67, 56, 202, 0.16);
+  border-color: rgba(99, 102, 241, 0.45);
+  color: #c7d2fe;
+}
+
+:global([data-theme='dark']) .review .detailLabel {
+  color: #a5b4fc;
+  opacity: 0.8;
+}
+
+:global([data-theme='dark']) .review .detailValue {
+  color: #e0e7ff;
+}
+
+:global([data-theme='dark']) .matchesHeading,
+:global([data-theme='dark']) .signalGroupLabel {
+  color: #a5b4fc;
+}
+
+:global([data-theme='dark']) .candidate {
+  background: rgba(30, 27, 75, 0.4);
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+:global([data-theme='dark']) .concealment {
+  color: #fcd34d;
+  background: rgba(180, 83, 9, 0.18);
+  border-color: rgba(217, 119, 6, 0.5);
+}
+
+:global([data-theme='dark']) .chip.agrees {
+  background: rgba(21, 128, 61, 0.18);
+  border-color: rgba(21, 128, 61, 0.45);
+  color: #6ee7b7;
+}
+
+:global([data-theme='dark']) .chip.disagrees {
+  background: rgba(185, 28, 28, 0.18);
+  border-color: rgba(185, 28, 28, 0.5);
+  color: #fca5a5;
+}
+
+:global([data-theme='dark']) .chip.neutral {
+  background: rgba(75, 85, 99, 0.25);
+  border-color: rgba(107, 114, 128, 0.5);
+  color: #d1d5db;
 }

--- a/src/lib/recognition.ts
+++ b/src/lib/recognition.ts
@@ -1,0 +1,101 @@
+/**
+ * Identity-recognition helpers for review-kind re-application halts.
+ *
+ * A "review" halt isn't a confirmed block — the applicant was flagged as a
+ * probable returning customer and auto-held for manual review. The recognition
+ * payload carries the match score and, per matched candidate, a per-signal
+ * evidence breakdown. These helpers shape that breakdown for the reviewer:
+ *
+ * - `name`/`dob` are the identity core — only these can confirm a real match.
+ * - `email`/`bank`/`address`/`phone` are corroborating hints (shared/duplicate
+ *   contact details, not identity).
+ *
+ * Positive bits = the signal agrees (evidence of the same person); negative =
+ * it disagrees. A high score driven by agreeing hints but disagreeing core
+ * means "same contact details, different identity" — the thing a reviewer most
+ * needs to see, which is why the core is grouped and surfaced separately.
+ */
+
+/** Identity core — the only signals that can confirm a real identity match. */
+export const CORE_SIGNALS = ['name', 'dob'] as const
+
+/** Corroborating hints — shared contact data, not proof of identity. */
+export const CORROBORATING_SIGNALS = ['email', 'bank', 'address', 'phone'] as const
+
+const SIGNAL_LABELS: Record<string, string> = {
+  name: 'Name',
+  dob: 'DOB',
+  email: 'Email',
+  bank: 'Bank',
+  address: 'Address',
+  phone: 'Phone',
+}
+
+export type SignalSign = 'agrees' | 'disagrees' | 'neutral'
+
+export interface SignalEntry {
+  signal: string
+  bits: number
+  sign: SignalSign
+}
+
+export interface GroupedSignals {
+  core: SignalEntry[]
+  corroborating: SignalEntry[]
+}
+
+/** Render a 0..1 match score as a 2-dp percentage; em dash when absent. */
+export function formatPosterior(posterior: number | null | undefined): string {
+  if (posterior == null || Number.isNaN(posterior)) return '—'
+  return `${(posterior * 100).toFixed(2)}%`
+}
+
+/** Positive bits agree (same person), negative disagree, zero is neutral. */
+export function signalSign(bits: number): SignalSign {
+  if (bits > 0) return 'agrees'
+  if (bits < 0) return 'disagrees'
+  return 'neutral'
+}
+
+/** Signed, 1-dp evidence weight for a chip (e.g. "+10.0", "-5.1"). */
+export function formatSignalBits(bits: number): string {
+  const rounded = bits.toFixed(1)
+  return bits > 0 ? `+${rounded}` : rounded
+}
+
+/** Staff-facing label for a signal; title-cases unknown signals. */
+export function signalLabel(signal: string): string {
+  return SIGNAL_LABELS[signal] ?? signal.charAt(0).toUpperCase() + signal.slice(1)
+}
+
+function toEntry(signal: string, bits: number): SignalEntry {
+  return { signal, bits, sign: signalSign(bits) }
+}
+
+/**
+ * Split a per-signal bit map into identity-core and corroborating groups in a
+ * fixed canonical order (so a chip never changes position between candidates).
+ * Unknown future signals are appended to corroborating rather than dropped.
+ */
+export function groupSignalBits(
+  perSignalBits: Record<string, number> | null | undefined,
+): GroupedSignals {
+  if (!perSignalBits) return { core: [], corroborating: [] }
+
+  const core: SignalEntry[] = []
+  for (const signal of CORE_SIGNALS) {
+    if (signal in perSignalBits) core.push(toEntry(signal, perSignalBits[signal]))
+  }
+
+  const corroborating: SignalEntry[] = []
+  for (const signal of CORROBORATING_SIGNALS) {
+    if (signal in perSignalBits) corroborating.push(toEntry(signal, perSignalBits[signal]))
+  }
+
+  const known = new Set<string>([...CORE_SIGNALS, ...CORROBORATING_SIGNALS])
+  for (const [signal, bits] of Object.entries(perSignalBits)) {
+    if (!known.has(signal)) corroborating.push(toEntry(signal, bits))
+  }
+
+  return { core, corroborating }
+}

--- a/src/lib/schemas/conversations.ts
+++ b/src/lib/schemas/conversations.ts
@@ -94,6 +94,41 @@ export const DecisionDetailSchema = z.object({
   blockedUntil: z.union([z.string(), z.date()]).nullable().optional(),
 })
 
+/**
+ * Identity-recognition context attached to a review-kind halt.
+ *
+ * Stored verbatim from the event payload's `recognition` object (a Payload
+ * `json` column projects it untouched), so the keys here mirror the event's
+ * snake_case — unlike the camelCase scalar columns around it.
+ */
+export const RecognitionCandidateSchema = z.object({
+  candidate_id: z.string().nullable().optional(),
+  /** This candidate's match score, 0..1. */
+  posterior: z.number().nullable().optional(),
+  /** Applicant appears to be concealing the prior identity. */
+  concealment: z.boolean().nullable().optional(),
+  /**
+   * Evidence weight per signal: positive = the signal agrees (same person),
+   * negative = it disagrees. Magnitude = strength. `name`/`dob` are the identity
+   * core; `email`/`bank`/`address`/`phone` are corroborating hints.
+   */
+  per_signal_bits: z.record(z.string(), z.number()).nullable().optional(),
+})
+
+export type RecognitionCandidate = z.infer<typeof RecognitionCandidateSchema>
+
+export const RecognitionSchema = z.object({
+  /** "review" for review halts; null for eligibility blocks. */
+  band: z.string().nullable().optional(),
+  /** Overall match confidence, 0..1 (render as %). */
+  posterior: z.number().nullable().optional(),
+  case_id: z.string().nullable().optional(),
+  /** Matched prior customers, even weak ones; [] for eligibility blocks. */
+  candidates: z.array(RecognitionCandidateSchema).nullable().optional(),
+})
+
+export type Recognition = z.infer<typeof RecognitionSchema>
+
 /** application.reapplication_blocked.v1 — the rich "why" behind a block-decline. */
 export const ReapplicationBlockSchema = z.object({
   reason: z.string().nullable().optional(),
@@ -110,6 +145,16 @@ export const ReapplicationBlockSchema = z.object({
   blockedUntil: z.union([z.string(), z.date()]).nullable().optional(),
   blockedAt: z.union([z.string(), z.date()]).nullable().optional(),
   canonicalCustomerId: z.string().nullable().optional(),
+  /**
+   * A halt is one of two kinds:
+   * - "block": a confirmed eligibility block (active loan / default / …). Render
+   *   the reason/window/source detail (recognition.candidates is empty).
+   * - "review": NOT a confirmed block — flagged as a probable returning customer
+   *   and auto-held for manual review. Surface the recognition match context.
+   */
+  dispositionKind: z.enum(['review', 'block']).nullable().optional(),
+  manualReviewCandidate: z.boolean().nullable().optional(),
+  recognition: RecognitionSchema.nullable().optional(),
 })
 
 /** Archived KYC artifact availability (S3 locations stay server-side). */

--- a/src/migrations/20260618_065013_reapplication_block_recognition.json
+++ b/src/migrations/20260618_065013_reapplication_block_recognition.json
@@ -1,0 +1,5676 @@
+{
+  "id": "344ca8ea-9f5b-433e-b324-a870333beeb2",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_users_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'readonly'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_id": {
+          "name": "avatar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "enable_a_p_i_key": {
+          "name": "enable_a_p_i_key",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_index": {
+          "name": "api_key_index",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_avatar_idx": {
+          "name": "users_avatar_idx",
+          "columns": [
+            {
+              "expression": "avatar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_avatar_id_media_id_fk": {
+          "name": "users_avatar_id_media_id_fk",
+          "tableFrom": "users",
+          "tableTo": "media",
+          "columnsFrom": [
+            "avatar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers_identity_documents": {
+      "name": "customers_identity_documents",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "enum_customers_identity_documents_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_subtype": {
+          "name": "document_subtype",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_of_issue": {
+          "name": "state_of_issue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_issue": {
+          "name": "country_of_issue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "additional_info": {
+          "name": "additional_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_identity_documents_order_idx": {
+          "name": "customers_identity_documents_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_identity_documents_parent_id_idx": {
+          "name": "customers_identity_documents_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_identity_documents_parent_id_fk": {
+          "name": "customers_identity_documents_parent_id_fk",
+          "tableFrom": "customers_identity_documents",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into": {
+          "name": "merged_into",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "middle_name": {
+          "name": "middle_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_phone_number": {
+          "name": "mobile_phone_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verified": {
+          "name": "identity_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_number": {
+          "name": "residential_address_street_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_name": {
+          "name": "residential_address_street_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_type": {
+          "name": "residential_address_street_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_unit_number": {
+          "name": "residential_address_unit_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street": {
+          "name": "residential_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_suburb": {
+          "name": "residential_address_suburb",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_city": {
+          "name": "residential_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_state": {
+          "name": "residential_address_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_postcode": {
+          "name": "residential_address_postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_country": {
+          "name": "residential_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "residential_address_full_address": {
+          "name": "residential_address_full_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_street": {
+          "name": "mailing_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_city": {
+          "name": "mailing_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_state": {
+          "name": "mailing_address_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_postcode": {
+          "name": "mailing_address_postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_country": {
+          "name": "mailing_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "staff_flag": {
+          "name": "staff_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "investor_flag": {
+          "name": "investor_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founder_flag": {
+          "name": "founder_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerable_flag": {
+          "name": "vulnerable_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ekyc_entity_id": {
+          "name": "ekyc_entity_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ekyc_status": {
+          "name": "ekyc_status",
+          "type": "enum_customers_ekyc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "individual_status": {
+          "name": "individual_status",
+          "type": "enum_customers_individual_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_reason": {
+          "name": "reapplication_block_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_until": {
+          "name": "reapplication_block_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_at": {
+          "name": "reapplication_block_blocked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_application_number": {
+          "name": "reapplication_block_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_overall_result": {
+          "name": "identity_verification_overall_result",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_provider": {
+          "name": "identity_verification_provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_provider_reference": {
+          "name": "identity_verification_provider_reference",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_lab_request_id": {
+          "name": "identity_verification_lab_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_checked_at": {
+          "name": "identity_verification_checked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_archived": {
+          "name": "identity_verification_report_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_archived_at": {
+          "name": "identity_verification_archived_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "customers_customer_id_idx": {
+          "name": "customers_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_merged_into_idx": {
+          "name": "customers_merged_into_idx",
+          "columns": [
+            {
+              "expression": "merged_into",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_updated_at_idx": {
+          "name": "customers_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_created_at_idx": {
+          "name": "customers_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers_rels": {
+      "name": "customers_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applications_id": {
+          "name": "applications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_accounts_id": {
+          "name": "loan_accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_rels_order_idx": {
+          "name": "customers_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_parent_idx": {
+          "name": "customers_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_path_idx": {
+          "name": "customers_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_applications_id_idx": {
+          "name": "customers_rels_applications_id_idx",
+          "columns": [
+            {
+              "expression": "applications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_conversations_id_idx": {
+          "name": "customers_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_loan_accounts_id_idx": {
+          "name": "customers_rels_loan_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "loan_accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_rels_parent_fk": {
+          "name": "customers_rels_parent_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_applications_fk": {
+          "name": "customers_rels_applications_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "applications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_conversations_fk": {
+          "name": "customers_rels_conversations_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_loan_accounts_fk": {
+          "name": "customers_rels_loan_accounts_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_utterances": {
+      "name": "conversations_utterances",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utterance": {
+          "name": "utterance",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_input_type": {
+          "name": "answer_input_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_seq": {
+          "name": "prev_seq",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_conversation": {
+          "name": "end_conversation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_utterances_order_idx": {
+          "name": "conversations_utterances_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_utterances_parent_id_idx": {
+          "name": "conversations_utterances_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_utterances_parent_id_fk": {
+          "name": "conversations_utterances_parent_id_fk",
+          "tableFrom": "conversations_utterances",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_facts": {
+      "name": "conversations_facts",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fact": {
+          "name": "fact",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_facts_order_idx": {
+          "name": "conversations_facts_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_facts_parent_id_idx": {
+          "name": "conversations_facts_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_facts_parent_id_fk": {
+          "name": "conversations_facts_parent_id_fk",
+          "tableFrom": "conversations_facts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_noticeboard": {
+      "name": "conversations_noticeboard",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_noticeboard_order_idx": {
+          "name": "conversations_noticeboard_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_noticeboard_parent_id_idx": {
+          "name": "conversations_noticeboard_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_noticeboard_parent_id_fk": {
+          "name": "conversations_noticeboard_parent_id_fk",
+          "tableFrom": "conversations_noticeboard",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_number": {
+          "name": "application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id_string": {
+          "name": "customer_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id_id": {
+          "name": "application_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_conversations_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "last_utterance_time": {
+          "name": "last_utterance_time",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_decision": {
+          "name": "final_decision",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_reason": {
+          "name": "decision_detail_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_retry_eligible": {
+          "name": "decision_detail_retry_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_source_application_number": {
+          "name": "decision_detail_source_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_blocked_until": {
+          "name": "decision_detail_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_reason": {
+          "name": "reapplication_block_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_message_variant": {
+          "name": "reapplication_block_message_variant",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_stop_message": {
+          "name": "reapplication_block_stop_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_application_number": {
+          "name": "reapplication_block_source_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_account_id": {
+          "name": "reapplication_block_source_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_decided_at": {
+          "name": "reapplication_block_source_decided_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_until": {
+          "name": "reapplication_block_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_at": {
+          "name": "reapplication_block_blocked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_canonical_customer_id": {
+          "name": "reapplication_block_canonical_customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_disposition_kind": {
+          "name": "reapplication_block_disposition_kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_manual_review_candidate": {
+          "name": "reapplication_block_manual_review_candidate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_recognition": {
+          "name": "reapplication_block_recognition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_lab_request_id": {
+          "name": "identity_verification_report_lab_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_provider_reference": {
+          "name": "identity_verification_report_provider_reference",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_report_file_location": {
+          "name": "identity_verification_report_report_file_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_report_file_name": {
+          "name": "identity_verification_report_report_file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_raw_response_file_location": {
+          "name": "identity_verification_report_raw_response_file_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_raw_response_file_name": {
+          "name": "identity_verification_report_raw_response_file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_archived_at": {
+          "name": "identity_verification_report_archived_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_identity_risk": {
+          "name": "assessments_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_serviceability": {
+          "name": "assessments_serviceability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_fraud_check": {
+          "name": "assessments_fraud_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_account_conduct": {
+          "name": "assessments_account_conduct",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_post_identity_risk": {
+          "name": "assessments_post_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_credit_assessment_complete": {
+          "name": "assessments_credit_assessment_complete",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture": {
+          "name": "statement_capture",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_status": {
+          "name": "decision_status",
+          "type": "enum_conversations_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_data": {
+          "name": "application_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_conversation_id_idx": {
+          "name": "conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_application_number_idx": {
+          "name": "conversations_application_number_idx",
+          "columns": [
+            {
+              "expression": "application_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_customer_id_idx": {
+          "name": "conversations_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_customer_id_string_idx": {
+          "name": "conversations_customer_id_string_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_application_id_idx": {
+          "name": "conversations_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_status_idx": {
+          "name": "conversations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_decision_status_idx": {
+          "name": "conversations_decision_status_idx",
+          "columns": [
+            {
+              "expression": "decision_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_created_at_idx": {
+          "name": "conversations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_monitor_grid_idx": {
+          "name": "conversations_monitor_grid_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_by_customer_idx": {
+          "name": "conversations_by_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_customer_id_id_customers_id_fk": {
+          "name": "conversations_customer_id_id_customers_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_application_id_id_applications_id_fk": {
+          "name": "conversations_application_id_id_applications_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_proc_state_steps": {
+      "name": "app_proc_state_steps",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "step_name": {
+          "name": "step_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_app_proc_state_steps_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        },
+        "completion_event_name": {
+          "name": "completion_event_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_input_type": {
+          "name": "answer_input_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_main": {
+          "name": "prompts_main",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_completeness_check": {
+          "name": "prompts_completeness_check",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_confirmation": {
+          "name": "prompts_confirmation",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_output_json": {
+          "name": "prompts_output_json",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_mapping_out": {
+          "name": "prompts_mapping_out",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_module_name": {
+          "name": "business_logic_module_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_method_name": {
+          "name": "business_logic_method_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_mapping_in": {
+          "name": "business_logic_mapping_in",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_mapping_out": {
+          "name": "business_logic_mapping_out",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_proc_state_steps_order_idx": {
+          "name": "app_proc_state_steps_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_proc_state_steps_parent_id_idx": {
+          "name": "app_proc_state_steps_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_proc_state_steps_parent_id_fk": {
+          "name": "app_proc_state_steps_parent_id_fk",
+          "tableFrom": "app_proc_state_steps",
+          "tableTo": "app_proc_state",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_proc_state": {
+      "name": "app_proc_state",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stage_name": {
+          "name": "stage_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_proc_state_order_idx": {
+          "name": "app_proc_state_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_proc_state_parent_id_idx": {
+          "name": "app_proc_state_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_proc_state_parent_id_fk": {
+          "name": "app_proc_state_parent_id_fk",
+          "tableFrom": "app_proc_state",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_application_process_conversation": {
+      "name": "applications_application_process_conversation",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_applications_application_process_conversation_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_application_process_conversation_order_idx": {
+          "name": "applications_application_process_conversation_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_application_process_conversation_parent_id_idx": {
+          "name": "applications_application_process_conversation_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_application_process_conversation_parent_id_fk": {
+          "name": "applications_application_process_conversation_parent_id_fk",
+          "tableFrom": "applications_application_process_conversation",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_noticeboard_versions": {
+      "name": "applications_noticeboard_versions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_noticeboard_versions_order_idx": {
+          "name": "applications_noticeboard_versions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_noticeboard_versions_parent_id_idx": {
+          "name": "applications_noticeboard_versions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_noticeboard_versions_parent_id_fk": {
+          "name": "applications_noticeboard_versions_parent_id_fk",
+          "tableFrom": "applications_noticeboard_versions",
+          "tableTo": "applications_noticeboard",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_noticeboard": {
+      "name": "applications_noticeboard",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "applications_noticeboard_order_idx": {
+          "name": "applications_noticeboard_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_noticeboard_parent_id_idx": {
+          "name": "applications_noticeboard_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_noticeboard_parent_id_fk": {
+          "name": "applications_noticeboard_parent_id_fk",
+          "tableFrom": "applications_noticeboard",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_number": {
+          "name": "application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_purpose": {
+          "name": "loan_purpose",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_amount": {
+          "name": "loan_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_fee": {
+          "name": "loan_fee",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_total_payable": {
+          "name": "loan_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_term": {
+          "name": "loan_term",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_attestation_acceptance": {
+          "name": "customer_attestation_acceptance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture_consent_provided": {
+          "name": "statement_capture_consent_provided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture_completed": {
+          "name": "statement_capture_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_offer_acceptance": {
+          "name": "product_offer_acceptance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_outcome": {
+          "name": "application_outcome",
+          "type": "enum_applications_application_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_current_process_stage": {
+          "name": "application_process_current_process_stage",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_current_process_step": {
+          "name": "application_process_current_process_step",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_started_at": {
+          "name": "application_process_started_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_updated_at": {
+          "name": "application_process_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_identity_risk": {
+          "name": "assessments_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_serviceability": {
+          "name": "assessments_serviceability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_fraud_check": {
+          "name": "assessments_fraud_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applications_application_number_idx": {
+          "name": "applications_application_number_idx",
+          "columns": [
+            {
+              "expression": "application_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_customer_id_idx": {
+          "name": "applications_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_application_outcome_idx": {
+          "name": "applications_application_outcome_idx",
+          "columns": [
+            {
+              "expression": "application_outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_updated_at_idx": {
+          "name": "applications_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_created_at_idx": {
+          "name": "applications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_customer_id_id_customers_id_fk": {
+          "name": "applications_customer_id_id_customers_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_rels": {
+      "name": "applications_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_rels_order_idx": {
+          "name": "applications_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_parent_idx": {
+          "name": "applications_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_path_idx": {
+          "name": "applications_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_conversations_id_idx": {
+          "name": "applications_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_rels_parent_fk": {
+          "name": "applications_rels_parent_fk",
+          "tableFrom": "applications_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_rels_conversations_fk": {
+          "name": "applications_rels_conversations_fk",
+          "tableFrom": "applications_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_accounts_repayment_schedule_payments": {
+      "name": "loan_accounts_repayment_schedule_payments",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payment_number": {
+          "name": "payment_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_loan_accounts_repayment_schedule_payments_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'scheduled'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_remaining": {
+          "name": "amount_remaining",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_transaction_ids": {
+          "name": "linked_transaction_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "loan_accounts_repayment_schedule_payments_order_idx": {
+          "name": "loan_accounts_repayment_schedule_payments_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_repayment_schedule_payments_parent_id_idx": {
+          "name": "loan_accounts_repayment_schedule_payments_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accts_repay_sched_payments_natural_key_idx": {
+          "name": "loan_accts_repay_sched_payments_natural_key_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_accounts_repayment_schedule_payments_parent_id_fk": {
+          "name": "loan_accounts_repayment_schedule_payments_parent_id_fk",
+          "tableFrom": "loan_accounts_repayment_schedule_payments",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_accounts": {
+      "name": "loan_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id_string": {
+          "name": "customer_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_loan_amount": {
+          "name": "loan_terms_loan_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_loan_fee": {
+          "name": "loan_terms_loan_fee",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_total_payable": {
+          "name": "loan_terms_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_opened_date": {
+          "name": "loan_terms_opened_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_disbursed_date": {
+          "name": "loan_terms_disbursed_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_current_balance": {
+          "name": "balances_current_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_total_outstanding": {
+          "name": "balances_total_outstanding",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_total_paid": {
+          "name": "balances_total_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_payment_date": {
+          "name": "last_payment_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_payment_amount": {
+          "name": "last_payment_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_is_in_arrears": {
+          "name": "aging_is_in_arrears",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "aging_bucket": {
+          "name": "aging_bucket",
+          "type": "enum_loan_accounts_aging_bucket",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_current_d_p_d": {
+          "name": "aging_current_d_p_d",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_last_updated": {
+          "name": "aging_last_updated",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_status": {
+          "name": "account_status",
+          "type": "enum_loan_accounts_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "sdk_status": {
+          "name": "sdk_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_loan_agreement_url": {
+          "name": "signed_loan_agreement_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "enum_loan_accounts_closure_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_previous_status": {
+          "name": "closure_previous_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_closed_date": {
+          "name": "closure_closed_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_final_balance": {
+          "name": "closure_final_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_total_paid": {
+          "name": "closure_total_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_loan_total_payable": {
+          "name": "closure_loan_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_triggered_by_transaction_id": {
+          "name": "closure_triggered_by_transaction_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_schedule_id": {
+          "name": "repayment_schedule_schedule_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_number_of_payments": {
+          "name": "repayment_schedule_number_of_payments",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_payment_frequency": {
+          "name": "repayment_schedule_payment_frequency",
+          "type": "enum_loan_accounts_repayment_schedule_payment_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_created_date": {
+          "name": "repayment_schedule_created_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "loan_accounts_loan_account_id_idx": {
+          "name": "loan_accounts_loan_account_id_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_account_number_idx": {
+          "name": "loan_accounts_account_number_idx",
+          "columns": [
+            {
+              "expression": "account_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_customer_id_idx": {
+          "name": "loan_accounts_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_customer_id_string_idx": {
+          "name": "loan_accounts_customer_id_string_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_loan_terms_loan_terms_disbursed_date_idx": {
+          "name": "loan_accounts_loan_terms_loan_terms_disbursed_date_idx",
+          "columns": [
+            {
+              "expression": "loan_terms_disbursed_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_aging_aging_is_in_arrears_idx": {
+          "name": "loan_accounts_aging_aging_is_in_arrears_idx",
+          "columns": [
+            {
+              "expression": "aging_is_in_arrears",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_aging_aging_bucket_idx": {
+          "name": "loan_accounts_aging_aging_bucket_idx",
+          "columns": [
+            {
+              "expression": "aging_bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_account_status_idx": {
+          "name": "loan_accounts_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_updated_at_idx": {
+          "name": "loan_accounts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_created_at_idx": {
+          "name": "loan_accounts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_accounts_customer_id_id_customers_id_fk": {
+          "name": "loan_accounts_customer_id_id_customers_id_fk",
+          "tableFrom": "loan_accounts",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.write_off_requests_supporting_documents": {
+      "name": "write_off_requests_supporting_documents",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "write_off_requests_supporting_documents_order_idx": {
+          "name": "write_off_requests_supporting_documents_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_supporting_documents_parent_id_idx": {
+          "name": "write_off_requests_supporting_documents_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_supporting_documents_document_idx": {
+          "name": "write_off_requests_supporting_documents_document_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "write_off_requests_supporting_documents_document_id_media_id_fk": {
+          "name": "write_off_requests_supporting_documents_document_id_media_id_fk",
+          "tableFrom": "write_off_requests_supporting_documents",
+          "tableTo": "media",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "write_off_requests_supporting_documents_parent_id_fk": {
+          "name": "write_off_requests_supporting_documents_parent_id_fk",
+          "tableFrom": "write_off_requests_supporting_documents",
+          "tableTo": "write_off_requests",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.write_off_requests": {
+      "name": "write_off_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_number": {
+          "name": "request_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_balance": {
+          "name": "original_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "enum_write_off_requests_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_write_off_requests_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum_write_off_requests_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "requires_senior_approval": {
+          "name": "requires_senior_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_by_id": {
+          "name": "approval_details_decided_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_by_name": {
+          "name": "approval_details_decided_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_at": {
+          "name": "approval_details_decided_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_comment": {
+          "name": "approval_details_comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by": {
+          "name": "approval_details_approved_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by_name": {
+          "name": "approval_details_approved_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_at": {
+          "name": "approval_details_approved_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by": {
+          "name": "approval_details_rejected_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by_name": {
+          "name": "approval_details_rejected_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_at": {
+          "name": "approval_details_rejected_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_reason": {
+          "name": "approval_details_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by": {
+          "name": "cancellation_details_cancelled_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by_name": {
+          "name": "cancellation_details_cancelled_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_at": {
+          "name": "cancellation_details_cancelled_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "write_off_requests_request_id_idx": {
+          "name": "write_off_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_event_id_idx": {
+          "name": "write_off_requests_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_request_number_idx": {
+          "name": "write_off_requests_request_number_idx",
+          "columns": [
+            {
+              "expression": "request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_loan_account_id_idx": {
+          "name": "write_off_requests_loan_account_id_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_customer_id_idx": {
+          "name": "write_off_requests_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_status_idx": {
+          "name": "write_off_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_requested_by_idx": {
+          "name": "write_off_requests_requested_by_idx",
+          "columns": [
+            {
+              "expression": "requested_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_approval_details_approval_details_decided_by_idx": {
+          "name": "write_off_requests_approval_details_approval_details_decided_by_idx",
+          "columns": [
+            {
+              "expression": "approval_details_decided_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_updated_at_idx": {
+          "name": "write_off_requests_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_created_at_idx": {
+          "name": "write_off_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "write_off_requests_requested_by_id_users_id_fk": {
+          "name": "write_off_requests_requested_by_id_users_id_fk",
+          "tableFrom": "write_off_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "write_off_requests_approval_details_decided_by_id_users_id_fk": {
+          "name": "write_off_requests_approval_details_decided_by_id_users_id_fk",
+          "tableFrom": "write_off_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approval_details_decided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_notes": {
+      "name": "contact_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "enum_contact_notes_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "enum_contact_notes_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_direction": {
+          "name": "contact_direction",
+          "type": "enum_contact_notes_contact_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum_contact_notes_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "enum_contact_notes_sentiment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'neutral'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amends_note_id": {
+          "name": "amends_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_contact_notes_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_notes_customer_idx": {
+          "name": "contact_notes_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_loan_account_idx": {
+          "name": "contact_notes_loan_account_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_application_idx": {
+          "name": "contact_notes_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_conversation_idx": {
+          "name": "contact_notes_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_created_by_idx": {
+          "name": "contact_notes_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_amends_note_idx": {
+          "name": "contact_notes_amends_note_idx",
+          "columns": [
+            {
+              "expression": "amends_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_status_idx": {
+          "name": "contact_notes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_created_at_idx": {
+          "name": "contact_notes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_updated_at_idx": {
+          "name": "contact_notes_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_notes_customer_id_customers_id_fk": {
+          "name": "contact_notes_customer_id_customers_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_loan_account_id_loan_accounts_id_fk": {
+          "name": "contact_notes_loan_account_id_loan_accounts_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_application_id_applications_id_fk": {
+          "name": "contact_notes_application_id_applications_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_conversation_id_conversations_id_fk": {
+          "name": "contact_notes_conversation_id_conversations_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_created_by_id_users_id_fk": {
+          "name": "contact_notes_created_by_id_users_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_amends_note_id_contact_notes_id_fk": {
+          "name": "contact_notes_amends_note_id_contact_notes_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "contact_notes",
+          "columnsFrom": [
+            "amends_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_ref_id": {
+          "name": "customer_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_notifications_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "enum_notifications_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_content_hash": {
+          "name": "template_content_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_git_sha": {
+          "name": "template_git_sha",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_hash": {
+          "name": "recipient_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_category": {
+          "name": "tags_category",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_reason": {
+          "name": "tags_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_step": {
+          "name": "tags_step",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_failed_at": {
+          "name": "failure_failed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_error_type": {
+          "name": "failure_error_type",
+          "type": "enum_notifications_failure_error_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_error_message": {
+          "name": "failure_error_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_attempt": {
+          "name": "failure_attempt",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_fallback_suggested": {
+          "name": "failure_fallback_suggested",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_account_id": {
+          "name": "statement_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_start": {
+          "name": "statement_period_start",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_end": {
+          "name": "statement_period_end",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_dispatched_at": {
+          "name": "statement_dispatched_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_mode": {
+          "name": "suppression_mode",
+          "type": "enum_notifications_suppression_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_reason": {
+          "name": "suppression_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_set_by": {
+          "name": "suppression_set_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_set_at": {
+          "name": "suppression_set_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_expires_at": {
+          "name": "suppression_expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_notification_id_idx": {
+          "name": "notifications_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_idempotency_key_idx": {
+          "name": "notifications_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_customer_ref_idx": {
+          "name": "notifications_customer_ref_idx",
+          "columns": [
+            {
+              "expression": "customer_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_customer_id_idx": {
+          "name": "notifications_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_status_idx": {
+          "name": "notifications_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_event_at_idx": {
+          "name": "notifications_event_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_customer_ref_id_customers_id_fk": {
+          "name": "notifications_customer_ref_id_customers_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customers_id": {
+          "name": "customers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applications_id": {
+          "name": "applications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_accounts_id": {
+          "name": "loan_accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_off_requests_id": {
+          "name": "write_off_requests_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_notes_id": {
+          "name": "contact_notes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notifications_id": {
+          "name": "notifications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_customers_id_idx": {
+          "name": "payload_locked_documents_rels_customers_id_idx",
+          "columns": [
+            {
+              "expression": "customers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_conversations_id_idx": {
+          "name": "payload_locked_documents_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_applications_id_idx": {
+          "name": "payload_locked_documents_rels_applications_id_idx",
+          "columns": [
+            {
+              "expression": "applications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_loan_accounts_id_idx": {
+          "name": "payload_locked_documents_rels_loan_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "loan_accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_write_off_requests_id_idx": {
+          "name": "payload_locked_documents_rels_write_off_requests_id_idx",
+          "columns": [
+            {
+              "expression": "write_off_requests_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contact_notes_id_idx": {
+          "name": "payload_locked_documents_rels_contact_notes_id_idx",
+          "columns": [
+            {
+              "expression": "contact_notes_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_notifications_id_idx": {
+          "name": "payload_locked_documents_rels_notifications_id_idx",
+          "columns": [
+            {
+              "expression": "notifications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_customers_fk": {
+          "name": "payload_locked_documents_rels_customers_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_conversations_fk": {
+          "name": "payload_locked_documents_rels_conversations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_applications_fk": {
+          "name": "payload_locked_documents_rels_applications_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "applications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_loan_accounts_fk": {
+          "name": "payload_locked_documents_rels_loan_accounts_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_write_off_requests_fk": {
+          "name": "payload_locked_documents_rels_write_off_requests_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "write_off_requests",
+          "columnsFrom": [
+            "write_off_requests_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contact_notes_fk": {
+          "name": "payload_locked_documents_rels_contact_notes_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contact_notes",
+          "columnsFrom": [
+            "contact_notes_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_notifications_fk": {
+          "name": "payload_locked_documents_rels_notifications_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notifications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_users_role": {
+      "name": "enum_users_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "supervisor",
+        "operations",
+        "readonly",
+        "service"
+      ]
+    },
+    "public.enum_customers_identity_documents_document_type": {
+      "name": "enum_customers_identity_documents_document_type",
+      "schema": "public",
+      "values": [
+        "DRIVERS_LICENCE",
+        "PASSPORT",
+        "MEDICARE"
+      ]
+    },
+    "public.enum_customers_ekyc_status": {
+      "name": "enum_customers_ekyc_status",
+      "schema": "public",
+      "values": [
+        "successful",
+        "failed",
+        "pending"
+      ]
+    },
+    "public.enum_customers_individual_status": {
+      "name": "enum_customers_individual_status",
+      "schema": "public",
+      "values": [
+        "LIVING",
+        "DECEASED",
+        "MISSING"
+      ]
+    },
+    "public.enum_conversations_status": {
+      "name": "enum_conversations_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "soft_end",
+        "hard_end",
+        "approved",
+        "declined"
+      ]
+    },
+    "public.enum_conversations_decision_status": {
+      "name": "enum_conversations_decision_status",
+      "schema": "public",
+      "values": [
+        "approved",
+        "declined",
+        "referred",
+        "no_decision"
+      ]
+    },
+    "public.enum_app_proc_state_steps_type": {
+      "name": "enum_app_proc_state_steps_type",
+      "schema": "public",
+      "values": [
+        "llm",
+        "business_logic",
+        "user_input"
+      ]
+    },
+    "public.enum_applications_application_process_conversation_role": {
+      "name": "enum_applications_application_process_conversation_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ]
+    },
+    "public.enum_applications_application_outcome": {
+      "name": "enum_applications_application_outcome",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "declined",
+        "withdrawn"
+      ]
+    },
+    "public.enum_loan_accounts_repayment_schedule_payments_status": {
+      "name": "enum_loan_accounts_repayment_schedule_payments_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "paid",
+        "missed",
+        "partial"
+      ]
+    },
+    "public.enum_loan_accounts_aging_bucket": {
+      "name": "enum_loan_accounts_aging_bucket",
+      "schema": "public",
+      "values": [
+        "current",
+        "early_arrears",
+        "late_arrears",
+        "default",
+        "closed"
+      ]
+    },
+    "public.enum_loan_accounts_account_status": {
+      "name": "enum_loan_accounts_account_status",
+      "schema": "public",
+      "values": [
+        "pending_disbursement",
+        "active",
+        "paid_off",
+        "in_arrears",
+        "written_off"
+      ]
+    },
+    "public.enum_loan_accounts_closure_reason": {
+      "name": "enum_loan_accounts_closure_reason",
+      "schema": "public",
+      "values": [
+        "PAID_OFF",
+        "WRITTEN_OFF",
+        "ADMIN_CLOSED"
+      ]
+    },
+    "public.enum_loan_accounts_repayment_schedule_payment_frequency": {
+      "name": "enum_loan_accounts_repayment_schedule_payment_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "fortnightly",
+        "monthly"
+      ]
+    },
+    "public.enum_write_off_requests_reason": {
+      "name": "enum_write_off_requests_reason",
+      "schema": "public",
+      "values": [
+        "hardship",
+        "bankruptcy",
+        "deceased",
+        "unable_to_locate",
+        "fraud_victim",
+        "disputed",
+        "aged_debt",
+        "other"
+      ]
+    },
+    "public.enum_write_off_requests_status": {
+      "name": "enum_write_off_requests_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.enum_write_off_requests_priority": {
+      "name": "enum_write_off_requests_priority",
+      "schema": "public",
+      "values": [
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.enum_contact_notes_channel": {
+      "name": "enum_contact_notes_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "internal",
+        "system"
+      ]
+    },
+    "public.enum_contact_notes_topic": {
+      "name": "enum_contact_notes_topic",
+      "schema": "public",
+      "values": [
+        "general_enquiry",
+        "complaint",
+        "escalation",
+        "internal_note",
+        "account_update",
+        "collections"
+      ]
+    },
+    "public.enum_contact_notes_contact_direction": {
+      "name": "enum_contact_notes_contact_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.enum_contact_notes_priority": {
+      "name": "enum_contact_notes_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.enum_contact_notes_sentiment": {
+      "name": "enum_contact_notes_sentiment",
+      "schema": "public",
+      "values": [
+        "positive",
+        "neutral",
+        "negative",
+        "escalation"
+      ]
+    },
+    "public.enum_contact_notes_status": {
+      "name": "enum_contact_notes_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "amended"
+      ]
+    },
+    "public.enum_notifications_status": {
+      "name": "enum_notifications_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "blocked",
+        "statement",
+        "suppression_change"
+      ]
+    },
+    "public.enum_notifications_channel": {
+      "name": "enum_notifications_channel",
+      "schema": "public",
+      "values": [
+        "email",
+        "sms"
+      ]
+    },
+    "public.enum_notifications_failure_error_type": {
+      "name": "enum_notifications_failure_error_type",
+      "schema": "public",
+      "values": [
+        "transient",
+        "permanent",
+        "auth",
+        "template",
+        "contact_missing",
+        "opt_out",
+        "suppressed"
+      ]
+    },
+    "public.enum_notifications_suppression_mode": {
+      "name": "enum_notifications_suppression_mode",
+      "schema": "public",
+      "values": [
+        "all",
+        "non_essential",
+        "marketing_only",
+        "panic_button",
+        "off"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/src/migrations/20260618_065013_reapplication_block_recognition.ts
+++ b/src/migrations/20260618_065013_reapplication_block_recognition.ts
@@ -1,0 +1,15 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "conversations" ADD COLUMN "reapplication_block_disposition_kind" varchar;
+  ALTER TABLE "conversations" ADD COLUMN "reapplication_block_manual_review_candidate" boolean;
+  ALTER TABLE "conversations" ADD COLUMN "reapplication_block_recognition" jsonb;`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "conversations" DROP COLUMN "reapplication_block_disposition_kind";
+  ALTER TABLE "conversations" DROP COLUMN "reapplication_block_manual_review_candidate";
+  ALTER TABLE "conversations" DROP COLUMN "reapplication_block_recognition";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -2,6 +2,7 @@ import * as migration_20260515_061818 from './20260515_061818';
 import * as migration_20260518_232948_drop_loan_account_customer_name from './20260518_232948_drop_loan_account_customer_name';
 import * as migration_20260607_132326 from './20260607_132326';
 import * as migration_20260610_114936_reapplication_block_identity_verification from './20260610_114936_reapplication_block_identity_verification';
+import * as migration_20260618_065013_reapplication_block_recognition from './20260618_065013_reapplication_block_recognition';
 
 export const migrations = [
   {
@@ -22,6 +23,11 @@ export const migrations = [
   {
     up: migration_20260610_114936_reapplication_block_identity_verification.up,
     down: migration_20260610_114936_reapplication_block_identity_verification.down,
-    name: '20260610_114936_reapplication_block_identity_verification'
+    name: '20260610_114936_reapplication_block_identity_verification',
+  },
+  {
+    up: migration_20260618_065013_reapplication_block_recognition.up,
+    down: migration_20260618_065013_reapplication_block_recognition.down,
+    name: '20260618_065013_reapplication_block_recognition'
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -678,6 +678,26 @@ export interface Conversation {
      * Resolved identity shared by all linked journeys
      */
     canonicalCustomerId?: string | null;
+    /**
+     * Halt kind: "block" (confirmed) or "review" (held for review)
+     */
+    dispositionKind?: string | null;
+    /**
+     * Whether this halt is a manual-review candidate
+     */
+    manualReviewCandidate?: boolean | null;
+    /**
+     * Identity-recognition match context for a review halt (band, posterior, case_id, candidates with per-signal evidence). Stored verbatim from the event.
+     */
+    recognition?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
   };
   /**
    * Archived identity verification artifacts (S3)
@@ -1597,6 +1617,9 @@ export interface ConversationsSelect<T extends boolean = true> {
         blockedUntil?: T;
         blockedAt?: T;
         canonicalCustomerId?: T;
+        dispositionKind?: T;
+        manualReviewCandidate?: T;
+        recognition?: T;
       };
   identityVerificationReport?:
     | T

--- a/tests/unit/lib/recognition.test.ts
+++ b/tests/unit/lib/recognition.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from 'vitest'
+import {
+  formatPosterior,
+  signalSign,
+  formatSignalBits,
+  signalLabel,
+  groupSignalBits,
+} from '@/lib/recognition'
+
+describe('formatPosterior', () => {
+  test('renders a 0..1 score as a 2-dp percentage', () => {
+    expect(formatPosterior(0.989831)).toBe('98.98%')
+  })
+
+  test('renders a confident link near the ceiling', () => {
+    expect(formatPosterior(0.9994)).toBe('99.94%')
+  })
+
+  test('returns a dash when the score is absent', () => {
+    expect(formatPosterior(null)).toBe('—')
+    expect(formatPosterior(undefined)).toBe('—')
+  })
+})
+
+describe('signalSign', () => {
+  test('positive bits mean the signal agrees (same person)', () => {
+    expect(signalSign(10)).toBe('agrees')
+  })
+
+  test('negative bits mean the signal disagrees', () => {
+    expect(signalSign(-5.06)).toBe('disagrees')
+  })
+
+  test('zero bits are neutral', () => {
+    expect(signalSign(0)).toBe('neutral')
+  })
+})
+
+describe('formatSignalBits', () => {
+  test('prefixes a + for agreeing signals, to 1 dp', () => {
+    expect(formatSignalBits(10)).toBe('+10.0')
+    expect(formatSignalBits(8.94)).toBe('+8.9')
+  })
+
+  test('keeps the minus for disagreeing signals', () => {
+    expect(formatSignalBits(-5.06)).toBe('-5.1')
+  })
+})
+
+describe('signalLabel', () => {
+  test('humanises known signals', () => {
+    expect(signalLabel('dob')).toBe('DOB')
+    expect(signalLabel('name')).toBe('Name')
+    expect(signalLabel('address')).toBe('Address')
+  })
+
+  test('title-cases unknown signals rather than dropping them', () => {
+    expect(signalLabel('device')).toBe('Device')
+  })
+})
+
+describe('groupSignalBits', () => {
+  // The example from the brief: a high overall score driven by agreeing contact
+  // details, but disagreeing name/dob — "same contact details, different identity".
+  const bits = { email: 10.0, bank: 8.94, address: 5.0, name: -5.06, dob: -5.64 }
+
+  test('splits identity-core (name, dob) from corroborating signals', () => {
+    const { core, corroborating } = groupSignalBits(bits)
+    expect(core.map((s) => s.signal)).toEqual(['name', 'dob'])
+    expect(corroborating.map((s) => s.signal)).toEqual(['email', 'bank', 'address'])
+  })
+
+  test('carries the sign so the chip can colour agree vs disagree', () => {
+    const { core } = groupSignalBits(bits)
+    expect(core).toEqual([
+      { signal: 'name', bits: -5.06, sign: 'disagrees' },
+      { signal: 'dob', bits: -5.64, sign: 'disagrees' },
+    ])
+  })
+
+  test('keeps a fixed canonical order regardless of payload key order', () => {
+    const shuffled = { address: 5, dob: -5.64, email: 10, name: -5.06, bank: 8.94 }
+    const { core, corroborating } = groupSignalBits(shuffled)
+    expect(core.map((s) => s.signal)).toEqual(['name', 'dob'])
+    expect(corroborating.map((s) => s.signal)).toEqual(['email', 'bank', 'address'])
+  })
+
+  test('appends unknown signals to corroborating without dropping them', () => {
+    const { corroborating } = groupSignalBits({ email: 1, device: 2 })
+    expect(corroborating.map((s) => s.signal)).toEqual(['email', 'device'])
+  })
+
+  test('handles a missing or empty bit map', () => {
+    expect(groupSignalBits(null)).toEqual({ core: [], corroborating: [] })
+    expect(groupSignalBits(undefined)).toEqual({ core: [], corroborating: [] })
+    expect(groupSignalBits({})).toEqual({ core: [], corroborating: [] })
+  })
+})

--- a/tests/unit/ui/decision-banner.test.tsx
+++ b/tests/unit/ui/decision-banner.test.tsx
@@ -160,4 +160,151 @@ describe('DecisionBanner block-decline detail', () => {
     expect(screen.getByText('Serviceability')).toBeInTheDocument()
     expect(screen.getByText(/until 10 June 2027/)).toBeInTheDocument()
   })
+
+  test('an explicit block disposition still renders the red eligibility-block panel', () => {
+    render(
+      <DecisionBanner
+        conversation={createConversation({
+          finalDecision: 'DECLINED',
+          reapplicationBlock: {
+            reason: 'ACTIVE_LOAN',
+            dispositionKind: 'block',
+            blockedUntil: null,
+            sourceAccountId: 'LA-9',
+          },
+        })}
+      />,
+    )
+    expect(screen.getByText('✗ Declined · Re-application block')).toBeInTheDocument()
+    expect(screen.getByText(/while loan open/)).toBeInTheDocument()
+    expect(screen.queryByText(/Flagged for manual review/)).not.toBeInTheDocument()
+  })
+})
+
+describe('DecisionBanner review halt (recognition)', () => {
+  afterEach(cleanup)
+
+  const reviewConversation = createConversation({
+    // Held for manual review — not decided. The review panel must render
+    // regardless of the (absent) credit decision.
+    finalDecision: null,
+    status: 'paused',
+    reapplicationBlock: {
+      reason: 'review',
+      dispositionKind: 'review',
+      manualReviewCandidate: true,
+      stopMessage:
+        'Thanks for sending that through! We just need to take a closer look before we can continue.',
+      blockedUntil: null,
+      blockedAt: '2026-06-18T04:15:30Z',
+      canonicalCustomerId: null,
+      recognition: {
+        band: 'review',
+        posterior: 0.989831,
+        case_id: '4494ed09-25c3-4095-9dc5-a34f5e6db584',
+        candidates: [
+          {
+            candidate_id: 'C5C7DD3A',
+            posterior: 0.98,
+            concealment: false,
+            per_signal_bits: { email: 10.0, bank: 8.94, address: 5.0, name: -5.06, dob: -5.64 },
+          },
+        ],
+      },
+    },
+  })
+
+  test('labels the halt as manual review, not a decline or a permanent block', () => {
+    render(<DecisionBanner conversation={reviewConversation} />)
+    expect(screen.getByText(/Flagged for manual review/)).toBeInTheDocument()
+    expect(screen.queryByText(/permanent/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/✗ Declined/)).not.toBeInTheDocument()
+  })
+
+  test('surfaces the overall match confidence and the case id', () => {
+    render(<DecisionBanner conversation={reviewConversation} />)
+    expect(screen.getByText('98.98%')).toBeInTheDocument()
+    expect(screen.getByText(/4494ed09-25c3-4095-9dc5-a34f5e6db584/)).toBeInTheDocument()
+  })
+
+  test('lists each potential match with its own match score', () => {
+    render(<DecisionBanner conversation={reviewConversation} />)
+    expect(screen.getByText('C5C7DD3A')).toBeInTheDocument()
+    expect(screen.getByText('98.00%')).toBeInTheDocument()
+  })
+
+  test('groups per-signal evidence into identity-core vs corroborating', () => {
+    render(<DecisionBanner conversation={reviewConversation} />)
+    expect(screen.getByText('Identity core')).toBeInTheDocument()
+    expect(screen.getByText('Corroborating')).toBeInTheDocument()
+  })
+
+  test('colours each signal by whether it agrees or disagrees', () => {
+    render(<DecisionBanner conversation={reviewConversation} />)
+    // Disagreeing identity core — the "different identity" tell.
+    const nameChip = screen.getByTestId('signal-chip-name')
+    expect(nameChip.className).toMatch(/disagrees/)
+    expect(nameChip).toHaveTextContent('Name')
+    expect(nameChip).toHaveTextContent('-5.1')
+    // Agreeing corroborating hint.
+    const emailChip = screen.getByTestId('signal-chip-email')
+    expect(emailChip.className).toMatch(/agrees/)
+    expect(emailChip).toHaveTextContent('+10.0')
+  })
+
+  test('keeps the stop message the customer saw', () => {
+    render(<DecisionBanner conversation={reviewConversation} />)
+    expect(screen.getByText(/Thanks for sending that through/)).toBeInTheDocument()
+  })
+
+  test('does not show a concealment flag when the candidate is not concealing', () => {
+    render(<DecisionBanner conversation={reviewConversation} />)
+    expect(screen.queryByText(/concealment/i)).not.toBeInTheDocument()
+  })
+
+  test('flags concealment when a candidate is concealing the prior identity', () => {
+    render(
+      <DecisionBanner
+        conversation={createConversation({
+          reapplicationBlock: {
+            reason: 'review',
+            dispositionKind: 'review',
+            recognition: {
+              band: 'review',
+              posterior: 0.5,
+              case_id: 'case-conceal',
+              candidates: [
+                {
+                  candidate_id: 'X1',
+                  posterior: 0.5,
+                  concealment: true,
+                  per_signal_bits: { name: 2.0 },
+                },
+              ],
+            },
+          },
+        })}
+      />,
+    )
+    expect(screen.getByText(/concealment/i)).toBeInTheDocument()
+  })
+
+  test('does not break when recognition is absent (older review events)', () => {
+    render(
+      <DecisionBanner
+        conversation={createConversation({
+          reapplicationBlock: {
+            reason: 'review',
+            dispositionKind: 'review',
+            stopMessage: 'We just need to take a closer look.',
+            recognition: null,
+          },
+        })}
+      />,
+    )
+    expect(screen.getByText(/Flagged for manual review/)).toBeInTheDocument()
+    expect(screen.getByText(/We just need to take a closer look/)).toBeInTheDocument()
+    // No matches table, but no crash.
+    expect(screen.queryByText('Potential matches')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## What

A re-application halt is now one of two kinds. This surfaces the new recognition data on the ops application-detail **Re-application block** panel.

- **`disposition_kind: "block"`** — a confirmed eligibility block (active loan / prior default / …). **Unchanged:** the existing red eligibility-block panel (reason / blocked / source / customer-saw).
- **`disposition_kind: "review"`** — NOT a confirmed block. The applicant was flagged as a probable returning customer and auto-held for manual review. Renders a new **indigo "under review"** panel: *"Flagged for manual review (not yet reviewed)"* + match confidence (`posterior` as %) + `case_id`, a **Potential matches** table (one row per candidate with its own match %), and a per-signal **agree/disagree** chip breakdown grouped **Identity core** (name, dob) vs **Corroborating** (email, bank, address, phone), plus a concealment flag. "Customer saw" is retained.

The key reviewer tell — a high score driven by agreeing corroborating chips but **disagreeing** identity-core chips ("same contact details, different identity") — is visible at a glance.

## Vertical slice
- **Consumer** (`reapplication.py`): projects `disposition_kind`, `manual_review_candidate`, and the `recognition` blob (stored **verbatim** as `jsonb` — asyncpg has no dict→jsonb codec, so `json.dumps`'d) from `application.reapplication_blocked.v1`.
- **Migration** `20260618_065013_reapplication_block_recognition`: adds 3 `conversations` columns (`varchar` / `boolean` / `jsonb`). Generated via Payload CLI; verified up **and** down against a throwaway Postgres.
- **Collection / types / schema**: `Conversations.ts` group fields, regenerated `payload-types.ts`, extended `ReapplicationBlockSchema` (+ `RecognitionSchema`).
- **UI**: `DecisionBanner` branches on `dispositionKind`; new `src/lib/recognition.ts` helpers (score %, signal sign, identity-core vs corroborating grouping).

## Tests / verification
- `recognition.test.ts` (15) · `decision-banner.test.tsx` (+8 review-halt) · Python handler (+2)
- Full TS int suite **1614 passed, 0 failed** · `typecheck` clean · `lint` 0 errors
- Migration up/down verified; columns confirmed `varchar`/`boolean`/`jsonb`

## Notes
- Extends the existing re-application block feature (BTB-135). I did **not** tag a specific ticket on this work — please add the right one if there is a dedicated ticket. (Avoided BTB-158, which is the unrelated commencement-date ingestion.)
- `manual_review_candidate` is captured in the projection + type but not separately rendered (`disposition_kind === "review"` already conveys it).
- The review panel shows whenever `dispositionKind === "review"`, independent of the (usually absent) credit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JPzBqhLmgFAC4aENqSgyr