### PR TITLE
fix(period-close): map ledger gRPC response to CRM shape (fixes NaNs)

### DIFF
--- a/src/app/api/period-close/finalize/route.ts
+++ b/src/app/api/period-close/finalize/route.ts
@@ -13,6 +13,7 @@ import { getLedgerClient } from '@/server/grpc-client'
 import { requireAuth } from '@/lib/auth'
 import { hasApprovalAuthority } from '@/lib/access'
 import { FinalizePeriodCloseSchema } from '@/lib/schemas/api'
+import { mapFinalizeResponse } from '@/server/period-close-mapper'
 
 export async function POST(request: NextRequest) {
   try {
@@ -37,7 +38,7 @@ export async function POST(request: NextRequest) {
       finalizedBy: String(user.id),
     })
 
-    return NextResponse.json(response)
+    return NextResponse.json(mapFinalizeResponse(response))
   } catch (error) {
     console.error('Error finalizing period close:', error)
     return NextResponse.json(

--- a/src/app/api/period-close/preview/route.ts
+++ b/src/app/api/period-close/preview/route.ts
@@ -13,6 +13,7 @@ import { getLedgerClient } from '@/server/grpc-client'
 import { requireAuth } from '@/lib/auth'
 import { canService } from '@/lib/access'
 import { PeriodClosePreviewSchema } from '@/lib/schemas/api'
+import { mapPreviewResponse } from '@/server/period-close-mapper'
 
 export async function POST(request: NextRequest) {
   try {
@@ -37,7 +38,7 @@ export async function POST(request: NextRequest) {
       requestedBy: String(user.id),
     })
 
-    return NextResponse.json(response)
+    return NextResponse.json(mapPreviewResponse(response))
   } catch (error) {
     console.error('Error generating period close preview:', error)
     return NextResponse.json(

--- a/src/hooks/mutations/useFinalizePeriodClose.ts
+++ b/src/hooks/mutations/useFinalizePeriodClose.ts
@@ -5,7 +5,7 @@ interface FinalizeRequest {
   finalizedBy: string
 }
 
-interface GeneratedJournalEntry {
+export interface GeneratedJournalEntry {
   id: string
   type: string
   description: string
@@ -15,7 +15,7 @@ interface GeneratedJournalEntry {
   createdAt: string
 }
 
-interface FinalizeResponse {
+export interface FinalizeResponse {
   success: boolean
   periodDate: string
   finalizedAt: string

--- a/src/server/period-close-mapper.ts
+++ b/src/server/period-close-mapper.ts
@@ -1,0 +1,79 @@
+import type { PeriodClosePreview } from '@/hooks/mutations/usePeriodClosePreview'
+import type { FinalizeResponse } from '@/hooks/mutations/useFinalizePeriodClose'
+
+/** Parse a Decimal-as-string (or number) into a finite number, defaulting to 0. */
+const num = (v: unknown): number => {
+  const n = typeof v === 'number' ? v : parseFloat(String(v ?? ''))
+  return Number.isFinite(n) ? n : 0
+}
+
+/**
+ * Map the raw AccountingLedger `previewPeriodClose` gRPC response (proto fields
+ * camelCased by proto-loader, money/rates as Decimal strings, movement nested under
+ * `eclMovement`) into the CRM's flat PeriodClosePreview shape.
+ */
+export function mapPreviewResponse(r: any): PeriodClosePreview {
+  const m = r?.eclMovement
+  const anomalies = Array.isArray(r?.anomalies) ? r.anomalies : []
+  return {
+    previewId: r?.previewId ?? '',
+    periodDate: r?.periodDate ?? '',
+    expiresAt: r?.expiresAt ?? '',
+    status: 'ready',
+    totalAccounts: r?.totalAccounts ?? 0,
+    totalAccruedYield: num(r?.totalAccruedYield),
+    totalECLAllowance: num(r?.totalEclAllowance),
+    totalCarryingAmount: num(r?.totalCarryingAmount),
+    eclByBucket: (Array.isArray(r?.eclByBucket) ? r.eclByBucket : []).map((b: any) => ({
+      bucket: b?.bucket ?? '',
+      accountCount: b?.accountCount ?? 0,
+      eclAmount: num(b?.totalEcl),
+      carryingAmount: num(b?.totalCarryingAmount),
+      pdRate: num(b?.averagePdRate),
+    })),
+    priorPeriodECL: m ? num(m.priorTotalEcl) : undefined,
+    eclChange: m ? num(m.netChange) : undefined,
+    eclChangePercent: m ? num(m.changePercent) : undefined,
+    movementByCause: (Array.isArray(m?.byCause) ? m.byCause : []).map((c: any) => ({
+      cause: c?.cause ?? '',
+      amount: num(c?.amount),
+      accountCount: 0, // ledger does not provide a per-cause account count
+    })),
+    movementByBucket: (Array.isArray(m?.byBucket) ? m.byBucket : []).map((b: any) => ({
+      bucket: b?.bucket ?? '',
+      inCount: b?.accountsEntered ?? 0,
+      outCount: b?.accountsExited ?? 0,
+      netChange: num(b?.netChange),
+    })),
+    anomalies, // gRPC anomaly objects already use anomalyId/anomalyType (matches PeriodCloseAnomaly)
+    anomalyCount: anomalies.length,
+    acknowledgedCount: anomalies.filter((a: any) => a?.acknowledged).length,
+    reconciled: r?.reconciliation?.isReconciled ?? false,
+    reconciliationNotes: undefined,
+    journalEntries: [], // ledger returns journal entries only at finalize, not preview
+  }
+}
+
+/**
+ * Map the raw `finalizePeriodClose` gRPC response (JournalEntry uses entryId/entryType,
+ * totals are Decimal strings, total_ecl_allowance -> totalEclAllowance) into FinalizeResponse.
+ */
+export function mapFinalizeResponse(r: any): FinalizeResponse {
+  return {
+    success: r?.success ?? false,
+    periodDate: r?.periodDate ?? '',
+    finalizedAt: r?.finalizedAt ?? '',
+    totalAccounts: r?.totalAccounts ?? 0,
+    totalECLAllowance: num(r?.totalEclAllowance),
+    totalAccruedYield: num(r?.totalAccruedYield),
+    journalEntries: (Array.isArray(r?.journalEntries) ? r.journalEntries : []).map((j: any) => ({
+      id: j?.entryId ?? '',
+      type: j?.entryType ?? '',
+      description: j?.description ?? '',
+      debitAccount: j?.debitAccount ?? '',
+      creditAccount: j?.creditAccount ?? '',
+      amount: num(j?.amount),
+      createdAt: j?.createdAt ?? '',
+    })),
+  }
+}


### PR DESCRIPTION
Fixes the `$NaN` values across the period-close wizard (Preview Summary, ECL-by-bucket, Movement Analysis).

**Cause (pre-existing, not BTB-26):** `previewPeriodClose`/`finalizePeriodClose` gRPC responses are returned raw, but proto-loader camelCases proto fields and nests movement under `eclMovement`. The components read names that don't match (`totalECLAllowance` vs `totalEclAllowance`, bucket `eclAmount` vs `totalEcl`, flat `priorPeriodECL` vs nested `eclMovement.priorTotalEcl`, etc.) → `undefined` → `formatCurrency(undefined)` = `$NaN`. Money/rates are also Decimal strings.

**Fix:** new `src/server/period-close-mapper.ts` translates the raw gRPC response → the clean shape the components/TS types already expect, wired into the preview + finalize routes (history already maps per-period). Components/types unchanged.

**Verified against the live ledger** (mapped response: `totalECLAllowance:3685.28`, buckets `{eclAmount,carryingAmount,pdRate}` populated, movement flattened, `reconciled`/`anomalyCount` correct — no NaN), typecheck, lint, **1642 int/unit tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)