### PR TITLE
fix(period-close): read correct gRPC anomaly fields (crash on Anomaly Review)

### DIFF
--- a/src/components/PeriodCloseView/PeriodCloseWizard.tsx
+++ b/src/components/PeriodCloseView/PeriodCloseWizard.tsx
@@ -179,7 +179,7 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
         // Optimistically update local state
         setLocalAnomalies((prev) =>
           prev.map((a) =>
-            a.id === anomalyId
+            a.anomalyId === anomalyId
               ? { ...a, acknowledged: true, acknowledgedBy: userName, acknowledgedAt: new Date().toISOString() }
               : a
           )
@@ -540,12 +540,12 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
             ) : (
               <div className={styles.anomalyList}>
                 {localAnomalies.map((anomaly) => (
-                  <div key={anomaly.id} className={`${styles.anomalyCard} ${styles[`severity${anomaly.severity}`]}`}>
+                  <div key={anomaly.anomalyId} className={`${styles.anomalyCard} ${styles[`severity${anomaly.severity}`]}`}>
                     <div className={styles.anomalyMeta}>
                       <span className={`${styles.severityBadge} ${styles[anomaly.severity]}`}>
                         {anomaly.severity.toUpperCase()}
                       </span>
-                      <span className={styles.anomalyType}>{anomaly.type.replace(/_/g, ' ')}</span>
+                      <span className={styles.anomalyType}>{(anomaly.anomalyType ?? '').replace(/_/g, ' ')}</span>
                     </div>
                     <p className={styles.anomalyDescription}>{anomaly.description}</p>
                     {anomaly.accountId && (
@@ -567,9 +567,9 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
                         <button
                           type="button"
                           className={styles.acknowledgeBtn}
-                          onClick={() => handleAcknowledge(anomaly.id)}
+                          onClick={() => handleAcknowledge(anomaly.anomalyId)}
                           disabled={isAcknowledging}
-                          data-testid={`acknowledge-${anomaly.id}`}
+                          data-testid={`acknowledge-${anomaly.anomalyId}`}
                         >
                           {isAcknowledging ? 'Acknowledging...' : 'Acknowledge'}
                         </button>

--- a/src/hooks/mutations/usePeriodClosePreview.ts
+++ b/src/hooks/mutations/usePeriodClosePreview.ts
@@ -4,9 +4,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
  * Anomaly detected during period close preview
  */
 export interface PeriodCloseAnomaly {
-  id: string
-  type: 'BALANCE_DISCREPANCY' | 'MISSING_ACCRUAL' | 'STALE_ECL' | 'UNPROCESSED_EVENT' | 'OTHER'
-  severity: 'low' | 'medium' | 'high' | 'critical'
+  // gRPC (previewPeriodClose) returns these as camelCase of the proto fields
+  // anomaly_id / anomaly_type (keepCase:false) — NOT `id` / `type`.
+  anomalyId: string
+  anomalyType: string
+  severity: string
   accountId: string
   accountNumber?: string
   description: string


### PR DESCRIPTION
**Fixes the `/admin/period-close` crash** ("This page couldn't load") at the Anomaly Review step.

**Cause (pre-existing, not the BTB-26 upgrade):** the ledger `previewPeriodClose` gRPC response is passed through untouched, so anomaly fields are the proto snake_case names camelCased by proto-loader (`keepCase:false`): `anomaly_id`→`anomalyId`, `anomaly_type`→`anomalyType`. The wizard read `anomaly.id`/`anomaly.type`, so `anomaly.type` was `undefined` and `.replace(/_/g,' ')` threw — crashing whenever a preview contained anomalies (first hit now). `anomaly.id` being undefined also silently broke Acknowledge. (`keepCase` is identical in proto-loader 0.7/0.8, so the dep bump didn't cause it.)

**Fix:** type + component now read `anomalyId`/`anomalyType` (matching the already-correct `accountId`/`acknowledgedBy`), plus a guard on `.replace`.

Verified: typecheck, lint, **1642 int/unit tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)