### PR TITLE
fix(deploy): ship proto/ in standalone image (Next 16 Turbopack trace gap)

### DIFF
--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -117,6 +117,12 @@ COPY --from=pydeps /pip-packages /pip-packages
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# gRPC clients read proto/*.proto at runtime (resolved as __dirname/../../proto
+# → /app/proto). Next's standalone output trace no longer bundles these under the
+# Next 16 Turbopack build (it did under the Next 15 webpack build), so copy the
+# proto dir explicitly — covers both accounting_ledger and notification_dispatcher.
+COPY --from=builder --chown=nextjs:nodejs /app/proto ./proto
+
 # Copy event processor source
 COPY --chown=nextjs:nodejs event-processor/src ./event-processor/src
 


### PR DESCRIPTION
Follow-up to #25. The deployed demo image crash-loops the gRPC ledger client with `ENOENT: /app/proto/accounting_ledger.proto`.

**Cause:** `grpc-client.ts` and `notification-dispatcher-client.ts` read `proto/*.proto` at runtime (`path.resolve(__dirname, '../../proto/...')`). Next 15's webpack build traced those reads into `.next/standalone/proto`; **Next 16's Turbopack build no longer does**, so the image is missing `/app/proto`. Invisible locally (no ledger).

**Fix:** `Dockerfile.demo` (used by all envs incl. prod) now copies `proto/` explicitly into the runtime image — covers both proto files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)