### PR TITLE
feat(collections): Stream D WS1 — collection.case.* read model (BTB-199)

### DIFF
--- a/docs/collections/collections-crm-build-scope.md
+++ b/docs/collections/collections-crm-build-scope.md
@@ -1,0 +1,123 @@
+# Collections CRM (Stream D) — build scope
+
+| Field | Value |
+| --- | --- |
+| Status | DRAFT — file-level build scope for review / ticket-cutting |
+| Repo | billie-crm (the CRM = consumer; UI + read model) |
+| Date | 2026-06-24 |
+| Parent | BTB-69 (Collections process embedment) |
+| Depends on (done) | BTB-166 — headless `collectionsService` emits all six `collection.case.*` to ChatLedger |
+| Depends on (backlog) | BTB-194 — cost-of-recovery economics engine (gate + `CaseEconomics`); CRM degrades gracefully until it lands |
+| Contract | `proto/collections_service.proto` (vendored copy of the provider's canonical) |
+| Consumer reqs | `docs/collections/collections-service-grpc-consumer-requirements.md` |
+
+## Decisions locked
+
+1. **CRM is the consumer.** The engine (`collectionsService`) owns the FSM, cadence, economics, and emits `collection.case.*`. The CRM consumes those events into its own Postgres read model and renders the operator UI. No collections business logic in the CRM.
+2. **Per-case view = Option A** — a **dedicated** collections case view, *plus* collections/hardship context surfaced in the (customer-scoped) **ServicingView** with a deep-link to the case view.
+3. **Operator actions = `collectionsService` gRPC** (vendored `collections_service.proto` + a new client), **not** the superseded `NotificationDispatcherService` hardship RPCs (those route to the wrong inbox post-BTB-166). Suppression stays on the dispatcher client (unchanged).
+4. **Economics is graceful-degrade.** Build the per-case view + worklist against the full `CaseEconomics` contract, but the economics panel + net-recovery sort + the `AdvanceToNextStep` cost-of-recovery gate render "pending"/disabled until BTB-194 ships real data. CRM v1 is not blocked on it.
+5. **Projection store = Postgres**, schema owned by Payload (TS collection config → Drizzle), written only by the Python event-processor (read-only projection — `create/update/delete: () => false`).
+
+## Data flow
+
+```
+collectionsService (engine) ──collection.case.*──▶ ChatLedger ──▶ inbox:billie-servicing
+                                                                        │
+                                  Python event-processor (WS1) ──upsert─┤
+                                                                        ▼
+                                                            Postgres: collection_cases
+                                                                        ▲ reads (WS2)
+   Payload/Next CRM ── worklist (WS3) · case view (WS4) · ServicingView surfacing (WS4)
+        │                         │ economics + contact log + actions
+        │ accounting reads        ▼
+        └──▶ AccountingLedgerService gRPC (exists)    CollectionsService gRPC (WS5, new client)
+```
+
+---
+
+## WS1 — Consume `collection.case.*` → `CollectionsCase` projection
+
+Unblocked; depends on nothing in WS2–WS5. Mirrors the existing 29-handler pattern.
+
+| File | Change |
+| --- | --- |
+| `event-processor/requirements.txt` | Add the `billie-collection-events` SDK (≥0.2.0, the version BTB-166 shipped — confirm tag/subdirectory, e.g. `…@collection-v0.2.0#subdirectory=packages/collection`) |
+| `event-processor/src/billie_servicing/processor.py` | Add a parse branch for the `collection.` prefix → `parse_collection_message` (typed); the operator events carry a real `customer_id` (BTB-154), so prefer the SDK over envelope-dict |
+| `event-processor/src/billie_servicing/handlers/collections.py` *(new)* | Six handlers — `opened`, `cured`, `exhausted`, `hardship_paused`, `resumed`, `stop_contact_applied` — using `db.py` `upsert`/`update_by_key` keyed on `account_id`. Map operational state/rung/flags/lifecycle/money-snapshot per the read-model spec (§2) |
+| `event-processor/src/billie_servicing/main.py` | Register the six handlers in `setup_handlers` |
+| `event-processor/tests/test_collections_handlers.py` *(new)* | `MockPool` assertions (table, conflict keys, idempotency) |
+| `src/collections/CollectionsCases.ts` *(new)* | Read-only Payload collection, slug `collection-cases`; fields: `accountId` (unique/index), `customerId` (relationship) + `customerIdString` (index), `state`, `rung`, `hardshipPaused`/`stoppedContact`, lifecycle timestamps, `overdueAmount`/`daysOverdue`/`lastStep`, terminal state; `access: { create/update/delete: () => false }`, all fields `readOnly` |
+| `src/payload.config.ts` | Register the collection; add `afterSchemaInit` indexes `(state, rung, updatedAt DESC)` and `(customerIdString, updatedAt DESC)` (same mechanism as the conversations monitor-grid) |
+| `src/payload-types.ts`, importMap, `src/migrations/*` | Regenerate (`pnpm generate:types` + `generate:importmap`); commit a Payload migration via the local-Docker-Postgres recipe |
+
+**Dependency to verify (platform-side, not this repo):** ChatLedger fan-out routes `collection.case.*` into `inbox:billie-servicing` (`consume_from_agents=["collectionsService"]`). Without it the projection never fills.
+
+## WS2 — Read-model API + query hooks
+
+| File | Change |
+| --- | --- |
+| `src/app/api/collections/cases/route.ts` *(new)* | List — filter/paginate over `collection_cases` (Payload local API); optionally enrich each row with ledger aging (reuse the `/api/ledger/aging/overdue` enrichment pattern) |
+| `src/app/api/collections/cases/[accountId]/route.ts` *(new)* | Single-case detail |
+| `src/hooks/queries/useCollectionsCases.ts` *(new)* | Infinite query (mirror `useConversations`) |
+| `src/hooks/queries/useCollectionsCase.ts` *(new)* | Single case |
+| `src/hooks/queries/useCollectionsCasesByCustomer.ts` *(new)* | All cases for a customer's accounts — feeds the ServicingView surfacing (WS4) |
+| `src/hooks/queries/index.ts`, `src/hooks/index.ts` | Barrel exports |
+
+## WS3 — Worklist (evolve the existing `/admin/collections-queue`)
+
+The current view is the ledger-driven "Shell" (Story E1-S1) = the spec's §5.4 pre-CRM bridge. **Re-platform it**, don't greenfield.
+
+| File | Change |
+| --- | --- |
+| `src/components/CollectionsView/CollectionsView.tsx` | Swap the data spine `useOverdueAccounts` → `useCollectionsCases` (+ ledger aging enrichment for DPD/bucket/amount); add filters: rung, `hardship_paused`, `stopped_contact`, `awaiting-human` (exhausted); add columns: Rung, State, Flags; add a **sort** control (expected-net-recovery option present but disabled until BTB-194); change row-click target → the dedicated case view |
+| `src/components/CollectionsView/styles.module.css` | Extend for new columns/badges |
+| `src/payload.config.ts` | Change `views.collections.path` → `/collections-queue/:segments*` so the route hosts both queue and case view |
+| *Keep unchanged* | `NavCollectionsLink` (overdue badge), `CollectionsViewWithTemplate`, CSV export, fallback banner, cursor pagination |
+
+## WS4 — Dedicated per-case view + ServicingView surfacing
+
+| File | Change |
+| --- | --- |
+| `src/components/CollectionsView/CollectionsCaseView.tsx` *(new)* | The dedicated case screen — three fixed panels: **operational** (rung ladder + state + lifecycle from the projection) · **accounting + economics** (accounting from `AccountingLedgerService`; economics/gate/cost-ledger/next-step-preview from `GetCaseEconomics`, graceful-degrade) · **contact + actions** (`GetContactLog` + cadence-cap; action buttons from WS5). Reuse ServicingView building blocks (`AccountPanel`, `ContactNotes`) where they fit |
+| `src/components/CollectionsView/CollectionsViewWithTemplate.tsx` | Route by segment: no segment → queue; `/{accountId}` → `CollectionsCaseView` |
+| `src/components/ServicingView/AttentionStrip.tsx` | Customer-level aggregate: if any of the customer's accounts is in a case / hardship / stop-contact, raise a strip entry with a link |
+| `src/components/ServicingView/LoanAccountCard.tsx` (and/or `AccountPanel`) | Per-account collections badge (rung + state + flags) + "View collections case →" deep-link |
+| data | `useCollectionsCasesByCustomer(customerId)` (WS2). **Customer-vs-account nuance:** case + hardship are per-account (show per account); suppression is per-customer (surface separately at customer level) |
+
+## WS5 — Operator actions + `CollectionsService` gRPC client
+
+| File | Change |
+| --- | --- |
+| `proto/collections_service.proto` | **Vendored ✓** (this change) |
+| `src/server/collections-service-client.ts` *(new)* | gRPC client mirroring `notification-dispatcher-client.ts`; env `COLLECTIONS_SERVICE_GRPC_URL`; dynamic proto-loader; hand-maintained TS interfaces. Methods: `flagHardship`, `resumeFromHardship`, `applyStopContact`, `advanceToNextStep`, `getCaseEconomics`, `listCaseEconomics`, `getContactLog`. Every command sends `operator_id` + `idempotency_key` |
+| `src/app/api/collections/actions/{flag-hardship,resume-hardship,stop-contact,advance}/route.ts` *(new)* | `requireAuth` (operator=`operations`; `advance`/escalation gated to `supervisor` via `hasApprovalAuthority`), generate idempotency key, call gRPC, return `CaseActionResponse` |
+| `src/app/api/collections/cases/[accountId]/{economics,contact-log}/route.ts` *(new)* | `GetCaseEconomics` / `GetContactLog` reads |
+| `src/hooks/mutations/{useFlagHardship,useResumeHardship,useApplyStopContact,useAdvanceToNextStep}.ts` *(new)* | Mirror `useWaiveFee` (optimistic stage, failed-actions queue, toasts, idempotency); barrel-export |
+| Record payment / write-off-park | Reuse existing ledger repayment + `/api/commands/writeoff/*` paths — no new engine RPC |
+| `.env.example`, fly config, `CLAUDE.md` | Add `COLLECTIONS_SERVICE_GRPC_URL` + a server-clients note |
+
+> The economics RPCs (`getCaseEconomics`/`listCaseEconomics`) and `advanceToNextStep`'s gate are wired now but return `NOT_APPLICABLE`/empty until BTB-194. Build the client + UI to handle that state explicitly (panel shows "pending"; Advance enforces state preconditions only).
+
+## WS6 — Cross-cutting
+
+- **Roles** (`src/lib/access.ts`): operator = `operations` (`canService`); escalation (`advance` / authorise-send) = `supervisor` (`hasApprovalAuthority`). Confirm.
+- **Tests**: Python `MockPool` (WS1); vitest for hooks/routes (WS2/WS5); reuse the testcontainers Postgres global setup; optional Playwright e2e for the queue→case→action flow.
+- **Deploy / backfill**: dev/demo use `push:true`; prod needs the committed migration. The projection is **replay-rebuildable** — backfill `collection_cases` by replaying `collection.case.*`; run inside the fly machine (demo pg is laptop-unreachable).
+
+---
+
+## Suggested ticket breakdown (cut from the workstreams)
+
+1. **WS1** — `CollectionsCase` projection + `collection.case.*` handlers (Python + Payload collection + indexes + migration). *Unblocked; start here.*
+2. **WS2** — read-model API + query hooks.
+3. **WS3** — re-platform the collections queue onto the projection (filters/columns/sort-shell).
+4. **WS4** — dedicated case view + ServicingView surfacing.
+5. **WS5** — `CollectionsService` gRPC client + operator-action routes/hooks (Phase-1 actions; economics graceful-degrade).
+6. *(BTB-194, separate/engine)* — when it ships, light up the economics panel, net-recovery sort, and the `AdvanceToNextStep` gate. No CRM rework beyond removing the "pending" state.
+
+## Out of scope
+
+- Legal ladder (remedy notice / letter of demand / court / Form 21A / enforcement) — later Stream D.
+- Cost-of-recovery engine internals / formulas — BTB-194 (engine).
+- Inbound SMS/chat ingestion; credit-bureau integration.

--- a/docs/collections/collections-service-grpc-consumer-requirements.md
+++ b/docs/collections/collections-service-grpc-consumer-requirements.md
@@ -1,0 +1,229 @@
+# `collectionsService` gRPC — CRM consumer requirements
+
+| Field | Value |
+| --- | --- |
+| Status | ADOPTED — provider authored `billie-platform-services/proto/collections_service.proto` from this note; the CRM vendors a copy at `proto/collections_service.proto`. Economics methods (`GetCaseEconomics`/`ListCaseEconomics` + the `AdvanceToNextStep` gate) are **Phase 2**, blocked on BTB-194. See `collections-crm-build-scope.md`. |
+| Consumer | billie-crm (Stream D, Collections CRM module) |
+| Provider | `collectionsService` (headless collections engine, BTB-166) |
+| Related | BTB-69; BTB-166; "Collections CRM — Front-End Requirements & Event-Routing Spec"; "Solution Design — Collections Policy Alignment" |
+| Date | 2026-06-24 |
+
+## Purpose
+
+The CRM's per-case view and operator actions need two classes of method from the
+collections engine that **are not available from any existing source**:
+
+1. **Operator-action commands** that move a case's state. Post-BTB-166 these live on
+   `collectionsService` (the operator gRPC was repointed to `inbox:collectionsService`),
+   so the CRM must call the engine — not `notificationDispatcherService`.
+2. **Engine-owned reads** — the cost-of-recovery gate, expected net recovery, cost
+   ledger, next-step preview, and the authoritative contact log. These are computed
+   inside the engine and are not on the `collection.case.*` events or in the ledger.
+
+This note is the **consumer's requirements**. The provider owns the canonical
+`collections_service.proto`; the CRM vendors a copy (same convention as
+`proto/accounting_ledger.proto` and `proto/notification_dispatcher.proto`) and builds a
+TS client against it. The proto sketches below are an illustrative strawman, not the
+final contract.
+
+## Boundary — what the CRM does NOT need from this endpoint
+
+To keep the contract minimal, these stay on their current owners and must **not** be
+duplicated here:
+
+- **Aging / DPD / bucket / gross / ECL allowance / net carrying / live balance** →
+  `AccountingLedgerService` (`GetAccountAging`, `GetCarryingAmountBreakdown`,
+  `GetECLAllowance`, `GetBalance`) — already wired in the CRM.
+- **Operational case state / rung / flags / lifecycle timestamps** → the CRM's own
+  `CollectionsCase` projection, built from the `collection.case.*` event stream. The
+  CRM owns this read model; no query RPC is required for it.
+- **Generic per-customer suppression CRUD** → `NotificationDispatcherService`
+  (`Get/Set/Clear/ListSuppression`) — already wired. (See note on stop-contact below.)
+- **Legal track** (remedy notice / letter of demand / court / Form 21A / enforcement)
+  → out of scope (Stream D non-goal).
+
+---
+
+## 1. Commands (operator actions)
+
+All commands:
+
+- Take an `operator_id` (the CRM staff user id) for the audit/contact log.
+- Accept an `idempotency_key` (the CRM generates one per action, as it does for ledger
+  writes) so retries are de-duplicated.
+- Return a `CaseActionResponse { account_id, new_state, emitted_event_id }` so the CRM
+  can drive its existing optimistic-mutation + idempotency UI pattern and trace the
+  emitted `collection.case.*` event.
+- Are expected to **emit the corresponding `collection.case.*` event to ChatLedger** as
+  the engine does today, so the CRM's own projection converges without a second code path.
+
+| RPC | Inputs | State transition / effect | Emits |
+| --- | --- | --- | --- |
+| `FlagHardship` | `account_id`, `operator_id`, `reason`, `idempotency_key` (engine resolves `customer_id`) | `active → paused_hardship` (retain step pointer) | `collection.case.hardship_paused.v1` |
+| `ResumeFromHardship` | `account_id`, `operator_id`, `idempotency_key` | `paused_hardship → active` (explicit hand-back; no auto-resume by policy) | `collection.case.resumed.v1` |
+| `ApplyStopContact` | `account_id`, `operator_id`, `reason?`, `idempotency_key` | `* → stopped_contact` (suppress all automated sends) | `collection.case.stop_contact_applied.v1` |
+| `AdvanceToNextStep` | `account_id`, `operator_id`, `idempotency_key` | Gated escalation + human consent-to-send: advance the rung and command notification to send the next step. **Only valid when the next-step gate passes.** | next-step send (and any rung/state event the engine already emits) |
+
+### Command semantics the CRM relies on
+
+- **`AdvanceToNextStep` is the human gate.** Per policy, routine reminders (rungs 0–2)
+  auto-send within the cadence cap; every escalation/escalated artefact is human-decided.
+  The CRM flow is: read `GetCaseEconomics` → show `next_step_preview` + `gate_result`
+  → operator confirms → `AdvanceToNextStep`. If the gate does **not** pass, the engine
+  should reject with `FAILED_PRECONDITION` and a human-readable reason (the CRM disables
+  the button from `gate_result`, but the server must enforce it too).
+- **Stop-contact is a collections command, not raw suppression.** `ApplyStopContact`
+  should both apply the suppression *and* emit the domain event. The CRM will call this
+  engine RPC for collections stop-contact, and reserve `NotificationDispatcherService.SetSuppression`
+  for generic, non-collections suppression.
+- **Preconditions / errors** the CRM will surface to the operator:
+  - `FlagHardship` on an already-paused case → idempotent success (no-op) or `FAILED_PRECONDITION`.
+  - `ResumeFromHardship` on a case that is not `paused_hardship` → `FAILED_PRECONDITION`.
+  - `AdvanceToNextStep` on a terminal/`exhausted`/`cured`/`stopped_contact` case → `FAILED_PRECONDITION`.
+  - Unknown `account_id` → `NOT_FOUND`.
+  Please return a stable error reason string the CRM can show verbatim.
+
+---
+
+## 2. Reads (engine-owned economics + contact log)
+
+These power the per-case "amount owed vs cost of recovery" panel (§3.2 of the front-end
+spec) and the contact-history / cadence-cap display.
+
+| RPC | Returns |
+| --- | --- |
+| `GetCaseEconomics(account_id)` | `amount_owed` (frozen **A**), `cost_of_next_step`, `expected_net_recovery`, `gate_result` (status + reason), `cost_ledger[]` (production + hard cost entries, each with a `recoverable` flag), `next_step_preview` (rung, channel, template, rendered subject/body the customer will see) |
+| `GetContactLog(account_id)` | immutable contact history (the Playbook §E2 log, sourced from `collections.send_log`) + `contact_cap_status` (`sent_7d`/`cap_7d` e.g. 2/3, `sent_month`/`cap_month` e.g. 6/10) |
+
+Notes:
+
+- **`amount_owed` is the frozen A** the engine asserts at case open (principal +
+  original fee − payments, no default-interest/fee/collection-fee fields). The CRM shows
+  this alongside the *live* ledger balance — they are intentionally different numbers.
+- **`gate_result`** drives both the economics panel and whether `AdvanceToNextStep` is
+  offered. Suggest `{ status: PASS | FAIL | NOT_APPLICABLE, reason: string }`.
+- For a `cured` / `closed` case, `gate_result = NOT_APPLICABLE` and `next_step_preview`
+  may be empty — please define rather than erroring.
+- **Money fields are decimal strings** (matching the ledger gRPC convention used
+  throughout the CRM). **Timestamps are `google.protobuf.Timestamp`** (matching the
+  dispatcher proto).
+
+---
+
+## 3. Open questions for the provider
+
+1. **Worklist sort by expected net recovery (front-end spec §3.1).** `GetCaseEconomics`
+   is per-account, but the queue must sort by `expected_net_recovery` across many cases.
+   We need one of:
+   - a batch `ListCaseEconomics(account_ids[])` the CRM calls for the loaded page, or
+   - a queue-level economics query, or
+   - acceptance that the sort runs only over the page the CRM has hydrated.
+   Provider's call — it changes the contract. The CRM's preference is a **batch
+   `ListCaseEconomics`** so the sort can cover a full filtered page.
+2. **Arrangement / park ownership.** "Record arrangement" (promise-to-pay / payment
+   plan) and "park" both affect cadence, so they may warrant engine commands
+   (`RecordArrangement`, `Park`) — or they may be expressible as hardship/stop-contact +
+   a CRM note. Plain payments already go to the ledger (`RecordRepayment`) and write-off
+   rides the existing CRM event path, so those two are **not** engine RPCs. Please
+   confirm whether arrangement/park are engine-owned.
+3. **`customer_id` on commands.** BTB-166 already has the engine resolving `customer_id`
+   from the accounts read-client for the operator events. We assume the CRM does **not**
+   need to pass it on commands — confirm.
+
+---
+
+## 4. Strawman proto (illustrative — provider owns the canonical version)
+
+```protobuf
+syntax = "proto3";
+package billie.collections.v1;
+
+import "google/protobuf/timestamp.proto";
+
+service CollectionsService {
+  // — commands —
+  rpc FlagHardship(FlagHardshipRequest)      returns (CaseActionResponse);
+  rpc ResumeFromHardship(ResumeRequest)      returns (CaseActionResponse);
+  rpc ApplyStopContact(StopContactRequest)   returns (CaseActionResponse);
+  rpc AdvanceToNextStep(AdvanceRequest)      returns (CaseActionResponse);
+
+  // — reads —
+  rpc GetCaseEconomics(CaseRef)              returns (CaseEconomics);
+  rpc GetContactLog(CaseRef)                 returns (ContactLog);
+
+  // — open (see §3.1) —
+  // rpc ListCaseEconomics(CaseRefs)         returns (CaseEconomicsList);
+}
+
+message CaseRef { string account_id = 1; }
+
+message FlagHardshipRequest {
+  string account_id = 1;
+  string operator_id = 2;
+  string reason = 3;
+  string idempotency_key = 4;
+}
+message ResumeRequest      { string account_id = 1; string operator_id = 2; string idempotency_key = 3; }
+message StopContactRequest { string account_id = 1; string operator_id = 2; string reason = 3; string idempotency_key = 4; }
+message AdvanceRequest     { string account_id = 1; string operator_id = 2; string idempotency_key = 3; }
+
+message CaseActionResponse {
+  string account_id = 1;
+  string new_state = 2;          // e.g. "paused_hardship"
+  string emitted_event_id = 3;   // the collection.case.* event_id, for trace/dedup
+}
+
+enum GateStatus { GATE_UNSPECIFIED = 0; PASS = 1; FAIL = 2; NOT_APPLICABLE = 3; }
+message GateResult { GateStatus status = 1; string reason = 2; }
+
+message CostLedgerEntry {
+  string label = 1;
+  string amount = 2;             // decimal string
+  string category = 3;           // "production" | "hard"
+  bool recoverable = 4;
+}
+
+message NextStepPreview {
+  int32 rung = 1;
+  string channel = 2;            // "sms" | "email"
+  string template = 3;
+  string subject = 4;
+  string body = 5;               // rendered, what the customer will see
+}
+
+message CaseEconomics {
+  string account_id = 1;
+  string amount_owed = 2;            // frozen A (decimal string)
+  string cost_of_next_step = 3;
+  string expected_net_recovery = 4;
+  GateResult gate_result = 5;
+  repeated CostLedgerEntry cost_ledger = 6;
+  NextStepPreview next_step_preview = 7;
+}
+
+message ContactCapStatus {
+  int32 sent_7d = 1;  int32 cap_7d = 2;     // e.g. 2 / 3
+  int32 sent_month = 3; int32 cap_month = 4; // e.g. 6 / 10
+}
+message ContactLogEntry {
+  google.protobuf.Timestamp sent_at = 1;
+  string channel = 2;
+  string template = 3;
+  string outcome = 4;            // sent | failed | skipped (+ reason)
+}
+message ContactLog {
+  string account_id = 1;
+  repeated ContactLogEntry entries = 2;
+  ContactCapStatus contact_cap_status = 3;
+}
+```
+
+---
+
+## Summary
+
+**4 commands** — `FlagHardship`, `ResumeFromHardship`, `ApplyStopContact`,
+`AdvanceToNextStep` — and **2 reads** — `GetCaseEconomics`, `GetContactLog` — plus a
+provider decision on a **batch economics** RPC for the worklist sort and on
+**arrangement/park** ownership. Everything else the per-case view needs comes from the
+ledger gRPC or the CRM's own event-sourced projection and must not be duplicated here.

--- a/event-processor/requirements.txt
+++ b/event-processor/requirements.txt
@@ -19,3 +19,7 @@ git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-s
 git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@ledger-v1.1.0#subdirectory=packages/ledger
 git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@notifications-v1.1.1#subdirectory=packages/notifications
 git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@aging-v1.1.0#subdirectory=packages/aging
+# Collection case events (BTB-199 consumer side). TODO: confirm the published tag
+# in billie-event-sdks — BTB-166 bumped billie-collection-events to 0.2.0 (adds
+# customer_id to the operator events), so the tag is expected to be collection-v0.2.0.
+git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@collection-v0.2.0#subdirectory=packages/collection

--- a/event-processor/src/billie_servicing/handlers/__init__.py
+++ b/event-processor/src/billie_servicing/handlers/__init__.py
@@ -56,6 +56,14 @@ from .notification import (
 from .aging import (
     handle_loan_aging_updated,
 )
+from .collections import (
+    handle_collection_case_opened,
+    handle_collection_case_exhausted,
+    handle_collection_case_cured,
+    handle_collection_case_hardship_paused,
+    handle_collection_case_resumed,
+    handle_collection_case_stop_contact_applied,
+)
 
 __all__ = [
     # Account handlers
@@ -106,4 +114,11 @@ __all__ = [
     "handle_statement_generated",
     # Aging handler (platform → CRM read-only projection of arrears state)
     "handle_loan_aging_updated",
+    # Collection case handlers (platform → CRM read-only projection — BTB-199)
+    "handle_collection_case_opened",
+    "handle_collection_case_exhausted",
+    "handle_collection_case_cured",
+    "handle_collection_case_hardship_paused",
+    "handle_collection_case_resumed",
+    "handle_collection_case_stop_contact_applied",
 ]

--- a/event-processor/src/billie_servicing/handlers/collections.py
+++ b/event-processor/src/billie_servicing/handlers/collections.py
@@ -1,0 +1,199 @@
+"""Collection case event handlers (read-only projection — Stream D / BTB-199).
+
+Consumes the six ``collection.case.*`` events the headless collectionsService
+(BTB-166) emits to ChatLedger and projects them into the ``collection_cases``
+table, keyed by ``account_id`` (one case per advance):
+
+- collection.case.opened.v1                → state = 'open'
+- collection.case.exhausted.v1             → state = 'awaiting_human'
+- collection.case.cured.v1                 → state = 'cured'
+- collection.case.hardship_paused.v1       → hardship_paused = True  (flag only)
+- collection.case.resumed.v1               → hardship_paused = False (flag only)
+- collection.case.stop_contact_applied.v1  → stopped_contact = True  (flag only)
+
+Handlers receive the flat ``billie_collection_events`` pydantic model (the
+event *is* the payload — ``account_id``/``customer_id``/… are top-level
+attributes, with ``event_id``/``timestamp``/``correlation_id`` from the common
+base). ``customer_id`` is the real id (BTB-154 provenance, sourced by the
+engine), so it is safe to resolve the customers relationship from it.
+
+The state events (opened/exhausted/cured) own ``state``; the flag events
+(hardship/resume/stop-contact) deliberately do NOT write ``state`` so a
+cross-cutting flag never clobbers the lifecycle. Every write is an idempotent
+upsert, so redelivery and out-of-order arrival converge.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import asyncpg
+import structlog
+
+from ..db import coerce_date, upsert
+
+logger = structlog.get_logger()
+
+TABLE = "collection_cases"
+
+
+async def _resolve_customer_link(pool: asyncpg.Pool, customer_id: str | None) -> Any | None:
+    """Look up customers.id (uuid) so Payload's relationship hydrates.
+
+    Returns None if the customer isn't projected yet — the ``customer_id``
+    string is still stored for later joining.
+    """
+    if not customer_id:
+        return None
+    return await pool.fetchval(
+        "SELECT id FROM customers WHERE customer_id = $1", customer_id
+    )
+
+
+def _to_amount(value: Any) -> float | None:
+    """Coerce the event's decimal-string amount to a float for the snapshot."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _upsert_case(
+    pool: asyncpg.Pool,
+    *,
+    account_id: str,
+    customer_id: str | None,
+    extra: dict[str, Any],
+) -> None:
+    """Upsert a collection_cases row keyed on account_id.
+
+    ``extra`` carries the event-specific columns. Identity + bookkeeping columns
+    are filled here so every handler stays a thin mapping.
+    """
+    now = datetime.now(timezone.utc)
+    customer_ref_id = await _resolve_customer_link(pool, customer_id)
+    values: dict[str, Any] = {
+        "account_id": account_id,
+        "customer_id": customer_id,
+        "customer_ref_id": customer_ref_id,
+        "updated_at": now,
+        "created_at": now,
+        **extra,
+    }
+    await upsert(
+        pool,
+        TABLE,
+        conflict_columns=["account_id"],
+        values=values,
+        insert_only_columns=["created_at"],
+    )
+
+
+async def handle_collection_case_opened(pool: asyncpg.Pool, event: Any) -> None:
+    """Project collection.case.opened.v1 — overdue series started."""
+    log = logger.bind(account_id=event.account_id, customer_id=event.customer_id)
+    log.info("Processing collection.case.opened.v1")
+    await _upsert_case(
+        pool,
+        account_id=event.account_id,
+        customer_id=event.customer_id,
+        extra={
+            "state": "open",
+            "overdue_amount": _to_amount(event.overdue_amount),
+            "due_date": coerce_date(event.due_date),
+            "opened_at": coerce_date(event.timestamp),
+            "correlation_id": event.correlation_id,
+        },
+    )
+    log.info("Collection case opened projected")
+
+
+async def handle_collection_case_exhausted(pool: asyncpg.Pool, event: Any) -> None:
+    """Project collection.case.exhausted.v1 — spine ended unpaid, needs a human."""
+    log = logger.bind(account_id=event.account_id, customer_id=event.customer_id)
+    log.info("Processing collection.case.exhausted.v1")
+    await _upsert_case(
+        pool,
+        account_id=event.account_id,
+        customer_id=event.customer_id,
+        extra={
+            "state": "awaiting_human",
+            "overdue_amount": _to_amount(event.overdue_amount),
+            "days_overdue": event.days_overdue,
+            "last_step": event.last_step,
+            "exhausted_at": coerce_date(event.timestamp),
+            "correlation_id": event.correlation_id,
+        },
+    )
+    log.info("Collection case exhausted projected")
+
+
+async def handle_collection_case_cured(pool: asyncpg.Pool, event: Any) -> None:
+    """Project collection.case.cured.v1 — balance cleared, clean close."""
+    log = logger.bind(account_id=event.account_id, customer_id=event.customer_id)
+    log.info("Processing collection.case.cured.v1")
+    await _upsert_case(
+        pool,
+        account_id=event.account_id,
+        customer_id=event.customer_id,
+        extra={
+            "state": "cured",
+            "cured_at": coerce_date(event.cured_at),
+            "correlation_id": event.correlation_id,
+        },
+    )
+    log.info("Collection case cured projected")
+
+
+async def handle_collection_case_hardship_paused(pool: asyncpg.Pool, event: Any) -> None:
+    """Project collection.case.hardship_paused.v1 — flag only, state untouched."""
+    log = logger.bind(account_id=event.account_id, customer_id=event.customer_id)
+    log.info("Processing collection.case.hardship_paused.v1")
+    await _upsert_case(
+        pool,
+        account_id=event.account_id,
+        customer_id=event.customer_id,
+        extra={
+            "hardship_paused": True,
+            "paused_at": coerce_date(event.paused_at),
+            "correlation_id": event.correlation_id,
+        },
+    )
+    log.info("Collection case hardship pause projected")
+
+
+async def handle_collection_case_resumed(pool: asyncpg.Pool, event: Any) -> None:
+    """Project collection.case.resumed.v1 — operator hand-back, clears the flag."""
+    log = logger.bind(account_id=event.account_id, customer_id=event.customer_id)
+    log.info("Processing collection.case.resumed.v1")
+    await _upsert_case(
+        pool,
+        account_id=event.account_id,
+        customer_id=event.customer_id,
+        extra={
+            "hardship_paused": False,
+            "resumed_at": coerce_date(event.resumed_at),
+            "correlation_id": event.correlation_id,
+        },
+    )
+    log.info("Collection case resume projected")
+
+
+async def handle_collection_case_stop_contact_applied(pool: asyncpg.Pool, event: Any) -> None:
+    """Project collection.case.stop_contact_applied.v1 — flag only, state untouched."""
+    log = logger.bind(account_id=event.account_id, customer_id=event.customer_id)
+    log.info("Processing collection.case.stop_contact_applied.v1")
+    await _upsert_case(
+        pool,
+        account_id=event.account_id,
+        customer_id=event.customer_id,
+        extra={
+            "stopped_contact": True,
+            "stop_contact_at": coerce_date(event.applied_at),
+            "correlation_id": event.correlation_id,
+        },
+    )
+    log.info("Collection case stop-contact projected")

--- a/event-processor/src/billie_servicing/main.py
+++ b/event-processor/src/billie_servicing/main.py
@@ -58,6 +58,13 @@ from .handlers import (
     handle_statement_generated,
     # Aging handler (platform → CRM read-only projection of arrears state)
     handle_loan_aging_updated,
+    # Collection case handlers (platform → CRM read-only projection — BTB-199)
+    handle_collection_case_opened,
+    handle_collection_case_exhausted,
+    handle_collection_case_cured,
+    handle_collection_case_hardship_paused,
+    handle_collection_case_resumed,
+    handle_collection_case_stop_contact_applied,
 )
 from .processor import EventProcessor
 
@@ -192,6 +199,22 @@ def setup_handlers(processor: EventProcessor) -> None:
         "notification.suppression.changed.v1", handle_notification_suppression_changed
     )
     processor.register_handler("statement.generated.v1", handle_statement_generated)
+
+    # =========================================================================
+    # Collection case events (platform → CRM, billie_collection_events SDK).
+    # Emitted by the headless collectionsService (BTB-166) to ChatLedger; project
+    # into the collection_cases read model (BTB-199).
+    # =========================================================================
+    processor.register_handler("collection.case.opened.v1", handle_collection_case_opened)
+    processor.register_handler("collection.case.exhausted.v1", handle_collection_case_exhausted)
+    processor.register_handler("collection.case.cured.v1", handle_collection_case_cured)
+    processor.register_handler(
+        "collection.case.hardship_paused.v1", handle_collection_case_hardship_paused
+    )
+    processor.register_handler("collection.case.resumed.v1", handle_collection_case_resumed)
+    processor.register_handler(
+        "collection.case.stop_contact_applied.v1", handle_collection_case_stop_contact_applied
+    )
 
 
 async def run() -> None:

--- a/event-processor/src/billie_servicing/processor.py
+++ b/event-processor/src/billie_servicing/processor.py
@@ -25,6 +25,38 @@ from .config import settings
 logger = structlog.get_logger()
 
 
+# collection.case.* event-type → billie_collection_events model class name.
+# The collection SDK ships flat pydantic models but no parser (unlike the other
+# SDKs), so the processor maps type → model itself.
+_COLLECTION_EVENT_MODELS = {
+    "collection.case.opened.v1": "CollectionCaseOpenedV1",
+    "collection.case.exhausted.v1": "CollectionCaseExhaustedV1",
+    "collection.case.cured.v1": "CollectionCaseCuredV1",
+    "collection.case.hardship_paused.v1": "CollectionCaseHardshipPausedV1",
+    "collection.case.resumed.v1": "CollectionCaseResumedV1",
+    "collection.case.stop_contact_applied.v1": "CollectionCaseStopContactAppliedV1",
+}
+
+
+def _parse_collection_event(event_type: str, env: dict[str, Any]) -> Any:
+    """Validate a collection.case.* payload into its billie_collection_events model.
+
+    The SDK is imported lazily so this module still loads where the SDK isn't
+    installed (dev venv / unrelated test paths). Unknown ``collection.*`` types
+    fall back to the envelope dict.
+    """
+    model_name = _COLLECTION_EVENT_MODELS.get(event_type)
+    if model_name is None:
+        return env
+    import billie_collection_events.models as collection_models
+
+    model_cls = getattr(collection_models, model_name)
+    payload = env.get("payload") or env.get("dat") or {}
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    return model_cls.model_validate(payload)
+
+
 def _check_tls_urls(redis_url: str, database_uri: str) -> None:
     """Fail fast in production if connection URLs are misconfigured.
 
@@ -660,6 +692,12 @@ class EventProcessor:
             # customers) correctly type `rec` as a list, so this is aging-only.
             aging_data = {k: v for k, v in sdk_data.items() if k != "rec"}
             return parse_aging_event(aging_data)
+
+        elif event_type.startswith("collection.case."):
+            # collectionsService (BTB-166) platform events → CRM collection_cases
+            # read model. Map type → billie_collection_events model and validate
+            # the payload (the SDK has no parser). Handlers receive the flat model.
+            return _parse_collection_event(event_type, sanitize_envelope(sanitized))
 
         else:
             # Chat/conversation events — sanitize envelope so payload JSON string

--- a/event-processor/tests/test_collections_handlers.py
+++ b/event-processor/tests/test_collections_handlers.py
@@ -1,0 +1,198 @@
+"""Unit tests for collection.case.* event handlers (Stream D / BTB-199).
+
+Covers the six platform → CRM read-only projections the headless
+collectionsService emits to ChatLedger. Each lands in the ``collection_cases``
+table, keyed by ``account_id``:
+
+- collection.case.opened.v1               → state = 'open'
+- collection.case.exhausted.v1            → state = 'awaiting_human'
+- collection.case.cured.v1                → state = 'cured'
+- collection.case.hardship_paused.v1      → hardship_paused = True  (flag; state untouched)
+- collection.case.resumed.v1              → hardship_paused = False
+- collection.case.stop_contact_applied.v1 → stopped_contact = True  (flag; state untouched)
+
+Payloads are the flat ``billie_collection_events`` pydantic models; handlers
+receive the parsed model directly (account_id/customer_id/… are top-level
+attributes). Tests use MagicMock payloads matching that contract.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from billie_servicing.db import coerce_date
+from billie_servicing.handlers.collections import (
+    handle_collection_case_cured,
+    handle_collection_case_exhausted,
+    handle_collection_case_hardship_paused,
+    handle_collection_case_opened,
+    handle_collection_case_resumed,
+    handle_collection_case_stop_contact_applied,
+)
+
+TABLE = "collection_cases"
+
+
+def _event(**attrs) -> MagicMock:
+    """Build a flat collection-event model stand-in with exactly the given attrs."""
+    event = MagicMock()
+    for key, value in attrs.items():
+        setattr(event, key, value)
+    return event
+
+
+class TestOpened:
+    @pytest.mark.asyncio
+    async def test_opened_upserts_case_keyed_on_account_id(self, mock_pool):
+        event = _event(
+            event_id="evt-1",
+            timestamp="2026-06-01T00:00:00Z",
+            account_id="acc_1",
+            correlation_id="corr-1",
+            customer_id="cust_1",
+            overdue_amount="312.40",
+            due_date="2026-05-20",
+        )
+
+        await handle_collection_case_opened(mock_pool, event)
+
+        call = mock_pool.calls_against(TABLE)[0]
+        assert call.conflict_columns == ["account_id"]
+
+        doc = mock_pool.last_insert(TABLE)
+        assert doc["account_id"] == "acc_1"
+        assert doc["customer_id"] == "cust_1"
+        assert doc["state"] == "open"
+        assert doc["overdue_amount"] == 312.40
+        assert doc["due_date"] == coerce_date("2026-05-20")
+        assert doc["opened_at"] == coerce_date("2026-06-01T00:00:00Z")
+        assert doc["correlation_id"] == "corr-1"
+        # created_at is insert-only (must not be in the DO UPDATE SET clause).
+        assert "created_at" in doc
+        assert "EXCLUDED.created_at" not in call.sql
+
+    @pytest.mark.asyncio
+    async def test_opened_resolves_customer_link(self, mock_pool):
+        mock_pool.set_fetchval("pg-customer-uuid")
+        event = _event(
+            event_id="evt-2",
+            timestamp="2026-06-01T00:00:00Z",
+            account_id="acc_2",
+            correlation_id=None,
+            customer_id="cust_2",
+            overdue_amount="50.00",
+            due_date=None,
+        )
+
+        await handle_collection_case_opened(mock_pool, event)
+
+        doc = mock_pool.last_insert(TABLE)
+        assert doc["customer_ref_id"] == "pg-customer-uuid"
+        assert doc["customer_id"] == "cust_2"
+
+
+class TestExhausted:
+    @pytest.mark.asyncio
+    async def test_exhausted_sets_awaiting_human_with_money_snapshot(self, mock_pool):
+        event = _event(
+            event_id="evt-3",
+            timestamp="2026-06-19T00:00:00Z",
+            account_id="acc_1",
+            correlation_id="corr-1",
+            customer_id="cust_1",
+            overdue_amount="540.00",
+            days_overdue=45,
+            last_step=5,
+        )
+
+        await handle_collection_case_exhausted(mock_pool, event)
+
+        call = mock_pool.calls_against(TABLE)[0]
+        assert call.conflict_columns == ["account_id"]
+        doc = mock_pool.last_insert(TABLE)
+        assert doc["account_id"] == "acc_1"
+        assert doc["state"] == "awaiting_human"
+        assert doc["overdue_amount"] == 540.00
+        assert doc["days_overdue"] == 45
+        assert doc["last_step"] == 5
+        assert doc["exhausted_at"] == coerce_date("2026-06-19T00:00:00Z")
+
+
+class TestCured:
+    @pytest.mark.asyncio
+    async def test_cured_sets_state_and_cured_at(self, mock_pool):
+        event = _event(
+            event_id="evt-4",
+            timestamp="2026-06-20T00:00:00Z",
+            account_id="acc_1",
+            correlation_id="corr-1",
+            customer_id="cust_1",
+            cured_at="2026-06-20T09:30:00Z",
+        )
+
+        await handle_collection_case_cured(mock_pool, event)
+
+        doc = mock_pool.last_insert(TABLE)
+        assert doc["state"] == "cured"
+        assert doc["cured_at"] == coerce_date("2026-06-20T09:30:00Z")
+
+
+class TestHardshipPausedAndResumed:
+    @pytest.mark.asyncio
+    async def test_hardship_paused_sets_flag_without_touching_state(self, mock_pool):
+        event = _event(
+            event_id="evt-5",
+            timestamp="2026-06-10T00:00:00Z",
+            account_id="acc_1",
+            correlation_id="corr-1",
+            customer_id="cust_1",
+            paused_at="2026-06-10T08:00:00Z",
+        )
+
+        await handle_collection_case_hardship_paused(mock_pool, event)
+
+        call = mock_pool.calls_against(TABLE)[0]
+        assert call.conflict_columns == ["account_id"]
+        doc = mock_pool.last_insert(TABLE)
+        assert doc["hardship_paused"] is True
+        assert doc["paused_at"] == coerce_date("2026-06-10T08:00:00Z")
+        # Flag-only upsert must NOT write `state` (would clobber the lifecycle).
+        assert "state" not in doc
+
+    @pytest.mark.asyncio
+    async def test_resumed_clears_flag(self, mock_pool):
+        event = _event(
+            event_id="evt-6",
+            timestamp="2026-06-12T00:00:00Z",
+            account_id="acc_1",
+            correlation_id="corr-1",
+            customer_id="cust_1",
+            resumed_at="2026-06-12T10:00:00Z",
+        )
+
+        await handle_collection_case_resumed(mock_pool, event)
+
+        doc = mock_pool.last_insert(TABLE)
+        assert doc["hardship_paused"] is False
+        assert doc["resumed_at"] == coerce_date("2026-06-12T10:00:00Z")
+        assert "state" not in doc
+
+
+class TestStopContact:
+    @pytest.mark.asyncio
+    async def test_stop_contact_sets_flag(self, mock_pool):
+        event = _event(
+            event_id="evt-7",
+            timestamp="2026-06-15T00:00:00Z",
+            account_id="acc_1",
+            correlation_id="corr-1",
+            customer_id="cust_1",
+            applied_at="2026-06-15T11:00:00Z",
+        )
+
+        await handle_collection_case_stop_contact_applied(mock_pool, event)
+
+        doc = mock_pool.last_insert(TABLE)
+        assert doc["stopped_contact"] is True
+        assert doc["stop_contact_at"] == coerce_date("2026-06-15T11:00:00Z")
+        assert "state" not in doc

--- a/event-processor/tests/test_processor_routing.py
+++ b/event-processor/tests/test_processor_routing.py
@@ -112,3 +112,114 @@ def test_other_application_events_still_use_customers_sdk(make_processor):
         proc._parse_event(
             "application.something_else.v1", {"typ": "application.something_else.v1"}
         )
+
+
+# ---------------------------------------------------------------------------
+# Collection case events (Stream D / BTB-199) — collectionsService → ChatLedger.
+# The billie_collection_events SDK ships flat pydantic models but no parser, so
+# the processor maps event-type → model and validates the payload.
+# ---------------------------------------------------------------------------
+
+COLLECTION_EVENT_TYPES = [
+    "collection.case.opened.v1",
+    "collection.case.exhausted.v1",
+    "collection.case.cured.v1",
+    "collection.case.hardship_paused.v1",
+    "collection.case.resumed.v1",
+    "collection.case.stop_contact_applied.v1",
+]
+
+
+def test_collection_handlers_registered(make_processor):
+    """setup_handlers wires a handler for each of the six collection.case.* types."""
+    from billie_servicing.main import setup_handlers
+
+    proc = make_processor
+    setup_handlers(proc)
+    for event_type in COLLECTION_EVENT_TYPES:
+        assert event_type in proc.handlers, f"{event_type} not registered"
+
+
+def _stub_collection_models(monkeypatch):
+    """Inject a fake billie_collection_events.models (the SDK isn't in the venv).
+
+    Each model's model_validate echoes the payload tagged with the class name so
+    routing can be asserted without the real SDK.
+    """
+    models = types.ModuleType("billie_collection_events.models")
+
+    def _make(name):
+        class _M:
+            _name = name
+
+            @classmethod
+            def model_validate(cls, data):
+                return {"__model__": cls._name, **data}
+
+        _M.__name__ = name
+        return _M
+
+    for cls_name in [
+        "CollectionCaseOpenedV1",
+        "CollectionCaseExhaustedV1",
+        "CollectionCaseCuredV1",
+        "CollectionCaseHardshipPausedV1",
+        "CollectionCaseResumedV1",
+        "CollectionCaseStopContactAppliedV1",
+    ]:
+        setattr(models, cls_name, _make(cls_name))
+
+    parent = types.ModuleType("billie_collection_events")
+    monkeypatch.setitem(sys.modules, "billie_collection_events", parent)
+    monkeypatch.setitem(sys.modules, "billie_collection_events.models", models)
+
+
+def test_collection_event_routes_to_typed_model(make_processor, monkeypatch):
+    _stub_collection_models(monkeypatch)
+    proc = make_processor
+    sanitized = {
+        "typ": "collection.case.opened.v1",
+        "conv": "c1",
+        "payload": json.dumps(
+            {
+                "event_id": "evt_1",
+                "timestamp": "2026-06-01T00:00:00Z",
+                "account_id": "acc_1",
+                "correlation_id": "corr_1",
+                "customer_id": "cust_1",
+                "overdue_amount": "312.40",
+                "due_date": "2026-05-20",
+            }
+        ),
+    }
+
+    parsed = proc._parse_event("collection.case.opened.v1", sanitized)
+
+    # Routed to the opened model (not the envelope-dict fallback), payload validated.
+    assert parsed["__model__"] == "CollectionCaseOpenedV1"
+    assert parsed["account_id"] == "acc_1"
+    assert parsed["customer_id"] == "cust_1"
+
+
+def test_collection_exhausted_routes_to_its_model(make_processor, monkeypatch):
+    _stub_collection_models(monkeypatch)
+    proc = make_processor
+    sanitized = {
+        "typ": "collection.case.exhausted.v1",
+        "payload": json.dumps(
+            {
+                "event_id": "evt_2",
+                "timestamp": "2026-06-19T00:00:00Z",
+                "account_id": "acc_1",
+                "customer_id": "cust_1",
+                "overdue_amount": "540.00",
+                "days_overdue": 45,
+                "last_step": 5,
+            }
+        ),
+    }
+
+    parsed = proc._parse_event("collection.case.exhausted.v1", sanitized)
+
+    assert parsed["__model__"] == "CollectionCaseExhaustedV1"
+    assert parsed["days_overdue"] == 45

--- a/proto/collections_service.proto
+++ b/proto/collections_service.proto
@@ -1,0 +1,129 @@
+syntax = "proto3";
+
+// Canonical contract for the headless collections engine's command + read API,
+// consumed by the Collections CRM (Stream D). Provider: collectionsService
+// (billie-platform-services). Consumer: billie-crm (vendors a copy of this file,
+// same convention as proto/accounting_ledger.proto + proto/notification_dispatcher.proto).
+//
+// Design basis (agreed): operator actions are SYNCHRONOUS gRPC commands, not
+// command-events — the CRM operator needs immediate validation + a verdict. The
+// commands STILL emit the collection.case.* events to ChatLedger (the gRPC is the
+// command *ingress*; the events remain the source of truth for case state and keep
+// the CRM's own projection converging). System-driven transitions (instalment.overdue,
+// payment.received, notification.sent, loan.aging.updated) continue to arrive as
+// events on inbox:collectionsService — both paths funnel into the same pg-atomic FSM
+// (SELECT ... FOR UPDATE), so they serialise safely per account.
+//
+// Conventions:
+//   - Money fields are decimal strings (e.g. "1234.56") — matches the ledger gRPC.
+//   - Timestamps are google.protobuf.Timestamp (UTC) — matches the dispatcher proto.
+//   - Every command carries operator_id (for the contact/audit log) and
+//     idempotency_key (CRM-generated; replay returns the original result, no re-apply).
+//   - The engine resolves customer_id from the accounts read-client (BTB-154); the
+//     CRM does NOT pass it on commands.
+//
+// gRPC status codes the CRM surfaces (message carries a stable, human-readable reason):
+//   NOT_FOUND            unknown account_id
+//   FAILED_PRECONDITION  command invalid for the case's current state (reason set)
+//   INVALID_ARGUMENT     missing/blank required field
+//   OK (idempotent)      idempotency_key replay → original CaseActionResponse, no-op apply
+//
+// ── Build phasing (see docs/superpowers/specs/2026-06-24-collections-grpc-provider.md) ──
+//   PHASE 1 (buildable now): FlagHardship, ResumeFromHardship, ApplyStopContact,
+//                            GetContactLog. AdvanceToNextStep with state preconditions
+//                            only (economic gate deferred).
+//   PHASE 2 (BLOCKED on the cost-of-recovery engine, which is unspecified):
+//                            GetCaseEconomics, ListCaseEconomics, and the economic-gate
+//                            enforcement inside AdvanceToNextStep.
+
+package billie.collections.v1;
+
+import "google/protobuf/timestamp.proto";
+
+service CollectionsService {
+  // ── Commands (operator actions) — sync; apply FSM txn → emit collection.case.* → return ──
+  rpc FlagHardship(FlagHardshipRequest)      returns (CaseActionResponse);
+  rpc ResumeFromHardship(ResumeRequest)      returns (CaseActionResponse);
+  rpc ApplyStopContact(StopContactRequest)   returns (CaseActionResponse);
+  // AdvanceToNextStep — the human escalation gate. Phase 1: enforces state
+  // preconditions (rejects on terminal/exhausted/cured/stopped_contact) and advances
+  // the rung + commands the next send. Phase 2: also enforces the cost-of-recovery
+  // gate (rejects FAILED_PRECONDITION when GetCaseEconomics.gate_result != PASS).
+  rpc AdvanceToNextStep(AdvanceRequest)      returns (CaseActionResponse);
+
+  // ── Reads ──
+  // Phase 1 — backed by collections.send_log (+ the count(*) cap windows).
+  rpc GetContactLog(CaseRef)                 returns (ContactLog);
+
+  // Phase 2 — BLOCKED on the cost-of-recovery engine (unspecified). Defined here so the
+  // CRM can code against the contract; until the engine lands the provider returns
+  // gate_result = NOT_APPLICABLE and empty economics (never errors — see consumer doc).
+  rpc GetCaseEconomics(CaseRef)              returns (CaseEconomics);
+  rpc ListCaseEconomics(CaseRefs)            returns (CaseEconomicsList);
+
+  // Future, pending product confirmation (do they affect cadence? → engine commands):
+  //   rpc RecordArrangement(ArrangementRequest) returns (CaseActionResponse);
+  //   rpc Park(ParkRequest)                     returns (CaseActionResponse);
+}
+
+message CaseRef  { string account_id = 1; }
+message CaseRefs { repeated string account_ids = 1; }
+
+// ── Command requests ──
+message FlagHardshipRequest { string account_id = 1; string operator_id = 2; string reason = 3; string idempotency_key = 4; }
+message ResumeRequest       { string account_id = 1; string operator_id = 2; string idempotency_key = 3; }
+message StopContactRequest  { string account_id = 1; string operator_id = 2; string reason = 3; string idempotency_key = 4; }
+message AdvanceRequest      { string account_id = 1; string operator_id = 2; string idempotency_key = 3; }
+
+message CaseActionResponse {
+  string account_id = 1;
+  string new_state = 2;        // e.g. "paused_hardship" | "active" | "stopped_contact"
+  string emitted_event_id = 3; // the collection.case.* event_id, for trace/dedup
+}
+
+// ── Economics (Phase 2 — cost-of-recovery engine) ──
+enum GateStatus { GATE_UNSPECIFIED = 0; PASS = 1; FAIL = 2; NOT_APPLICABLE = 3; }
+message GateResult { GateStatus status = 1; string reason = 2; }
+
+message CostLedgerEntry {
+  string label = 1;
+  string amount = 2;    // decimal string
+  string category = 3;  // "production" | "hard"
+  bool recoverable = 4;
+}
+
+message NextStepPreview {
+  int32 rung = 1;
+  string channel = 2;   // "sms" | "email"
+  string template = 3;
+  string subject = 4;
+  string body = 5;      // rendered — what the customer would see
+}
+
+message CaseEconomics {
+  string account_id = 1;
+  string amount_owed = 2;            // frozen A (principal + original fee − payments)
+  string cost_of_next_step = 3;
+  string expected_net_recovery = 4;
+  GateResult gate_result = 5;
+  repeated CostLedgerEntry cost_ledger = 6;
+  NextStepPreview next_step_preview = 7;
+}
+message CaseEconomicsList { repeated CaseEconomics items = 1; }
+
+// ── Contact log (Phase 1 — collections.send_log) ──
+message ContactCapStatus {
+  int32 sent_7d = 1;  int32 cap_7d = 2;      // e.g. 2 / 3
+  int32 sent_month = 3; int32 cap_month = 4; // e.g. 6 / 10
+}
+message ContactLogEntry {
+  google.protobuf.Timestamp sent_at = 1;
+  string channel = 2;
+  string template = 3;
+  string outcome = 4;   // "sent" | "failed" | "skipped" (+ reason)
+}
+message ContactLog {
+  string account_id = 1;
+  repeated ContactLogEntry entries = 2;
+  ContactCapStatus contact_cap_status = 3;
+}

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -3,6 +3,7 @@ import { NotificationAction as NotificationAction_ff7594e27eaf34e7ce9acae213b054
 import { GoogleLoginButton as GoogleLoginButton_f8eb56cd8fd98e23e8bcaf648a37c729 } from '@/components/Auth/GoogleLoginButton'
 import { NavSearchTrigger as NavSearchTrigger_aef8b4b7b9afc7097ff45e7590131c08 } from '@/components/navigation/NavSearchTrigger'
 import { NavDashboardLink as NavDashboardLink_8ed26f5dfcf4b8f60da98c3488976ae8 } from '@/components/navigation/NavDashboardLink'
+import { NavApplicationsLink as NavApplicationsLink_554f3cd5ec77593b1109c73a71b4e7f2 } from '@/components/navigation/NavApplicationsLink'
 import { NavAccountsLink as NavAccountsLink_f9e90e2a5a25699ab203b1e93b9f79d6 } from '@/components/navigation/NavAccountsLink'
 import { NavCollectionsLink as NavCollectionsLink_cace573cc395aa45fa1be624b4874bcd } from '@/components/navigation/NavCollectionsLink'
 import { NavApprovalsLink as NavApprovalsLink_432895ce587e4825ef60ac4a4de8aa43 } from '@/components/navigation/NavApprovalsLink'
@@ -10,7 +11,6 @@ import { NavPeriodCloseLink as NavPeriodCloseLink_b876b3abd416c3d860c4802b5c1185
 import { NavECLConfigLink as NavECLConfigLink_3ff0f20809012ed106da89f9feaf716c } from '@/components/navigation/NavECLConfigLink'
 import { NavExportsLink as NavExportsLink_30210b8f1b8d6622c22618d359a47328 } from '@/components/navigation/NavExportsLink'
 import { NavInvestigationLink as NavInvestigationLink_25d4a0e46dfdaebb4b30fe5c09ac4503 } from '@/components/navigation/NavInvestigationLink'
-import { NavApplicationsLink as NavApplicationsLink_554f3cd5ec77593b1109c73a71b4e7f2 } from '@/components/navigation/NavApplicationsLink'
 import { default as default_2aef381f6a0e89088ab303e1162933ca } from '@/providers'
 import { DashboardViewWithTemplate as DashboardViewWithTemplate_aa38ffaef1440457ff25f89c94f88b6b } from '@/components/DashboardView/DashboardViewWithTemplate'
 import { ServicingViewWithTemplate as ServicingViewWithTemplate_04dbd51012de8c56c1deb3ec9516015c } from '@/components/ServicingView/ServicingViewWithTemplate'
@@ -25,13 +25,16 @@ import { ECLConfigViewWithTemplate as ECLConfigViewWithTemplate_da54698be16fc6d4
 import { ExportCenterViewWithTemplate as ExportCenterViewWithTemplate_df012e52e067a6044c3439dd142ed735 } from '@/components/ExportCenterView/ExportCenterViewWithTemplate'
 import { InvestigationViewWithTemplate as InvestigationViewWithTemplate_da95a625101a2d97fc47681066b86998 } from '@/components/InvestigationView/InvestigationViewWithTemplate'
 import { ApplicationsViewWithTemplate as ApplicationsViewWithTemplate_d004262689768525c348b9fc1d1da517 } from '@/components/ApplicationsView/ApplicationsViewWithTemplate'
+import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
+/** @type import('payload').ImportMap */
 export const importMap = {
   "@/components/LoanAccountServicing#LoanAccountServicing": LoanAccountServicing_ddd43f8b2788d92f39012f5e3f407ad6,
   "@/components/Notifications/NotificationAction#NotificationAction": NotificationAction_ff7594e27eaf34e7ce9acae213b05415,
   "@/components/Auth/GoogleLoginButton#GoogleLoginButton": GoogleLoginButton_f8eb56cd8fd98e23e8bcaf648a37c729,
   "@/components/navigation/NavSearchTrigger#NavSearchTrigger": NavSearchTrigger_aef8b4b7b9afc7097ff45e7590131c08,
   "@/components/navigation/NavDashboardLink#NavDashboardLink": NavDashboardLink_8ed26f5dfcf4b8f60da98c3488976ae8,
+  "@/components/navigation/NavApplicationsLink#NavApplicationsLink": NavApplicationsLink_554f3cd5ec77593b1109c73a71b4e7f2,
   "@/components/navigation/NavAccountsLink#NavAccountsLink": NavAccountsLink_f9e90e2a5a25699ab203b1e93b9f79d6,
   "@/components/navigation/NavCollectionsLink#NavCollectionsLink": NavCollectionsLink_cace573cc395aa45fa1be624b4874bcd,
   "@/components/navigation/NavApprovalsLink#NavApprovalsLink": NavApprovalsLink_432895ce587e4825ef60ac4a4de8aa43,
@@ -39,7 +42,6 @@ export const importMap = {
   "@/components/navigation/NavECLConfigLink#NavECLConfigLink": NavECLConfigLink_3ff0f20809012ed106da89f9feaf716c,
   "@/components/navigation/NavExportsLink#NavExportsLink": NavExportsLink_30210b8f1b8d6622c22618d359a47328,
   "@/components/navigation/NavInvestigationLink#NavInvestigationLink": NavInvestigationLink_25d4a0e46dfdaebb4b30fe5c09ac4503,
-  "@/components/navigation/NavApplicationsLink#NavApplicationsLink": NavApplicationsLink_554f3cd5ec77593b1109c73a71b4e7f2,
   "@/providers#default": default_2aef381f6a0e89088ab303e1162933ca,
   "@/components/DashboardView/DashboardViewWithTemplate#DashboardViewWithTemplate": DashboardViewWithTemplate_aa38ffaef1440457ff25f89c94f88b6b,
   "@/components/ServicingView/ServicingViewWithTemplate#ServicingViewWithTemplate": ServicingViewWithTemplate_04dbd51012de8c56c1deb3ec9516015c,
@@ -53,5 +55,6 @@ export const importMap = {
   "@/components/ECLConfigView/ECLConfigViewWithTemplate#ECLConfigViewWithTemplate": ECLConfigViewWithTemplate_da54698be16fc6d457187852eba8f854,
   "@/components/ExportCenterView/ExportCenterViewWithTemplate#ExportCenterViewWithTemplate": ExportCenterViewWithTemplate_df012e52e067a6044c3439dd142ed735,
   "@/components/InvestigationView/InvestigationViewWithTemplate#InvestigationViewWithTemplate": InvestigationViewWithTemplate_da95a625101a2d97fc47681066b86998,
-  "@/components/ApplicationsView/ApplicationsViewWithTemplate#ApplicationsViewWithTemplate": ApplicationsViewWithTemplate_d004262689768525c348b9fc1d1da517
+  "@/components/ApplicationsView/ApplicationsViewWithTemplate#ApplicationsViewWithTemplate": ApplicationsViewWithTemplate_d004262689768525c348b9fc1d1da517,
+  "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/src/collections/CollectionsCases.ts
+++ b/src/collections/CollectionsCases.ts
@@ -1,0 +1,123 @@
+import type { CollectionConfig, Access } from 'payload'
+import { hideFromNonAdmins, hasAnyRole } from '@/lib/access'
+
+const anyRole: Access = ({ req: { user } }) => hasAnyRole(user)
+
+/**
+ * Collection Cases — read-only projection (Stream D / BTB-199).
+ *
+ * Written by the Python event processor from the six `collection.case.*` events
+ * the headless collectionsService (BTB-166) emits to ChatLedger:
+ *   collection.case.opened.v1              → state = 'open'
+ *   collection.case.exhausted.v1           → state = 'awaiting_human'
+ *   collection.case.cured.v1               → state = 'cured'
+ *   collection.case.hardship_paused.v1     → hardshipPaused = true   (flag; state unchanged)
+ *   collection.case.resumed.v1             → hardshipPaused = false
+ *   collection.case.stop_contact_applied.v1→ stoppedContact = true   (flag; state unchanged)
+ *
+ * One document per advance, keyed by `accountId` (unique). Operational state +
+ * flags only — economics (cost-of-recovery gate, expected net recovery) come
+ * from the collectionsService gRPC at read time (BTB-198), and live accounting
+ * from the AccountingLedgerService gRPC. The projection is replay-rebuildable.
+ */
+export const CollectionsCases: CollectionConfig = {
+  slug: 'collection-cases',
+  admin: {
+    useAsTitle: 'accountId',
+    defaultColumns: ['accountId', 'customerId', 'state', 'overdueAmount', 'daysOverdue', 'updatedAt'],
+    group: 'Supervisor Dashboard',
+    hidden: hideFromNonAdmins,
+  },
+  access: {
+    read: anyRole,
+    create: () => false,
+    update: () => false,
+    delete: () => false,
+  },
+  fields: [
+    {
+      name: 'accountId',
+      type: 'text',
+      required: true,
+      unique: true,
+      index: true,
+      admin: { readOnly: true, description: 'Ledger account_id — one case per advance (natural key)' },
+    },
+    {
+      name: 'customerRef',
+      type: 'relationship',
+      relationTo: 'customers',
+      admin: {
+        readOnly: true,
+        description: 'Resolved customer link (may be null if customer not yet projected)',
+      },
+    },
+    {
+      name: 'customerId',
+      type: 'text',
+      index: true,
+      admin: { readOnly: true, description: 'Customer ID string from the event (BTB-154 provenance)' },
+    },
+    {
+      name: 'state',
+      type: 'select',
+      index: true,
+      options: [
+        { label: 'Open (overdue series active)', value: 'open' },
+        { label: 'Awaiting human (exhausted)', value: 'awaiting_human' },
+        { label: 'Cured', value: 'cured' },
+      ],
+      admin: { readOnly: true, description: 'Base lifecycle state. Cross-cutting hardship / stop-contact are flags.' },
+    },
+    {
+      name: 'hardshipPaused',
+      type: 'checkbox',
+      index: true,
+      admin: { readOnly: true },
+    },
+    {
+      name: 'stoppedContact',
+      type: 'checkbox',
+      index: true,
+      admin: { readOnly: true },
+    },
+    {
+      name: 'overdueAmount',
+      type: 'number',
+      admin: { readOnly: true, step: 0.01, description: 'Snapshot from the event; live amount comes from the ledger' },
+    },
+    {
+      name: 'daysOverdue',
+      type: 'number',
+      admin: { readOnly: true },
+    },
+    {
+      name: 'lastStep',
+      type: 'number',
+      admin: { readOnly: true, description: 'Last automated reminder step sent (max 5); set on exhaustion' },
+    },
+    {
+      name: 'dueDate',
+      type: 'date',
+      admin: { readOnly: true },
+    },
+    {
+      name: 'openedAt',
+      type: 'date',
+      index: true,
+      admin: { readOnly: true },
+    },
+    { name: 'curedAt', type: 'date', admin: { readOnly: true } },
+    { name: 'exhaustedAt', type: 'date', admin: { readOnly: true } },
+    { name: 'pausedAt', type: 'date', admin: { readOnly: true } },
+    { name: 'resumedAt', type: 'date', admin: { readOnly: true } },
+    { name: 'stopContactAt', type: 'date', admin: { readOnly: true } },
+    {
+      name: 'correlationId',
+      type: 'text',
+      admin: { readOnly: true },
+    },
+    { name: 'createdAt', type: 'date', admin: { readOnly: true } },
+    { name: 'updatedAt', type: 'date', admin: { readOnly: true } },
+  ],
+}

--- a/src/migrations/20260624_094132.json
+++ b/src/migrations/20260624_094132.json
@@ -1,0 +1,6087 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_users_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'readonly'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_id": {
+          "name": "avatar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "enable_a_p_i_key": {
+          "name": "enable_a_p_i_key",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_index": {
+          "name": "api_key_index",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_avatar_idx": {
+          "name": "users_avatar_idx",
+          "columns": [
+            {
+              "expression": "avatar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_avatar_id_media_id_fk": {
+          "name": "users_avatar_id_media_id_fk",
+          "tableFrom": "users",
+          "tableTo": "media",
+          "columnsFrom": [
+            "avatar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers_identity_documents": {
+      "name": "customers_identity_documents",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "enum_customers_identity_documents_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_subtype": {
+          "name": "document_subtype",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_of_issue": {
+          "name": "state_of_issue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_issue": {
+          "name": "country_of_issue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "additional_info": {
+          "name": "additional_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_identity_documents_order_idx": {
+          "name": "customers_identity_documents_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_identity_documents_parent_id_idx": {
+          "name": "customers_identity_documents_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_identity_documents_parent_id_fk": {
+          "name": "customers_identity_documents_parent_id_fk",
+          "tableFrom": "customers_identity_documents",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into": {
+          "name": "merged_into",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "middle_name": {
+          "name": "middle_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_phone_number": {
+          "name": "mobile_phone_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verified": {
+          "name": "identity_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_number": {
+          "name": "residential_address_street_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_name": {
+          "name": "residential_address_street_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_type": {
+          "name": "residential_address_street_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_unit_number": {
+          "name": "residential_address_unit_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street": {
+          "name": "residential_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_suburb": {
+          "name": "residential_address_suburb",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_city": {
+          "name": "residential_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_state": {
+          "name": "residential_address_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_postcode": {
+          "name": "residential_address_postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_country": {
+          "name": "residential_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "residential_address_full_address": {
+          "name": "residential_address_full_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_street": {
+          "name": "mailing_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_city": {
+          "name": "mailing_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_state": {
+          "name": "mailing_address_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_postcode": {
+          "name": "mailing_address_postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_country": {
+          "name": "mailing_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "staff_flag": {
+          "name": "staff_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "investor_flag": {
+          "name": "investor_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founder_flag": {
+          "name": "founder_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerable_flag": {
+          "name": "vulnerable_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ekyc_entity_id": {
+          "name": "ekyc_entity_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ekyc_status": {
+          "name": "ekyc_status",
+          "type": "enum_customers_ekyc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "individual_status": {
+          "name": "individual_status",
+          "type": "enum_customers_individual_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_reason": {
+          "name": "reapplication_block_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_until": {
+          "name": "reapplication_block_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_at": {
+          "name": "reapplication_block_blocked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_application_number": {
+          "name": "reapplication_block_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_overall_result": {
+          "name": "identity_verification_overall_result",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_provider": {
+          "name": "identity_verification_provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_provider_reference": {
+          "name": "identity_verification_provider_reference",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_lab_request_id": {
+          "name": "identity_verification_lab_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_checked_at": {
+          "name": "identity_verification_checked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_archived": {
+          "name": "identity_verification_report_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_archived_at": {
+          "name": "identity_verification_archived_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "customers_customer_id_idx": {
+          "name": "customers_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_merged_into_idx": {
+          "name": "customers_merged_into_idx",
+          "columns": [
+            {
+              "expression": "merged_into",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_updated_at_idx": {
+          "name": "customers_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_created_at_idx": {
+          "name": "customers_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers_rels": {
+      "name": "customers_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applications_id": {
+          "name": "applications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_accounts_id": {
+          "name": "loan_accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_rels_order_idx": {
+          "name": "customers_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_parent_idx": {
+          "name": "customers_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_path_idx": {
+          "name": "customers_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_applications_id_idx": {
+          "name": "customers_rels_applications_id_idx",
+          "columns": [
+            {
+              "expression": "applications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_conversations_id_idx": {
+          "name": "customers_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_loan_accounts_id_idx": {
+          "name": "customers_rels_loan_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "loan_accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_rels_parent_fk": {
+          "name": "customers_rels_parent_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_applications_fk": {
+          "name": "customers_rels_applications_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "applications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_conversations_fk": {
+          "name": "customers_rels_conversations_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_loan_accounts_fk": {
+          "name": "customers_rels_loan_accounts_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_utterances": {
+      "name": "conversations_utterances",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utterance": {
+          "name": "utterance",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_input_type": {
+          "name": "answer_input_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_seq": {
+          "name": "prev_seq",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_conversation": {
+          "name": "end_conversation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_utterances_order_idx": {
+          "name": "conversations_utterances_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_utterances_parent_id_idx": {
+          "name": "conversations_utterances_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_utterances_parent_id_fk": {
+          "name": "conversations_utterances_parent_id_fk",
+          "tableFrom": "conversations_utterances",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_facts": {
+      "name": "conversations_facts",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fact": {
+          "name": "fact",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_facts_order_idx": {
+          "name": "conversations_facts_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_facts_parent_id_idx": {
+          "name": "conversations_facts_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_facts_parent_id_fk": {
+          "name": "conversations_facts_parent_id_fk",
+          "tableFrom": "conversations_facts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_noticeboard": {
+      "name": "conversations_noticeboard",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_noticeboard_order_idx": {
+          "name": "conversations_noticeboard_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_noticeboard_parent_id_idx": {
+          "name": "conversations_noticeboard_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_noticeboard_parent_id_fk": {
+          "name": "conversations_noticeboard_parent_id_fk",
+          "tableFrom": "conversations_noticeboard",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_number": {
+          "name": "application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id_string": {
+          "name": "customer_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id_id": {
+          "name": "application_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_conversations_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "last_utterance_time": {
+          "name": "last_utterance_time",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_decision": {
+          "name": "final_decision",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_reason": {
+          "name": "decision_detail_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_retry_eligible": {
+          "name": "decision_detail_retry_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_source_application_number": {
+          "name": "decision_detail_source_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_blocked_until": {
+          "name": "decision_detail_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_reason": {
+          "name": "reapplication_block_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_message_variant": {
+          "name": "reapplication_block_message_variant",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_stop_message": {
+          "name": "reapplication_block_stop_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_application_number": {
+          "name": "reapplication_block_source_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_account_id": {
+          "name": "reapplication_block_source_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_decided_at": {
+          "name": "reapplication_block_source_decided_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_until": {
+          "name": "reapplication_block_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_at": {
+          "name": "reapplication_block_blocked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_canonical_customer_id": {
+          "name": "reapplication_block_canonical_customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_disposition_kind": {
+          "name": "reapplication_block_disposition_kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_manual_review_candidate": {
+          "name": "reapplication_block_manual_review_candidate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_recognition": {
+          "name": "reapplication_block_recognition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_lab_request_id": {
+          "name": "identity_verification_report_lab_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_provider_reference": {
+          "name": "identity_verification_report_provider_reference",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_report_file_location": {
+          "name": "identity_verification_report_report_file_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_report_file_name": {
+          "name": "identity_verification_report_report_file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_raw_response_file_location": {
+          "name": "identity_verification_report_raw_response_file_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_raw_response_file_name": {
+          "name": "identity_verification_report_raw_response_file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_archived_at": {
+          "name": "identity_verification_report_archived_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_identity_risk": {
+          "name": "assessments_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_serviceability": {
+          "name": "assessments_serviceability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_fraud_check": {
+          "name": "assessments_fraud_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_account_conduct": {
+          "name": "assessments_account_conduct",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_post_identity_risk": {
+          "name": "assessments_post_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_credit_assessment_complete": {
+          "name": "assessments_credit_assessment_complete",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture": {
+          "name": "statement_capture",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_status": {
+          "name": "decision_status",
+          "type": "enum_conversations_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_data": {
+          "name": "application_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_conversation_id_idx": {
+          "name": "conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_application_number_idx": {
+          "name": "conversations_application_number_idx",
+          "columns": [
+            {
+              "expression": "application_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_customer_id_idx": {
+          "name": "conversations_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_customer_id_string_idx": {
+          "name": "conversations_customer_id_string_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_application_id_idx": {
+          "name": "conversations_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_status_idx": {
+          "name": "conversations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_decision_status_idx": {
+          "name": "conversations_decision_status_idx",
+          "columns": [
+            {
+              "expression": "decision_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_created_at_idx": {
+          "name": "conversations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_monitor_grid_idx": {
+          "name": "conversations_monitor_grid_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_by_customer_idx": {
+          "name": "conversations_by_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_customer_id_id_customers_id_fk": {
+          "name": "conversations_customer_id_id_customers_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_application_id_id_applications_id_fk": {
+          "name": "conversations_application_id_id_applications_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_proc_state_steps": {
+      "name": "app_proc_state_steps",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "step_name": {
+          "name": "step_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_app_proc_state_steps_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        },
+        "completion_event_name": {
+          "name": "completion_event_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_input_type": {
+          "name": "answer_input_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_main": {
+          "name": "prompts_main",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_completeness_check": {
+          "name": "prompts_completeness_check",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_confirmation": {
+          "name": "prompts_confirmation",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_output_json": {
+          "name": "prompts_output_json",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_mapping_out": {
+          "name": "prompts_mapping_out",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_module_name": {
+          "name": "business_logic_module_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_method_name": {
+          "name": "business_logic_method_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_mapping_in": {
+          "name": "business_logic_mapping_in",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_mapping_out": {
+          "name": "business_logic_mapping_out",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_proc_state_steps_order_idx": {
+          "name": "app_proc_state_steps_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_proc_state_steps_parent_id_idx": {
+          "name": "app_proc_state_steps_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_proc_state_steps_parent_id_fk": {
+          "name": "app_proc_state_steps_parent_id_fk",
+          "tableFrom": "app_proc_state_steps",
+          "tableTo": "app_proc_state",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_proc_state": {
+      "name": "app_proc_state",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stage_name": {
+          "name": "stage_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_proc_state_order_idx": {
+          "name": "app_proc_state_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_proc_state_parent_id_idx": {
+          "name": "app_proc_state_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_proc_state_parent_id_fk": {
+          "name": "app_proc_state_parent_id_fk",
+          "tableFrom": "app_proc_state",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_application_process_conversation": {
+      "name": "applications_application_process_conversation",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_applications_application_process_conversation_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_application_process_conversation_order_idx": {
+          "name": "applications_application_process_conversation_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_application_process_conversation_parent_id_idx": {
+          "name": "applications_application_process_conversation_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_application_process_conversation_parent_id_fk": {
+          "name": "applications_application_process_conversation_parent_id_fk",
+          "tableFrom": "applications_application_process_conversation",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_noticeboard_versions": {
+      "name": "applications_noticeboard_versions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_noticeboard_versions_order_idx": {
+          "name": "applications_noticeboard_versions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_noticeboard_versions_parent_id_idx": {
+          "name": "applications_noticeboard_versions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_noticeboard_versions_parent_id_fk": {
+          "name": "applications_noticeboard_versions_parent_id_fk",
+          "tableFrom": "applications_noticeboard_versions",
+          "tableTo": "applications_noticeboard",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_noticeboard": {
+      "name": "applications_noticeboard",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "applications_noticeboard_order_idx": {
+          "name": "applications_noticeboard_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_noticeboard_parent_id_idx": {
+          "name": "applications_noticeboard_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_noticeboard_parent_id_fk": {
+          "name": "applications_noticeboard_parent_id_fk",
+          "tableFrom": "applications_noticeboard",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_number": {
+          "name": "application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_purpose": {
+          "name": "loan_purpose",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_amount": {
+          "name": "loan_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_fee": {
+          "name": "loan_fee",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_total_payable": {
+          "name": "loan_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_term": {
+          "name": "loan_term",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_attestation_acceptance": {
+          "name": "customer_attestation_acceptance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture_consent_provided": {
+          "name": "statement_capture_consent_provided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture_completed": {
+          "name": "statement_capture_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_offer_acceptance": {
+          "name": "product_offer_acceptance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_outcome": {
+          "name": "application_outcome",
+          "type": "enum_applications_application_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_current_process_stage": {
+          "name": "application_process_current_process_stage",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_current_process_step": {
+          "name": "application_process_current_process_step",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_started_at": {
+          "name": "application_process_started_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_updated_at": {
+          "name": "application_process_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_identity_risk": {
+          "name": "assessments_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_serviceability": {
+          "name": "assessments_serviceability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_fraud_check": {
+          "name": "assessments_fraud_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applications_application_number_idx": {
+          "name": "applications_application_number_idx",
+          "columns": [
+            {
+              "expression": "application_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_customer_id_idx": {
+          "name": "applications_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_application_outcome_idx": {
+          "name": "applications_application_outcome_idx",
+          "columns": [
+            {
+              "expression": "application_outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_updated_at_idx": {
+          "name": "applications_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_created_at_idx": {
+          "name": "applications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_customer_id_id_customers_id_fk": {
+          "name": "applications_customer_id_id_customers_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_rels": {
+      "name": "applications_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_rels_order_idx": {
+          "name": "applications_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_parent_idx": {
+          "name": "applications_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_path_idx": {
+          "name": "applications_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_conversations_id_idx": {
+          "name": "applications_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_rels_parent_fk": {
+          "name": "applications_rels_parent_fk",
+          "tableFrom": "applications_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_rels_conversations_fk": {
+          "name": "applications_rels_conversations_fk",
+          "tableFrom": "applications_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_accounts_repayment_schedule_payments": {
+      "name": "loan_accounts_repayment_schedule_payments",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payment_number": {
+          "name": "payment_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_loan_accounts_repayment_schedule_payments_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'scheduled'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_remaining": {
+          "name": "amount_remaining",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_transaction_ids": {
+          "name": "linked_transaction_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "loan_accounts_repayment_schedule_payments_order_idx": {
+          "name": "loan_accounts_repayment_schedule_payments_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_repayment_schedule_payments_parent_id_idx": {
+          "name": "loan_accounts_repayment_schedule_payments_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accts_repay_sched_payments_natural_key_idx": {
+          "name": "loan_accts_repay_sched_payments_natural_key_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_accounts_repayment_schedule_payments_parent_id_fk": {
+          "name": "loan_accounts_repayment_schedule_payments_parent_id_fk",
+          "tableFrom": "loan_accounts_repayment_schedule_payments",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_accounts": {
+      "name": "loan_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id_string": {
+          "name": "customer_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_loan_amount": {
+          "name": "loan_terms_loan_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_loan_fee": {
+          "name": "loan_terms_loan_fee",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_total_payable": {
+          "name": "loan_terms_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_opened_date": {
+          "name": "loan_terms_opened_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_disbursed_date": {
+          "name": "loan_terms_disbursed_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_current_balance": {
+          "name": "balances_current_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_total_outstanding": {
+          "name": "balances_total_outstanding",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_total_paid": {
+          "name": "balances_total_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_payment_date": {
+          "name": "last_payment_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_payment_amount": {
+          "name": "last_payment_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_is_in_arrears": {
+          "name": "aging_is_in_arrears",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "aging_bucket": {
+          "name": "aging_bucket",
+          "type": "enum_loan_accounts_aging_bucket",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_current_d_p_d": {
+          "name": "aging_current_d_p_d",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_last_updated": {
+          "name": "aging_last_updated",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_status": {
+          "name": "account_status",
+          "type": "enum_loan_accounts_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "sdk_status": {
+          "name": "sdk_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commencement_date": {
+          "name": "commencement_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_loan_agreement_url": {
+          "name": "signed_loan_agreement_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "enum_loan_accounts_closure_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_previous_status": {
+          "name": "closure_previous_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_closed_date": {
+          "name": "closure_closed_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_final_balance": {
+          "name": "closure_final_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_total_paid": {
+          "name": "closure_total_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_loan_total_payable": {
+          "name": "closure_loan_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_triggered_by_transaction_id": {
+          "name": "closure_triggered_by_transaction_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_schedule_id": {
+          "name": "repayment_schedule_schedule_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_number_of_payments": {
+          "name": "repayment_schedule_number_of_payments",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_payment_frequency": {
+          "name": "repayment_schedule_payment_frequency",
+          "type": "enum_loan_accounts_repayment_schedule_payment_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_created_date": {
+          "name": "repayment_schedule_created_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "loan_accounts_loan_account_id_idx": {
+          "name": "loan_accounts_loan_account_id_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_account_number_idx": {
+          "name": "loan_accounts_account_number_idx",
+          "columns": [
+            {
+              "expression": "account_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_customer_id_idx": {
+          "name": "loan_accounts_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_customer_id_string_idx": {
+          "name": "loan_accounts_customer_id_string_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_loan_terms_loan_terms_disbursed_date_idx": {
+          "name": "loan_accounts_loan_terms_loan_terms_disbursed_date_idx",
+          "columns": [
+            {
+              "expression": "loan_terms_disbursed_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_aging_aging_is_in_arrears_idx": {
+          "name": "loan_accounts_aging_aging_is_in_arrears_idx",
+          "columns": [
+            {
+              "expression": "aging_is_in_arrears",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_aging_aging_bucket_idx": {
+          "name": "loan_accounts_aging_aging_bucket_idx",
+          "columns": [
+            {
+              "expression": "aging_bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_account_status_idx": {
+          "name": "loan_accounts_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_commencement_date_idx": {
+          "name": "loan_accounts_commencement_date_idx",
+          "columns": [
+            {
+              "expression": "commencement_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_updated_at_idx": {
+          "name": "loan_accounts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_created_at_idx": {
+          "name": "loan_accounts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_accounts_customer_id_id_customers_id_fk": {
+          "name": "loan_accounts_customer_id_id_customers_id_fk",
+          "tableFrom": "loan_accounts",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.write_off_requests_supporting_documents": {
+      "name": "write_off_requests_supporting_documents",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "write_off_requests_supporting_documents_order_idx": {
+          "name": "write_off_requests_supporting_documents_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_supporting_documents_parent_id_idx": {
+          "name": "write_off_requests_supporting_documents_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_supporting_documents_document_idx": {
+          "name": "write_off_requests_supporting_documents_document_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "write_off_requests_supporting_documents_document_id_media_id_fk": {
+          "name": "write_off_requests_supporting_documents_document_id_media_id_fk",
+          "tableFrom": "write_off_requests_supporting_documents",
+          "tableTo": "media",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "write_off_requests_supporting_documents_parent_id_fk": {
+          "name": "write_off_requests_supporting_documents_parent_id_fk",
+          "tableFrom": "write_off_requests_supporting_documents",
+          "tableTo": "write_off_requests",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.write_off_requests": {
+      "name": "write_off_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_number": {
+          "name": "request_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_balance": {
+          "name": "original_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "enum_write_off_requests_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_write_off_requests_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum_write_off_requests_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "requires_senior_approval": {
+          "name": "requires_senior_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_by_id": {
+          "name": "approval_details_decided_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_by_name": {
+          "name": "approval_details_decided_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_at": {
+          "name": "approval_details_decided_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_comment": {
+          "name": "approval_details_comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by": {
+          "name": "approval_details_approved_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by_name": {
+          "name": "approval_details_approved_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_at": {
+          "name": "approval_details_approved_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by": {
+          "name": "approval_details_rejected_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by_name": {
+          "name": "approval_details_rejected_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_at": {
+          "name": "approval_details_rejected_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_reason": {
+          "name": "approval_details_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by": {
+          "name": "cancellation_details_cancelled_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by_name": {
+          "name": "cancellation_details_cancelled_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_at": {
+          "name": "cancellation_details_cancelled_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "write_off_requests_request_id_idx": {
+          "name": "write_off_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_event_id_idx": {
+          "name": "write_off_requests_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_request_number_idx": {
+          "name": "write_off_requests_request_number_idx",
+          "columns": [
+            {
+              "expression": "request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_loan_account_id_idx": {
+          "name": "write_off_requests_loan_account_id_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_customer_id_idx": {
+          "name": "write_off_requests_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_status_idx": {
+          "name": "write_off_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_requested_by_idx": {
+          "name": "write_off_requests_requested_by_idx",
+          "columns": [
+            {
+              "expression": "requested_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_approval_details_approval_details_dec_idx": {
+          "name": "write_off_requests_approval_details_approval_details_dec_idx",
+          "columns": [
+            {
+              "expression": "approval_details_decided_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_updated_at_idx": {
+          "name": "write_off_requests_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_created_at_idx": {
+          "name": "write_off_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "write_off_requests_requested_by_id_users_id_fk": {
+          "name": "write_off_requests_requested_by_id_users_id_fk",
+          "tableFrom": "write_off_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "write_off_requests_approval_details_decided_by_id_users_id_fk": {
+          "name": "write_off_requests_approval_details_decided_by_id_users_id_fk",
+          "tableFrom": "write_off_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approval_details_decided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_notes": {
+      "name": "contact_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "enum_contact_notes_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "enum_contact_notes_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_direction": {
+          "name": "contact_direction",
+          "type": "enum_contact_notes_contact_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum_contact_notes_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "enum_contact_notes_sentiment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'neutral'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amends_note_id": {
+          "name": "amends_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_contact_notes_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_notes_customer_idx": {
+          "name": "contact_notes_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_loan_account_idx": {
+          "name": "contact_notes_loan_account_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_application_idx": {
+          "name": "contact_notes_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_conversation_idx": {
+          "name": "contact_notes_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_created_by_idx": {
+          "name": "contact_notes_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_amends_note_idx": {
+          "name": "contact_notes_amends_note_idx",
+          "columns": [
+            {
+              "expression": "amends_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_status_idx": {
+          "name": "contact_notes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_created_at_idx": {
+          "name": "contact_notes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_updated_at_idx": {
+          "name": "contact_notes_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_notes_customer_id_customers_id_fk": {
+          "name": "contact_notes_customer_id_customers_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_loan_account_id_loan_accounts_id_fk": {
+          "name": "contact_notes_loan_account_id_loan_accounts_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_application_id_applications_id_fk": {
+          "name": "contact_notes_application_id_applications_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_conversation_id_conversations_id_fk": {
+          "name": "contact_notes_conversation_id_conversations_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_created_by_id_users_id_fk": {
+          "name": "contact_notes_created_by_id_users_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_amends_note_id_contact_notes_id_fk": {
+          "name": "contact_notes_amends_note_id_contact_notes_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "contact_notes",
+          "columnsFrom": [
+            "amends_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_ref_id": {
+          "name": "customer_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_notifications_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "enum_notifications_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_content_hash": {
+          "name": "template_content_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_git_sha": {
+          "name": "template_git_sha",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_hash": {
+          "name": "recipient_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_category": {
+          "name": "tags_category",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_reason": {
+          "name": "tags_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_step": {
+          "name": "tags_step",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_failed_at": {
+          "name": "failure_failed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_error_type": {
+          "name": "failure_error_type",
+          "type": "enum_notifications_failure_error_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_error_message": {
+          "name": "failure_error_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_attempt": {
+          "name": "failure_attempt",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_fallback_suggested": {
+          "name": "failure_fallback_suggested",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_account_id": {
+          "name": "statement_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_start": {
+          "name": "statement_period_start",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_end": {
+          "name": "statement_period_end",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_dispatched_at": {
+          "name": "statement_dispatched_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_mode": {
+          "name": "suppression_mode",
+          "type": "enum_notifications_suppression_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_reason": {
+          "name": "suppression_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_set_by": {
+          "name": "suppression_set_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_set_at": {
+          "name": "suppression_set_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_expires_at": {
+          "name": "suppression_expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_notification_id_idx": {
+          "name": "notifications_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_idempotency_key_idx": {
+          "name": "notifications_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_customer_ref_idx": {
+          "name": "notifications_customer_ref_idx",
+          "columns": [
+            {
+              "expression": "customer_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_customer_id_idx": {
+          "name": "notifications_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_status_idx": {
+          "name": "notifications_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_event_at_idx": {
+          "name": "notifications_event_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_customer_ref_id_customers_id_fk": {
+          "name": "notifications_customer_ref_id_customers_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_cases": {
+      "name": "collection_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_ref_id": {
+          "name": "customer_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum_collection_cases_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardship_paused": {
+          "name": "hardship_paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_contact": {
+          "name": "stopped_contact",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overdue_amount": {
+          "name": "overdue_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_overdue": {
+          "name": "days_overdue",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_step": {
+          "name": "last_step",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cured_at": {
+          "name": "cured_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhausted_at": {
+          "name": "exhausted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_at": {
+          "name": "resumed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_contact_at": {
+          "name": "stop_contact_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_cases_account_id_idx": {
+          "name": "collection_cases_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_customer_ref_idx": {
+          "name": "collection_cases_customer_ref_idx",
+          "columns": [
+            {
+              "expression": "customer_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_customer_id_idx": {
+          "name": "collection_cases_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_state_idx": {
+          "name": "collection_cases_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_hardship_paused_idx": {
+          "name": "collection_cases_hardship_paused_idx",
+          "columns": [
+            {
+              "expression": "hardship_paused",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_stopped_contact_idx": {
+          "name": "collection_cases_stopped_contact_idx",
+          "columns": [
+            {
+              "expression": "stopped_contact",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_opened_at_idx": {
+          "name": "collection_cases_opened_at_idx",
+          "columns": [
+            {
+              "expression": "opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_worklist_idx": {
+          "name": "collection_cases_worklist_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_by_customer_idx": {
+          "name": "collection_cases_by_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_cases_customer_ref_id_customers_id_fk": {
+          "name": "collection_cases_customer_ref_id_customers_id_fk",
+          "tableFrom": "collection_cases",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customers_id": {
+          "name": "customers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applications_id": {
+          "name": "applications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_accounts_id": {
+          "name": "loan_accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_off_requests_id": {
+          "name": "write_off_requests_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_notes_id": {
+          "name": "contact_notes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notifications_id": {
+          "name": "notifications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cases_id": {
+          "name": "collection_cases_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_customers_id_idx": {
+          "name": "payload_locked_documents_rels_customers_id_idx",
+          "columns": [
+            {
+              "expression": "customers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_conversations_id_idx": {
+          "name": "payload_locked_documents_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_applications_id_idx": {
+          "name": "payload_locked_documents_rels_applications_id_idx",
+          "columns": [
+            {
+              "expression": "applications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_loan_accounts_id_idx": {
+          "name": "payload_locked_documents_rels_loan_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "loan_accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_write_off_requests_id_idx": {
+          "name": "payload_locked_documents_rels_write_off_requests_id_idx",
+          "columns": [
+            {
+              "expression": "write_off_requests_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contact_notes_id_idx": {
+          "name": "payload_locked_documents_rels_contact_notes_id_idx",
+          "columns": [
+            {
+              "expression": "contact_notes_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_notifications_id_idx": {
+          "name": "payload_locked_documents_rels_notifications_id_idx",
+          "columns": [
+            {
+              "expression": "notifications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_collection_cases_id_idx": {
+          "name": "payload_locked_documents_rels_collection_cases_id_idx",
+          "columns": [
+            {
+              "expression": "collection_cases_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_customers_fk": {
+          "name": "payload_locked_documents_rels_customers_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_conversations_fk": {
+          "name": "payload_locked_documents_rels_conversations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_applications_fk": {
+          "name": "payload_locked_documents_rels_applications_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "applications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_loan_accounts_fk": {
+          "name": "payload_locked_documents_rels_loan_accounts_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_write_off_requests_fk": {
+          "name": "payload_locked_documents_rels_write_off_requests_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "write_off_requests",
+          "columnsFrom": [
+            "write_off_requests_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contact_notes_fk": {
+          "name": "payload_locked_documents_rels_contact_notes_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contact_notes",
+          "columnsFrom": [
+            "contact_notes_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_notifications_fk": {
+          "name": "payload_locked_documents_rels_notifications_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notifications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_collection_cases_fk": {
+          "name": "payload_locked_documents_rels_collection_cases_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "collection_cases",
+          "columnsFrom": [
+            "collection_cases_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_users_role": {
+      "name": "enum_users_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "supervisor",
+        "operations",
+        "readonly",
+        "service"
+      ]
+    },
+    "public.enum_customers_identity_documents_document_type": {
+      "name": "enum_customers_identity_documents_document_type",
+      "schema": "public",
+      "values": [
+        "DRIVERS_LICENCE",
+        "PASSPORT",
+        "MEDICARE"
+      ]
+    },
+    "public.enum_customers_ekyc_status": {
+      "name": "enum_customers_ekyc_status",
+      "schema": "public",
+      "values": [
+        "successful",
+        "failed",
+        "pending"
+      ]
+    },
+    "public.enum_customers_individual_status": {
+      "name": "enum_customers_individual_status",
+      "schema": "public",
+      "values": [
+        "LIVING",
+        "DECEASED",
+        "MISSING"
+      ]
+    },
+    "public.enum_conversations_status": {
+      "name": "enum_conversations_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "soft_end",
+        "hard_end",
+        "approved",
+        "declined"
+      ]
+    },
+    "public.enum_conversations_decision_status": {
+      "name": "enum_conversations_decision_status",
+      "schema": "public",
+      "values": [
+        "approved",
+        "declined",
+        "referred",
+        "no_decision"
+      ]
+    },
+    "public.enum_app_proc_state_steps_type": {
+      "name": "enum_app_proc_state_steps_type",
+      "schema": "public",
+      "values": [
+        "llm",
+        "business_logic",
+        "user_input"
+      ]
+    },
+    "public.enum_applications_application_process_conversation_role": {
+      "name": "enum_applications_application_process_conversation_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ]
+    },
+    "public.enum_applications_application_outcome": {
+      "name": "enum_applications_application_outcome",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "declined",
+        "withdrawn"
+      ]
+    },
+    "public.enum_loan_accounts_repayment_schedule_payments_status": {
+      "name": "enum_loan_accounts_repayment_schedule_payments_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "paid",
+        "missed",
+        "partial"
+      ]
+    },
+    "public.enum_loan_accounts_aging_bucket": {
+      "name": "enum_loan_accounts_aging_bucket",
+      "schema": "public",
+      "values": [
+        "current",
+        "early_arrears",
+        "late_arrears",
+        "default",
+        "closed"
+      ]
+    },
+    "public.enum_loan_accounts_account_status": {
+      "name": "enum_loan_accounts_account_status",
+      "schema": "public",
+      "values": [
+        "pending_disbursement",
+        "active",
+        "paid_off",
+        "in_arrears",
+        "written_off"
+      ]
+    },
+    "public.enum_loan_accounts_closure_reason": {
+      "name": "enum_loan_accounts_closure_reason",
+      "schema": "public",
+      "values": [
+        "PAID_OFF",
+        "WRITTEN_OFF",
+        "ADMIN_CLOSED"
+      ]
+    },
+    "public.enum_loan_accounts_repayment_schedule_payment_frequency": {
+      "name": "enum_loan_accounts_repayment_schedule_payment_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "fortnightly",
+        "monthly"
+      ]
+    },
+    "public.enum_write_off_requests_reason": {
+      "name": "enum_write_off_requests_reason",
+      "schema": "public",
+      "values": [
+        "hardship",
+        "bankruptcy",
+        "deceased",
+        "unable_to_locate",
+        "fraud_victim",
+        "disputed",
+        "aged_debt",
+        "other"
+      ]
+    },
+    "public.enum_write_off_requests_status": {
+      "name": "enum_write_off_requests_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.enum_write_off_requests_priority": {
+      "name": "enum_write_off_requests_priority",
+      "schema": "public",
+      "values": [
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.enum_contact_notes_channel": {
+      "name": "enum_contact_notes_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "internal",
+        "system"
+      ]
+    },
+    "public.enum_contact_notes_topic": {
+      "name": "enum_contact_notes_topic",
+      "schema": "public",
+      "values": [
+        "general_enquiry",
+        "complaint",
+        "escalation",
+        "internal_note",
+        "account_update",
+        "collections"
+      ]
+    },
+    "public.enum_contact_notes_contact_direction": {
+      "name": "enum_contact_notes_contact_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.enum_contact_notes_priority": {
+      "name": "enum_contact_notes_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.enum_contact_notes_sentiment": {
+      "name": "enum_contact_notes_sentiment",
+      "schema": "public",
+      "values": [
+        "positive",
+        "neutral",
+        "negative",
+        "escalation"
+      ]
+    },
+    "public.enum_contact_notes_status": {
+      "name": "enum_contact_notes_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "amended"
+      ]
+    },
+    "public.enum_notifications_status": {
+      "name": "enum_notifications_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "blocked",
+        "statement",
+        "suppression_change"
+      ]
+    },
+    "public.enum_notifications_channel": {
+      "name": "enum_notifications_channel",
+      "schema": "public",
+      "values": [
+        "email",
+        "sms"
+      ]
+    },
+    "public.enum_notifications_failure_error_type": {
+      "name": "enum_notifications_failure_error_type",
+      "schema": "public",
+      "values": [
+        "transient",
+        "permanent",
+        "auth",
+        "template",
+        "contact_missing",
+        "opt_out",
+        "suppressed"
+      ]
+    },
+    "public.enum_notifications_suppression_mode": {
+      "name": "enum_notifications_suppression_mode",
+      "schema": "public",
+      "values": [
+        "all",
+        "non_essential",
+        "marketing_only",
+        "panic_button",
+        "off"
+      ]
+    },
+    "public.enum_collection_cases_state": {
+      "name": "enum_collection_cases_state",
+      "schema": "public",
+      "values": [
+        "open",
+        "awaiting_human",
+        "cured"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "ce9ace35-c50a-4a04-8739-ddb3c8d572d0",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/src/migrations/20260624_094132.ts
+++ b/src/migrations/20260624_094132.ts
@@ -1,0 +1,53 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   CREATE TYPE "public"."enum_collection_cases_state" AS ENUM('open', 'awaiting_human', 'cured');
+  CREATE TABLE "collection_cases" (
+  	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  	"account_id" varchar NOT NULL,
+  	"customer_ref_id" uuid,
+  	"customer_id" varchar,
+  	"state" "enum_collection_cases_state",
+  	"hardship_paused" boolean,
+  	"stopped_contact" boolean,
+  	"overdue_amount" numeric,
+  	"days_overdue" numeric,
+  	"last_step" numeric,
+  	"due_date" timestamp(3) with time zone,
+  	"opened_at" timestamp(3) with time zone,
+  	"cured_at" timestamp(3) with time zone,
+  	"exhausted_at" timestamp(3) with time zone,
+  	"paused_at" timestamp(3) with time zone,
+  	"resumed_at" timestamp(3) with time zone,
+  	"stop_contact_at" timestamp(3) with time zone,
+  	"correlation_id" varchar,
+  	"created_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+  	"updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  );
+  
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "collection_cases_id" uuid;
+  ALTER TABLE "collection_cases" ADD CONSTRAINT "collection_cases_customer_ref_id_customers_id_fk" FOREIGN KEY ("customer_ref_id") REFERENCES "public"."customers"("id") ON DELETE set null ON UPDATE no action;
+  CREATE UNIQUE INDEX "collection_cases_account_id_idx" ON "collection_cases" USING btree ("account_id");
+  CREATE INDEX "collection_cases_customer_ref_idx" ON "collection_cases" USING btree ("customer_ref_id");
+  CREATE INDEX "collection_cases_customer_id_idx" ON "collection_cases" USING btree ("customer_id");
+  CREATE INDEX "collection_cases_state_idx" ON "collection_cases" USING btree ("state");
+  CREATE INDEX "collection_cases_hardship_paused_idx" ON "collection_cases" USING btree ("hardship_paused");
+  CREATE INDEX "collection_cases_stopped_contact_idx" ON "collection_cases" USING btree ("stopped_contact");
+  CREATE INDEX "collection_cases_opened_at_idx" ON "collection_cases" USING btree ("opened_at");
+  CREATE INDEX "collection_cases_worklist_idx" ON "collection_cases" USING btree ("state","updated_at" desc);
+  CREATE INDEX "collection_cases_by_customer_idx" ON "collection_cases" USING btree ("customer_id","updated_at" desc);
+  ALTER TABLE "payload_locked_documents_rels" ADD CONSTRAINT "payload_locked_documents_rels_collection_cases_fk" FOREIGN KEY ("collection_cases_id") REFERENCES "public"."collection_cases"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "payload_locked_documents_rels_collection_cases_id_idx" ON "payload_locked_documents_rels" USING btree ("collection_cases_id");`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "collection_cases" DISABLE ROW LEVEL SECURITY;
+  DROP TABLE "collection_cases" CASCADE;
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT "payload_locked_documents_rels_collection_cases_fk";
+  
+  DROP INDEX "payload_locked_documents_rels_collection_cases_id_idx";
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN "collection_cases_id";
+  DROP TYPE "public"."enum_collection_cases_state";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -5,6 +5,7 @@ import * as migration_20260610_114936_reapplication_block_identity_verification 
 import * as migration_20260618_065013_reapplication_block_recognition from './20260618_065013_reapplication_block_recognition';
 import * as migration_20260619_011621 from './20260619_011621';
 import * as migration_20260619_061320_payload_385_upgrade from './20260619_061320_payload_385_upgrade';
+import * as migration_20260624_094132 from './20260624_094132';
 
 export const migrations = [
   {
@@ -40,6 +41,11 @@ export const migrations = [
   {
     up: migration_20260619_061320_payload_385_upgrade.up,
     down: migration_20260619_061320_payload_385_upgrade.down,
-    name: '20260619_061320_payload_385_upgrade'
+    name: '20260619_061320_payload_385_upgrade',
+  },
+  {
+    up: migration_20260624_094132.up,
+    down: migration_20260624_094132.down,
+    name: '20260624_094132'
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -76,6 +76,7 @@ export interface Config {
     'write-off-requests': WriteOffRequest;
     'contact-notes': ContactNote;
     notifications: Notification;
+    'collection-cases': CollectionCase;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -92,6 +93,7 @@ export interface Config {
     'write-off-requests': WriteOffRequestsSelect<false> | WriteOffRequestsSelect<true>;
     'contact-notes': ContactNotesSelect<false> | ContactNotesSelect<true>;
     notifications: NotificationsSelect<false> | NotificationsSelect<true>;
+    'collection-cases': CollectionCasesSelect<false> | CollectionCasesSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -1354,6 +1356,50 @@ export interface Notification {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-cases".
+ */
+export interface CollectionCase {
+  id: string;
+  /**
+   * Ledger account_id — one case per advance (natural key)
+   */
+  accountId: string;
+  /**
+   * Resolved customer link (may be null if customer not yet projected)
+   */
+  customerRef?: (string | null) | Customer;
+  /**
+   * Customer ID string from the event (BTB-154 provenance)
+   */
+  customerId?: string | null;
+  /**
+   * Base lifecycle state. Cross-cutting hardship / stop-contact are flags.
+   */
+  state?: ('open' | 'awaiting_human' | 'cured') | null;
+  hardshipPaused?: boolean | null;
+  stoppedContact?: boolean | null;
+  /**
+   * Snapshot from the event; live amount comes from the ledger
+   */
+  overdueAmount?: number | null;
+  daysOverdue?: number | null;
+  /**
+   * Last automated reminder step sent (max 5); set on exhaustion
+   */
+  lastStep?: number | null;
+  dueDate?: string | null;
+  openedAt?: string | null;
+  curedAt?: string | null;
+  exhaustedAt?: string | null;
+  pausedAt?: string | null;
+  resumedAt?: string | null;
+  stopContactAt?: string | null;
+  correlationId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -1411,6 +1457,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'notifications';
         value: string | Notification;
+      } | null)
+    | ({
+        relationTo: 'collection-cases';
+        value: string | CollectionCase;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -1988,6 +2038,31 @@ export interface NotificationsSelect<T extends boolean = true> {
         setAt?: T;
         expiresAt?: T;
       };
+  createdAt?: T;
+  updatedAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "collection-cases_select".
+ */
+export interface CollectionCasesSelect<T extends boolean = true> {
+  accountId?: T;
+  customerRef?: T;
+  customerId?: T;
+  state?: T;
+  hardshipPaused?: T;
+  stoppedContact?: T;
+  overdueAmount?: T;
+  daysOverdue?: T;
+  lastStep?: T;
+  dueDate?: T;
+  openedAt?: T;
+  curedAt?: T;
+  exhaustedAt?: T;
+  pausedAt?: T;
+  resumedAt?: T;
+  stopContactAt?: T;
+  correlationId?: T;
   createdAt?: T;
   updatedAt?: T;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -18,6 +18,7 @@ import { LoanAccounts } from './collections/LoanAccounts'
 import { WriteOffRequests } from './collections/WriteOffRequests'
 import { ContactNotes } from './collections/ContactNotes'
 import { Notifications } from './collections/Notifications'
+import { CollectionsCases } from './collections/CollectionsCases'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -127,7 +128,7 @@ export default buildConfig({
       },
     },
   },
-  collections: [Users, Media, Customers, Conversations, Applications, LoanAccounts, WriteOffRequests, ContactNotes, Notifications],
+  collections: [Users, Media, Customers, Conversations, Applications, LoanAccounts, WriteOffRequests, ContactNotes, Notifications, CollectionsCases],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || 'build-placeholder-not-for-production',
   typescript: {
@@ -182,6 +183,28 @@ export default buildConfig({
               ),
               conversationsByCustomerIdx: index('conversations_by_customer_idx').on(
                 t.customerIdString,
+                desc(t.updatedAt),
+              ),
+            }),
+          })
+        }
+
+        // Compound indexes for the collections worklist grid (BTB-199). Single
+        // `index: true` on the collection can't express these; mirror the
+        // conversations monitor-grid pattern above.
+        const collectionCases = (schema.tables as Record<string, unknown>).collection_cases as
+          | Parameters<typeof extendTable>[0]['table']
+          | undefined
+        if (collectionCases) {
+          extendTable({
+            table: collectionCases,
+            extraConfig: (t) => ({
+              collectionCasesWorklistIdx: index('collection_cases_worklist_idx').on(
+                t.state,
+                desc(t.updatedAt),
+              ),
+              collectionCasesByCustomerIdx: index('collection_cases_by_customer_idx').on(
+                t.customerId,
                 desc(t.updatedAt),
               ),
             }),


### PR DESCRIPTION
Stream D / Collections CRM — **WS1**: consume the six `collection.case.*` events the headless `collectionsService` (BTB-166) emits to ChatLedger and project them into a read-only `collection_cases` table. Consumer-side only.

## What's here
- **Python event-processor:** six handlers (opened/exhausted/cured/hardship_paused/resumed/stop_contact_applied) → idempotent upserts keyed on `account_id`; state events own `state`, flag events never write `state`. Parse routing (type→model, lazy SDK import) + handler registration. `billie-collection-events` added to `requirements.txt`.
- **Payload:** `CollectionsCases` read-only projection + `afterSchemaInit` worklist indexes.
- **Docs:** WS1–WS5 build scope + vendored `collections_service.proto` + consumer-requirements note.

## Tests
- TDD: 13 collection/routing tests green; full event-processor suite **199 passed** (2 pre-existing `test_payload_size.py` failures are unrelated — verified pre-existing).

## ⚠️ Before merge / deploy — not yet in this branch
- [ ] **Payload migration for `collection_cases`** + regenerated `payload-types.ts` (`pnpm generate:types`). dev/demo create the table via `push:true`, but **prod needs the committed migration** (repo rule). Generate locally and add to this PR.
- [ ] **Confirm the `billie-collection-events` git tag** (used `collection-v0.2.0` as a placeholder in `requirements.txt`).

## Dependency — end-to-end is blocked until billieChat routes the events
The CRM handlers are correct but receive **no traffic** until billieChat's `routing/routes.json` forwards `collection.case.*` → `agent_billie-crm` (separate repo/PR). Tracked alongside WS1.

Refs BTB-199 (WS1), BTB-69 (parent), BTB-166 (producer, done), BTB-194 (economics, backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)