### PR TITLE
feat(block-clear): manual block clear — CRM (backend + routes + UI)

### DIFF
--- a/docs/superpowers/plans/2026-06-28-manual-block-clear-crm-backend.md
+++ b/docs/superpowers/plans/2026-06-28-manual-block-clear-crm-backend.md
@@ -1,0 +1,684 @@
+# Manual Block Clear — billie-crm Backend Contract (Plan B1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the billie-crm backend half of the manual block-clear feature: the event contract, a producer that emits the authorised clear onto the shared `chatLedger`, the maker-checker request projection (Postgres + Payload collection + Python lifecycle handlers), and the consumer that projects billieChat's `cleared`/`clear_rejected` outcome back into the CRM.
+
+**Architecture:** Event-sourced, mirroring the existing write-off approval pattern. TS command routes (Plan B2) publish CRM-internal `block_clear_approval.*` lifecycle events to `inbox:billie-servicing:internal`; the Python event-processor projects them into a `reapplication_block_clear_requests` table. On approval (or a single-operator clear), the CRM emits `reapplication_block.clear_authorized.v1` onto the shared `chatLedger`; billieChat applies it and emits `reapplication_block.cleared.v1` / `.clear_rejected.v1`, which the Python processor consumes to NULL the block on `conversations`/`customers` and close out the request row.
+
+**Tech Stack:** Payload CMS 3.85 (Next.js 16), TypeScript, Zod v4, ioredis; Python event-processor (asyncpg, pytest); Postgres (Payload migrations). pnpm + vitest (TS), pytest (Python).
+
+## Global Constraints
+
+- **Binding contract = the billieChat spec** `../../billieChat/docs/superpowers/specs/2026-06-27-reapplication-block-manual-clear-design.md` (§7 event payloads, §12 maker-checker, §13 producer, §14 projection). The billieChat side is merged as PR #110 and is the consumer of `clear_authorized` / producer of `cleared`/`clear_rejected`.
+- **Read/write split:** only the Python event-processor writes projection tables (`conversations`, `customers`, `reapplication_block_clear_requests`). TS publishes events; never write these tables from Payload hooks/routes.
+- **Event types:**
+  - CRM-internal lifecycle (→ `inbox:billie-servicing:internal`): `block_clear_approval.requested.v1`, `.approved.v1`, `.rejected.v1`, `.cancelled.v1`.
+  - billieChat-facing, produced onto `chatLedger`: `reapplication_block.clear_authorized.v1`.
+  - billieChat-facing, consumed from `inbox:billie-servicing`: `reapplication_block.cleared.v1`, `reapplication_block.clear_rejected.v1`.
+- **clear_authorized payload (must match billieChat spec §7.1):** `canonical_customer_id`, `reasons` (array or `"ALL_CLEARABLE"`), `operator_id`, `justification` (non-empty), `request_id`, `requested_at`, and — for default-class reasons — `approval: { approval_request_id, approved_by, approved_by_name, approved_at, comment }`.
+- **Clearable reasons:** `PRIOR_DEFAULT`, `PRIOR_SERIOUS_ARREARS`, `ID_VERIFICATION`, `SERVICEABILITY`, `ACCOUNT_CONDUCT`. **Default-class (need approval):** `PRIOR_DEFAULT`, `PRIOR_SERIOUS_ARREARS`. (PEP / active-loan / identity-conflict are never offered — billieChat rejects them defensively.)
+- **chatLedger envelope:** reuse `eventToStreamFields` shape (`conv/agt/usr/seq/cls/typ/cause/payload`), `agt = "billie-crm"`, `conv = "ops:block-clear:{request_id}"`, `usr = canonical_customer_id`, `cls = "cmd"`. Target stream `chatLedger` (config `CHATLEDGER_STREAM`, default `chatLedger`) on the producer Redis (default = existing `getRedisClient()`; override `CHATLEDGER_REDIS_URL` for the dev two-instance split where chatLedger sits on the persistent Redis).
+- **rejection_code vocabulary (from billieChat, for the consumer):** `MISSING_FIELDS | NOTHING_CLEARABLE | UNKNOWN_CANONICAL | APPROVAL_REQUIRED | SELF_APPROVAL`.
+- Commands: TS tests `pnpm exec vitest run <file> --config ./vitest.config.mts`; Python `cd event-processor && pytest <file>`; Prettier (single quotes, no semicolons, 100 cols); `ruff check .` for Python.
+- This plan is **backend only** — the 4 command routes + single-operator path + companion write-off fix are Plan B2; the UI is Plan B3.
+
+---
+
+### Task 1: Event contract — types, schemas, config (TS)
+
+**Files:**
+- Modify: `src/lib/events/types.ts`, `src/lib/events/schemas.ts`, `src/lib/events/config.ts`
+- Test: `tests/unit/events/blockClear.test.ts`
+
+**Interfaces produced (later tasks/plan B2 consume these):**
+- Payloads: `BlockClearApprovalRequestedPayload`, `BlockClearApprovalApprovedPayload`, `BlockClearApprovalRejectedPayload`, `BlockClearApprovalCancelledPayload`, `ReapplicationBlockClearAuthorizedPayload`.
+- Zod: `BlockClearRequestCommandSchema`, `BlockClearApproveCommandSchema`, `BlockClearRejectCommandSchema`, `BlockClearCancelCommandSchema`.
+- Constants: `EVENT_TYPE_BLOCK_CLEAR_APPROVAL_{REQUESTED,APPROVED,REJECTED,CANCELLED}`, `EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED`, `CLEARABLE_REASONS`, `REASONS_REQUIRING_APPROVAL`, `CHATLEDGER_STREAM`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/events/blockClear.test.ts
+import { describe, it, expect } from 'vitest'
+import {
+  BlockClearRequestCommandSchema,
+  BlockClearApproveCommandSchema,
+} from '@/lib/events/schemas'
+import {
+  CLEARABLE_REASONS,
+  REASONS_REQUIRING_APPROVAL,
+  EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED,
+} from '@/lib/events/config'
+
+describe('block-clear event contract', () => {
+  it('accepts a valid request command', () => {
+    const ok = BlockClearRequestCommandSchema.safeParse({
+      canonicalCustomerId: 'c123',
+      conversationId: 'conv-1',
+      reasons: ['SERVICEABILITY'],
+      justification: 'manual assessment, ticket OPS-1',
+    })
+    expect(ok.success).toBe(true)
+  })
+
+  it('rejects an empty justification', () => {
+    const bad = BlockClearRequestCommandSchema.safeParse({
+      canonicalCustomerId: 'c123',
+      reasons: ['SERVICEABILITY'],
+      justification: '',
+    })
+    expect(bad.success).toBe(false)
+  })
+
+  it('requires a >=10 char comment to approve', () => {
+    expect(
+      BlockClearApproveCommandSchema.safeParse({
+        requestId: 'r1',
+        requestNumber: 'RBC-1',
+        comment: 'too short',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('exposes the clearable + approval-required vocabularies and the authorize type', () => {
+    expect(CLEARABLE_REASONS).toEqual([
+      'PRIOR_DEFAULT',
+      'PRIOR_SERIOUS_ARREARS',
+      'ID_VERIFICATION',
+      'SERVICEABILITY',
+      'ACCOUNT_CONDUCT',
+    ])
+    expect(REASONS_REQUIRING_APPROVAL).toEqual(['PRIOR_DEFAULT', 'PRIOR_SERIOUS_ARREARS'])
+    expect(EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED).toBe(
+      'reapplication_block.clear_authorized.v1',
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run test → fails** — `pnpm exec vitest run tests/unit/events/blockClear.test.ts --config ./vitest.config.mts` (module/exports not found).
+
+- [ ] **Step 3: Add config constants** to `src/lib/events/config.ts`:
+
+```typescript
+export const CHATLEDGER_STREAM = process.env.CHATLEDGER_STREAM ?? 'chatLedger'
+
+export const EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REQUESTED =
+  process.env.EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REQUESTED ?? 'block_clear_approval.requested.v1'
+export const EVENT_TYPE_BLOCK_CLEAR_APPROVAL_APPROVED =
+  process.env.EVENT_TYPE_BLOCK_CLEAR_APPROVAL_APPROVED ?? 'block_clear_approval.approved.v1'
+export const EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REJECTED =
+  process.env.EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REJECTED ?? 'block_clear_approval.rejected.v1'
+export const EVENT_TYPE_BLOCK_CLEAR_APPROVAL_CANCELLED =
+  process.env.EVENT_TYPE_BLOCK_CLEAR_APPROVAL_CANCELLED ?? 'block_clear_approval.cancelled.v1'
+export const EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED =
+  process.env.EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED ??
+  'reapplication_block.clear_authorized.v1'
+
+// Single source of truth for the clear vocabulary (mirrors billieChat enums).
+export const CLEARABLE_REASONS = [
+  'PRIOR_DEFAULT',
+  'PRIOR_SERIOUS_ARREARS',
+  'ID_VERIFICATION',
+  'SERVICEABILITY',
+  'ACCOUNT_CONDUCT',
+] as const
+export const REASONS_REQUIRING_APPROVAL = ['PRIOR_DEFAULT', 'PRIOR_SERIOUS_ARREARS'] as const
+export type ClearableReason = (typeof CLEARABLE_REASONS)[number]
+```
+
+- [ ] **Step 4: Add payload interfaces** to `src/lib/events/types.ts`:
+
+```typescript
+import type { ClearableReason } from './config'
+
+export interface BlockClearApprovalRequestedPayload {
+  canonicalCustomerId: string
+  conversationId?: string
+  reasons: ClearableReason[]
+  justification: string
+  requestedBy: string
+  requestedByName: string
+}
+
+export interface BlockClearApprovalApprovedPayload {
+  requestId: string
+  requestNumber: string
+  comment: string
+  approvedBy: string
+  approvedByName: string
+}
+
+export interface BlockClearApprovalRejectedPayload {
+  requestId: string
+  requestNumber: string
+  reason: string
+  rejectedBy: string
+  rejectedByName: string
+}
+
+export interface BlockClearApprovalCancelledPayload {
+  requestId: string
+  requestNumber: string
+  cancelledBy: string
+  cancelledByName: string
+}
+
+// The authoritative command billieChat consumes off chatLedger (spec §7.1).
+export interface ReapplicationBlockClearAuthorizedPayload {
+  canonical_customer_id: string
+  reasons: ClearableReason[] | 'ALL_CLEARABLE'
+  operator_id: string
+  justification: string
+  request_id: string
+  requested_at: string
+  approval?: {
+    approval_request_id: string
+    approved_by: string
+    approved_by_name: string
+    approved_at: string
+    comment: string
+  }
+}
+```
+
+- [ ] **Step 5: Add Zod command schemas** to `src/lib/events/schemas.ts`:
+
+```typescript
+import { CLEARABLE_REASONS } from '../events/config'
+
+const ClearableReasonSchema = z.enum(CLEARABLE_REASONS)
+
+export const BlockClearRequestCommandSchema = z.object({
+  canonicalCustomerId: z.string().min(1, 'Canonical customer ID is required'),
+  conversationId: z.string().optional(),
+  reasons: z.array(ClearableReasonSchema).min(1, 'At least one reason is required'),
+  justification: z.string().min(1, 'Justification is required'),
+})
+
+export const BlockClearApproveCommandSchema = z.object({
+  requestId: z.string().min(1, 'Request ID is required'),
+  requestNumber: z.string().min(1, 'Request number is required'),
+  comment: z.string().min(10, 'Approval comment must be at least 10 characters'),
+})
+
+export const BlockClearRejectCommandSchema = z.object({
+  requestId: z.string().min(1, 'Request ID is required'),
+  requestNumber: z.string().min(1, 'Request number is required'),
+  reason: z.string().min(10, 'Rejection reason must be at least 10 characters'),
+})
+
+export const BlockClearCancelCommandSchema = z.object({
+  requestId: z.string().min(1, 'Request ID is required'),
+  requestNumber: z.string().min(1, 'Request number is required'),
+})
+```
+
+- [ ] **Step 6: Run test → passes; Prettier; commit**
+
+```bash
+pnpm exec vitest run tests/unit/events/blockClear.test.ts --config ./vitest.config.mts
+pnpm exec prettier --write src/lib/events/*.ts tests/unit/events/blockClear.test.ts
+git add src/lib/events/ tests/unit/events/blockClear.test.ts
+git commit -m "feat(block-clear): event contract — types, schemas, config"
+```
+
+---
+
+### Task 2: chatLedger producer (TS)
+
+**Files:**
+- Create: `src/server/chatledger-publisher.ts`
+- Test: `tests/unit/server/chatledgerPublisher.test.ts`
+
+**Interfaces:**
+- Consumes: `ReapplicationBlockClearAuthorizedPayload` (Task 1), `CHATLEDGER_STREAM`, `EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED`, `CRM_AGENT_ID`.
+- Produces: `publishClearAuthorized(payload: ReapplicationBlockClearAuthorizedPayload): Promise<{ eventId: string }>` — xadds a LedgerMessage to `chatLedger`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/server/chatledgerPublisher.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const xadd = vi.fn().mockResolvedValue('1-0')
+vi.mock('@/server/redis-client', () => ({
+  getChatLedgerRedisClient: () => ({ xadd }),
+}))
+
+import { publishClearAuthorized } from '@/server/chatledger-publisher'
+
+beforeEach(() => xadd.mockClear())
+
+describe('publishClearAuthorized', () => {
+  it('xadds a chatLedger LedgerMessage with agt=billie-crm and the ops conv', async () => {
+    const res = await publishClearAuthorized({
+      canonical_customer_id: 'c123',
+      reasons: ['SERVICEABILITY'],
+      operator_id: 'ops-1',
+      justification: 'manual assessment',
+      request_id: 'req-1',
+      requested_at: '2026-06-28T00:00:00.000Z',
+    })
+    expect(res.eventId).toBeTruthy()
+    expect(xadd).toHaveBeenCalledTimes(1)
+    const [stream, star, ...flat] = xadd.mock.calls[0]
+    expect(stream).toBe('chatLedger')
+    expect(star).toBe('*')
+    const fields = Object.fromEntries(
+      flat.reduce((acc: string[][], v: string, i: number) => {
+        if (i % 2 === 0) acc.push([v, flat[i + 1]])
+        return acc
+      }, []),
+    )
+    expect(fields.agt).toBe('billie-crm')
+    expect(fields.typ).toBe('reapplication_block.clear_authorized.v1')
+    expect(fields.conv).toBe('ops:block-clear:req-1')
+    expect(fields.usr).toBe('c123')
+    expect(fields.cls).toBe('cmd')
+    expect(JSON.parse(fields.payload).request_id).toBe('req-1')
+  })
+})
+```
+
+- [ ] **Step 2: Run test → fails** (module not found).
+
+- [ ] **Step 3: Add a chatLedger Redis accessor** to `src/server/redis-client.ts` (a second lazily-created client, defaulting to the same `REDIS_URL` so docker/prod reuse it, with a `CHATLEDGER_REDIS_URL` override for the dev split):
+
+```typescript
+let chatLedgerClient: Redis | null = null
+
+export function getChatLedgerRedisClient(): Redis {
+  if (!chatLedgerClient) {
+    const url = process.env.CHATLEDGER_REDIS_URL ?? REDIS_URL
+    chatLedgerClient = new Redis(url, {
+      retryStrategy: (times) => Math.min(times * 100, 30000),
+      maxRetriesPerRequest: 3,
+      connectTimeout: 10000,
+      keepAlive: 10000,
+      enableOfflineQueue: false,
+      lazyConnect: true,
+    })
+    chatLedgerClient.on('error', (e) => console.error('[ChatLedger Redis] error:', e.message))
+  }
+  return chatLedgerClient
+}
+```
+
+- [ ] **Step 4: Implement the producer** `src/server/chatledger-publisher.ts`:
+
+```typescript
+import { nanoid } from 'nanoid'
+import { getChatLedgerRedisClient } from './redis-client'
+import { CHATLEDGER_STREAM, CRM_AGENT_ID, EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED } from '@/lib/events/config'
+import type { ReapplicationBlockClearAuthorizedPayload } from '@/lib/events/types'
+
+// Mirrors billieChat's LedgerMessage envelope on the shared chatLedger stream so
+// its Broker routes the command (agt=billie-crm) to the reapplicationBlock service.
+export async function publishClearAuthorized(
+  payload: ReapplicationBlockClearAuthorizedPayload,
+): Promise<{ eventId: string }> {
+  const eventId = nanoid()
+  const fields: Record<string, string> = {
+    conv: `ops:block-clear:${payload.request_id}`,
+    agt: CRM_AGENT_ID,
+    usr: payload.canonical_customer_id,
+    seq: '1',
+    cls: 'cmd',
+    typ: EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED,
+    cause: eventId,
+    payload: JSON.stringify(payload),
+  }
+  const redis = getChatLedgerRedisClient()
+  await redis.xadd(CHATLEDGER_STREAM, '*', ...Object.entries(fields).flat())
+  return { eventId }
+}
+```
+
+- [ ] **Step 5: Run test → passes; Prettier; commit**
+
+```bash
+pnpm exec vitest run tests/unit/server/chatledgerPublisher.test.ts --config ./vitest.config.mts
+pnpm exec prettier --write src/server/chatledger-publisher.ts src/server/redis-client.ts tests/unit/server/chatledgerPublisher.test.ts
+git add src/server/chatledger-publisher.ts src/server/redis-client.ts tests/unit/server/chatledgerPublisher.test.ts
+git commit -m "feat(block-clear): chatLedger producer for clear_authorized"
+```
+
+---
+
+### Task 3: Postgres migration — requests table + clear columns
+
+**Files:**
+- Create: `src/migrations/<timestamp>_reapplication_block_clear_requests.ts` (generate via `make -C infra/fly pg-migrate-create ENV=dev NAME=reapplication_block_clear_requests`, then edit)
+- Modify: `src/migrations/index.ts` (register)
+
+**Interfaces:** table `reapplication_block_clear_requests` (natural key `request_id`); new columns on `conversations` (`reapplication_block_clear_status`, `_cleared_at`, `_cleared_by`, `_clear_justification`, `_clear_request_id`) and `customers` (`reapplication_block_clear_status`, `_cleared_at`).
+
+- [ ] **Step 1: Generate the migration file** with the make target above; it scaffolds `up`/`down` with `MigrateUpArgs`/`MigrateDownArgs`.
+
+- [ ] **Step 2: Write `up`** (mirror `20260515_061818.ts` structure):
+
+```typescript
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    CREATE TYPE "public"."enum_reapplication_block_clear_requests_status" AS ENUM('pending', 'approved', 'rejected', 'cancelled');
+    CREATE TABLE "reapplication_block_clear_requests" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+      "request_id" varchar NOT NULL,
+      "event_id" varchar,
+      "request_number" varchar,
+      "canonical_customer_id" varchar NOT NULL,
+      "conversation_id" varchar,
+      "customer_name" varchar,
+      "reasons" jsonb,
+      "justification" varchar,
+      "status" "enum_reapplication_block_clear_requests_status" DEFAULT 'pending' NOT NULL,
+      "requested_by_id" uuid,
+      "requested_by_name" varchar,
+      "requested_at" timestamp(3) with time zone,
+      "approval_details_approved_by" varchar,
+      "approval_details_approved_by_name" varchar,
+      "approval_details_approved_at" timestamp(3) with time zone,
+      "approval_details_comment" varchar,
+      "approval_details_rejected_by" varchar,
+      "approval_details_rejected_by_name" varchar,
+      "approval_details_reason" varchar,
+      "approval_details_rejected_at" timestamp(3) with time zone,
+      "cancellation_details_cancelled_by" varchar,
+      "cancellation_details_cancelled_by_name" varchar,
+      "cancellation_details_cancelled_at" timestamp(3) with time zone,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+    );
+    CREATE UNIQUE INDEX "rbcr_request_id_idx" ON "reapplication_block_clear_requests" ("request_id");
+    CREATE INDEX "rbcr_status_created_idx" ON "reapplication_block_clear_requests" ("status","created_at");
+    ALTER TABLE "reapplication_block_clear_requests" ADD CONSTRAINT "rbcr_requested_by_fk" FOREIGN KEY ("requested_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+
+    ALTER TABLE "conversations" ADD COLUMN "reapplication_block_clear_status" varchar;
+    ALTER TABLE "conversations" ADD COLUMN "reapplication_block_cleared_at" timestamp(3) with time zone;
+    ALTER TABLE "conversations" ADD COLUMN "reapplication_block_cleared_by" varchar;
+    ALTER TABLE "conversations" ADD COLUMN "reapplication_block_clear_justification" varchar;
+    ALTER TABLE "conversations" ADD COLUMN "reapplication_block_clear_request_id" varchar;
+    ALTER TABLE "customers" ADD COLUMN "reapplication_block_clear_status" varchar;
+    ALTER TABLE "customers" ADD COLUMN "reapplication_block_cleared_at" timestamp(3) with time zone;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DROP TABLE "reapplication_block_clear_requests" CASCADE;
+    DROP TYPE "public"."enum_reapplication_block_clear_requests_status";
+    ALTER TABLE "conversations" DROP COLUMN "reapplication_block_clear_status";
+    ALTER TABLE "conversations" DROP COLUMN "reapplication_block_cleared_at";
+    ALTER TABLE "conversations" DROP COLUMN "reapplication_block_cleared_by";
+    ALTER TABLE "conversations" DROP COLUMN "reapplication_block_clear_justification";
+    ALTER TABLE "conversations" DROP COLUMN "reapplication_block_clear_request_id";
+    ALTER TABLE "customers" DROP COLUMN "reapplication_block_clear_status";
+    ALTER TABLE "customers" DROP COLUMN "reapplication_block_cleared_at";
+  `)
+}
+```
+
+- [ ] **Step 3: Register in `src/migrations/index.ts`** — add the import + an entry in the `migrations` array (matching the existing pattern, in timestamp order).
+
+- [ ] **Step 4: Verify** — `pnpm typecheck` passes and the migration imports resolve. (Schema is applied to dev/test via Payload `push:true`; the migration is for demo/prod deploy. The collection in Task 4 is what `push:true` syncs for tests.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/migrations/
+git commit -m "feat(block-clear): migration — clear requests table + conversation/customer clear columns"
+```
+
+---
+
+### Task 4: Payload collection + projection columns
+
+**Files:**
+- Create: `src/collections/ReapplicationBlockClearRequests.ts`
+- Modify: `src/payload.config.ts` (register collection), `src/collections/Conversations.ts` + `src/collections/Customers.ts` (add the clear fields to the `reapplicationBlock` group so `push:true` and types match the migration)
+- Then: `pnpm generate:types`
+- Test: `tests/int/collections/reapplicationBlockClearRequests.int.spec.ts`
+
+**Interfaces:** collection slug `reapplication-block-clear-requests` (read via `canRead`, create via `canCreate`, update via `canUpdate`, delete via `canDelete` — same helpers as `WriteOffRequests`). The Python processor is the real writer.
+
+- [ ] **Step 1: Write the failing integration test** (uses the testcontainer Postgres from `globalSetup`):
+
+```typescript
+// tests/int/collections/reapplicationBlockClearRequests.int.spec.ts
+import { describe, it, expect, beforeAll } from 'vitest'
+import { getPayload, type Payload } from 'payload'
+import config from '@payload-config'
+
+let payload: Payload
+beforeAll(async () => {
+  payload = await getPayload({ config })
+})
+
+describe('reapplication-block-clear-requests collection', () => {
+  it('round-trips a request row with status + reasons', async () => {
+    const created = await payload.create({
+      collection: 'reapplication-block-clear-requests',
+      data: {
+        requestId: 'req-int-1',
+        canonicalCustomerId: 'c-int-1',
+        reasons: ['SERVICEABILITY'],
+        justification: 'int test',
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+    expect(created.requestNumber).toMatch(/^RBC-/)
+    const found = await payload.find({
+      collection: 'reapplication-block-clear-requests',
+      where: { requestId: { equals: 'req-int-1' } },
+      overrideAccess: true,
+    })
+    expect(found.docs[0].status).toBe('pending')
+  })
+})
+```
+
+- [ ] **Step 2: Run test → fails** — `pnpm exec vitest run tests/int/collections/reapplicationBlockClearRequests.int.spec.ts --config ./vitest.config.mts` (unknown collection).
+
+- [ ] **Step 3: Create the collection** `src/collections/ReapplicationBlockClearRequests.ts` (mirror `WriteOffRequests.ts`; `useAsTitle: 'requestNumber'`, group `'Servicing'`, `hidden: hideFromNonAdmins`, access `{ read: canRead, create: canCreate, update: canUpdate, delete: canDelete }`, a `beforeChange` that stamps `RBC-{ts}-{rand}` on create). Fields: `requestId` (unique, index), `eventId`, `requestNumber` (readOnly, index), `canonicalCustomerId` (index), `conversationId`, `customerName`, `reasons` (`type: 'json'`), `justification` (textarea), `status` (select pending/approved/rejected/cancelled, index), `requestedBy` (relationship→users), `requestedByName`, `approvalDetails` (group: approvedBy/approvedByName/approvedAt/comment/rejectedBy/rejectedByName/reason/rejectedAt — conditional on status approved|rejected), `cancellationDetails` (group: cancelledBy/cancelledByName/cancelledAt — conditional on status cancelled); `timestamps: true`. Use the verbatim `WriteOffRequests` shape with the loan-specific fields swapped for `canonicalCustomerId`/`reasons`/`justification`.
+
+- [ ] **Step 4: Register** in `src/payload.config.ts` — import `ReapplicationBlockClearRequests` and add it to the `collections: [...]` array (next to `WriteOffRequests`).
+
+- [ ] **Step 5: Add the clear columns to the projection collections** — in `Conversations.ts` and `Customers.ts`, extend the `reapplicationBlock` group with the fields matching Task 3's migration (`clearStatus`, `clearedAt`, `clearedBy`, `clearJustification`, `clearRequestId` on conversations; `clearStatus`, `clearedAt` on customers). Field names flatten to the migration's snake_case columns.
+
+- [ ] **Step 6: Regenerate types + run test → passes**
+
+```bash
+pnpm generate:types
+pnpm exec vitest run tests/int/collections/reapplicationBlockClearRequests.int.spec.ts --config ./vitest.config.mts
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/collections/ src/payload.config.ts src/payload-types.ts tests/int/collections/reapplicationBlockClearRequests.int.spec.ts
+git commit -m "feat(block-clear): clear-requests collection + projection columns"
+```
+
+---
+
+### Task 5: Python lifecycle handlers (approval projection)
+
+**Files:**
+- Create: `event-processor/src/billie_servicing/handlers/block_clear_approval.py`
+- Modify: `event-processor/src/billie_servicing/main.py` (register 4 handlers)
+- Test: `event-processor/tests/test_block_clear_approval_handlers.py`
+
+**Interfaces:** `handle_block_clear_approval_{requested,approved,rejected,cancelled}(pool, parsed_event)` writing `reapplication_block_clear_requests` via `upsert`/`update_by_key`.
+
+- [ ] **Step 1: Write the failing tests** (mirror `test_writeoff_handlers.py`, using the `mock_pool` fixture):
+
+```python
+# event-processor/tests/test_block_clear_approval_handlers.py
+import pytest
+from billie_servicing.handlers.block_clear_approval import (
+    handle_block_clear_approval_requested,
+    handle_block_clear_approval_approved,
+)
+
+
+@pytest.mark.asyncio
+async def test_requested_creates_pending_row(mock_pool):
+    event = {
+        "conv": "req-1",
+        "cause": "evt-1",
+        "typ": "block_clear_approval.requested.v1",
+        "payload": {
+            "canonicalCustomerId": "c1",
+            "conversationId": "conv-1",
+            "reasons": ["PRIOR_DEFAULT"],
+            "justification": "manual assessment",
+            "requestedByName": "Jane Ops",
+        },
+    }
+    await handle_block_clear_approval_requested(mock_pool, event)
+    doc = mock_pool.last_insert("reapplication_block_clear_requests")
+    assert doc["request_id"] == "req-1"
+    assert doc["canonical_customer_id"] == "c1"
+    assert doc["status"] == "pending"
+    assert doc["request_number"].startswith("RBC-")
+    assert mock_pool.calls_against("reapplication_block_clear_requests")[0].conflict_columns == [
+        "request_id"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_approved_flips_status(mock_pool):
+    event = {
+        "conv": "req-1",
+        "cause": "evt-2",
+        "typ": "block_clear_approval.approved.v1",
+        "payload": {"approvedBy": "boss-1", "approvedByName": "Sam Sup", "comment": "ok"},
+    }
+    await handle_block_clear_approval_approved(mock_pool, event)
+    doc = mock_pool.last_update("reapplication_block_clear_requests")
+    assert doc["status"] == "approved"
+    assert doc["approval_details_approved_by"] == "boss-1"
+```
+
+- [ ] **Step 2: Run → fails** — `cd event-processor && pytest tests/test_block_clear_approval_handlers.py` (module missing).
+
+- [ ] **Step 3: Implement the handlers** (copy `writeoff.py`'s structure: `_parse_payload`, `safe_str`, `_generate_request_number` → `RBC-` prefix, `upsert(..., do_nothing_on_conflict=True)` for requested, `update_by_key(...)` for approved/rejected/cancelled). `requested` writes `request_id`, `event_id`, `request_number`, `canonical_customer_id`, `conversation_id`, `reasons` (JSON-encode the list), `justification`, `status='pending'`, `requested_by_name`, timestamps. approved/rejected/cancelled mirror `handle_writeoff_{approved,rejected,cancelled}` with the same `approval_details_*` / `cancellation_details_*` columns.
+
+- [ ] **Step 4: Register** in `main.py` (next to the writeoff registrations):
+
+```python
+processor.register_handler("block_clear_approval.requested.v1", handle_block_clear_approval_requested)
+processor.register_handler("block_clear_approval.approved.v1", handle_block_clear_approval_approved)
+processor.register_handler("block_clear_approval.rejected.v1", handle_block_clear_approval_rejected)
+processor.register_handler("block_clear_approval.cancelled.v1", handle_block_clear_approval_cancelled)
+```
+
+- [ ] **Step 5: Run → passes; `ruff check .`; commit**
+
+```bash
+cd event-processor && pytest tests/test_block_clear_approval_handlers.py -q && ruff check src/billie_servicing/handlers/block_clear_approval.py
+cd .. && git add event-processor/src/billie_servicing/handlers/block_clear_approval.py event-processor/src/billie_servicing/main.py event-processor/tests/test_block_clear_approval_handlers.py
+git commit -m "feat(block-clear): python approval-lifecycle handlers"
+```
+
+---
+
+### Task 6: Python projection — consume billieChat's cleared / clear_rejected
+
+**Files:**
+- Modify: `event-processor/src/billie_servicing/handlers/reapplication.py` (add 2 handlers), `event-processor/src/billie_servicing/main.py` (register)
+- Test: `event-processor/tests/test_block_clear_projection.py`
+
+**Interfaces:** `handle_reapplication_block_cleared(pool, event)` and `handle_reapplication_block_clear_rejected(pool, event)`. On cleared: NULL the conversation/customer block reason, stamp clear audit, and flip the request row to `approved`/applied. On rejected: stamp `clear_status` + the rejection_code.
+
+- [ ] **Step 1: Write the failing tests** (mirror `test_reapplication_and_identity_verification.py`):
+
+```python
+# event-processor/tests/test_block_clear_projection.py
+import pytest
+from billie_servicing.handlers.reapplication import (
+    handle_reapplication_block_cleared,
+    handle_reapplication_block_clear_rejected,
+)
+
+
+@pytest.mark.asyncio
+async def test_cleared_nulls_block_and_stamps_audit(mock_pool):
+    event = {
+        "typ": "reapplication_block.cleared.v1",
+        "usr": "c1",
+        "payload": {
+            "canonical_customer_id": "c1",
+            "request_id": "req-1",
+            "cleared_reasons": ["SERVICEABILITY"],
+            "cleared_at": "2026-06-28T01:00:00+00:00",
+            "operator_id": "ops-1",
+            "justification": "manual assessment",
+            "prior_block_reason": "SERVICEABILITY",
+        },
+    }
+    await handle_reapplication_block_cleared(mock_pool, event)
+    cust = mock_pool.last_upsert("customers")
+    assert cust["reapplication_block_reason"] is None
+    assert cust["reapplication_block_clear_status"] == "cleared"
+    req = mock_pool.last_update("reapplication_block_clear_requests")
+    assert req["status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_rejected_stamps_clear_status(mock_pool):
+    event = {
+        "typ": "reapplication_block.clear_rejected.v1",
+        "usr": "c1",
+        "payload": {
+            "canonical_customer_id": "c1",
+            "request_id": "req-1",
+            "rejection_code": "APPROVAL_REQUIRED",
+            "detail": "needs approval",
+        },
+    }
+    await handle_reapplication_block_clear_rejected(mock_pool, event)
+    req = mock_pool.last_update("reapplication_block_clear_requests")
+    assert req["reapplication_block_clear_status"] == "rejected" or req["status"] == "rejected"
+```
+
+- [ ] **Step 2: Run → fails** — `cd event-processor && pytest tests/test_block_clear_projection.py`.
+
+- [ ] **Step 3: Implement the two handlers** in `reapplication.py` (reuse `parse_payload`, `safe_str`, `resolve_canonical_customer_id`, `upsert`, `upsert_conversation`, `update_by_key`, `coerce_date`):
+  - `handle_reapplication_block_cleared`: resolve canonical; `upsert("customers", conflict=["customer_id"], { reapplication_block_reason: None, reapplication_block_clear_status: "cleared", reapplication_block_cleared_at: coerce_date(payload["cleared_at"]), updated_at })`; mirror onto the blocked `conversations` row(s) for the canonical (`upsert_conversation` keyed by `conversation_id` if present, else update by `reapplication_block_canonical_customer_id`); `update_by_key("reapplication_block_clear_requests", key_column="request_id", key_value=request_id, values={ status: "approved", updated_at })` so the queue shows it applied. NULLing the block reason is the load-bearing effect (CRM stops showing the customer as blocked) — but only when at least one reason cleared; if `prior_block_reason` is still a non-cleared higher-precedence reason, leave the block reason but stamp the clear audit (per spec §14).
+  - `handle_reapplication_block_clear_rejected`: `update_by_key("reapplication_block_clear_requests", request_id, { status: "rejected", approval_details_reason: payload["detail"], updated_at })` and stamp `reapplication_block_clear_status="rejected"` on the conversation/customer so the operator sees why.
+
+- [ ] **Step 4: Register** in `main.py`:
+
+```python
+processor.register_handler("reapplication_block.cleared.v1", handle_reapplication_block_cleared)
+processor.register_handler("reapplication_block.clear_rejected.v1", handle_reapplication_block_clear_rejected)
+```
+
+(`reapplication_block.*` falls through `_parse_event`'s prefix checks to the `else` → `sanitize_envelope` dict path — handlers receive a dict payload. Confirm no earlier prefix branch captures it.)
+
+- [ ] **Step 5: Run → passes; `ruff check .`; commit**
+
+```bash
+cd event-processor && pytest tests/test_block_clear_projection.py -q && ruff check src/billie_servicing/handlers/reapplication.py
+cd .. && git add event-processor/src/billie_servicing/handlers/reapplication.py event-processor/src/billie_servicing/main.py event-processor/tests/test_block_clear_projection.py
+git commit -m "feat(block-clear): project cleared/clear_rejected back into CRM"
+```
+
+---
+
+## Out of scope (Plan B2 / B3)
+
+- **B2:** the 4 TS command routes `/api/commands/reapp-block-clear/{request,approve,reject,cancel}` (request publishes `block_clear_approval.requested` for default-class reasons, OR calls `publishClearAuthorized` directly for single-operator windowed-decline clears; approve calls `publishClearAuthorized` with the approval attestation **and** enforces server-side maker≠checker `requestedBy !== approverId`), plus the **companion fix** adding the same server-side guard to `src/app/api/commands/writeoff/approve/route.ts`.
+- **B3:** the "Clear block" action on the blocked customer/conversation view, the ApprovalsView extension (block-clear queue + detail drawer with the self-approval-disabled Approve button), and the React Query hooks.
+
+## Self-Review
+
+- **Spec coverage:** §7 contract → Tasks 1, 6; §13 producer → Task 2; §12 maker-checker projection storage → Tasks 3–5; §14 confirmation projection → Task 6. The maker-checker *enforcement* and producer *invocation* are B2 (noted out-of-scope).
+- **Type consistency:** `publishClearAuthorized` (Task 2) consumes `ReapplicationBlockClearAuthorizedPayload` (Task 1). Python handlers (Tasks 5–6) key on `request_id = conv` / `event_id = cause` per the verbatim write-off pattern. Migration columns (Task 3) match the collection fields (Task 4) and the handler writes (Tasks 5–6).
+- **Placeholder scan:** event/schema/producer/migration/handler code is concrete; the collection (Task 4 Step 3) references the verbatim `WriteOffRequests` shape with named field swaps rather than re-transcribing all 300 lines — acceptable as it names every field and the source file.

--- a/docs/superpowers/plans/2026-06-28-manual-block-clear-crm-routes.md
+++ b/docs/superpowers/plans/2026-06-28-manual-block-clear-crm-routes.md
@@ -1,0 +1,291 @@
+# Manual Block Clear — billie-crm Command Routes (Plan B2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** The operator-facing command routes for manual block clear: raise a clear (single-operator for windowed declines, maker-checker for default-class), approve/reject (with **server-side maker≠checker**), and cancel — plus the companion server-side maker≠checker fix on the existing write-off approve route.
+
+**Architecture:** Mirrors the existing write-off command routes (`src/app/api/commands/writeoff/*`). Routes publish events (B1's contract): the maker-checker path publishes `block_clear_approval.*` internal lifecycle events (B1 Python handlers project them); the approve route (and the single-operator request path) emit the authoritative `reapplication_block.clear_authorized.v1` onto the shared chatLedger via B1's `publishClearAuthorized`.
+
+**Tech Stack:** Next.js route handlers, Payload auth, Zod, vitest. Builds on Plan B1 (PR #34, same branch `feat/manual-block-clear-crm`).
+
+## Global Constraints
+
+- Mirror `src/app/api/commands/writeoff/{request,approve,reject,cancel}/route.ts` for the try/catch + error-response boilerplate (`VALIDATION_ERROR` 400, `EventPublishError`→503, `INTERNAL_ERROR` 500, 202 on success). Read those files; copy their structure; only the auth/role checks, the parsed schema, and the published event(s) differ.
+- Auth: `request`/`cancel` use `requireAuth(canService)` (`src/lib/auth.ts`); `approve`/`reject` use `getPayload({config})` + `payload.auth({headers})` + `hasApprovalAuthority(user)` (`src/lib/access.ts`).
+- **Reason tiering (B1 `config.ts`):** `REASONS_REQUIRING_APPROVAL = ['PRIOR_DEFAULT','PRIOR_SERIOUS_ARREARS']`. A request whose `reasons` includes ANY of these goes through maker-checker; otherwise it is a single-operator immediate clear (bundling rule, billieChat spec §6).
+- **Server-side maker≠checker** is mandatory on the approve route: `String(requestDoc.requestedBy) !== String(user.id)`, else 403 `SELF_APPROVAL`.
+- The authoritative clear uses B1's `publishClearAuthorized(payload)` (`src/server/chatledger-publisher.ts`) with `operator_id` = the MAKER (requester) and, for default-class, an `approval` attestation whose `approved_by` = the checker (≠ operator_id). `request_id` correlates the approval-request row to billieChat's `cleared`/`clear_rejected` (which the B1 Python handler projects back).
+- Internal lifecycle events via B1's `createAndPublishEvent({typ, userId, payload, requestId})` (`src/server/event-publisher.ts`), types `EVENT_TYPE_BLOCK_CLEAR_APPROVAL_{REQUESTED,APPROVED,REJECTED,CANCELLED}` (B1 `config.ts`).
+- Tests: vitest. Model on an existing route/handler test if one exists; otherwise mock `@/server/chatledger-publisher` (`publishClearAuthorized`), `@/server/event-publisher` (`createAndPublishEvent`), and Payload auth/find (`getPayload`/`payload.auth`/`payload.find` or `requireAuth`) and call the route's exported `POST(req)` directly, asserting status + the published event payload. Prettier (single quotes, no semicolons, 100 cols).
+- This is Plan B2. The UI is Plan B3.
+
+---
+
+### Task 1: `request` + `cancel` routes
+
+**Files:**
+- Create: `src/app/api/commands/reapp-block-clear/request/route.ts`, `src/app/api/commands/reapp-block-clear/cancel/route.ts`
+- Modify: `src/lib/events/schemas.ts` (add `customerName: z.string().optional()` to `BlockClearRequestCommandSchema`)
+- Test: `tests/unit/routes/reappBlockClearRequest.test.ts`, `tests/unit/routes/reappBlockClearCancel.test.ts`
+
+**Interfaces produced:** `POST /api/commands/reapp-block-clear/request`, `POST /api/commands/reapp-block-clear/cancel`.
+
+- [ ] **Step 1: Write failing tests** for the request route covering: (a) a single-operator request (`reasons:['SERVICEABILITY']`) calls `publishClearAuthorized` with `operator_id=user.id`, `reasons`, `justification`, a generated `request_id`, and NO `approval`; returns 202; (b) a default-class request (`reasons:['PRIOR_DEFAULT']`) calls `createAndPublishEvent` with `typ=block_clear_approval.requested.v1` and does NOT call `publishClearAuthorized`; returns 202; (c) invalid body → 400. Mock `@/server/chatledger-publisher`, `@/server/event-publisher`, and `requireAuth` (return `{ user: { id: 'ops-1', firstName: 'Op', role: 'operations' } }`). Run: `cd /Users/rohansharp/workspace/billie-crm && pnpm exec vitest run tests/unit/routes/reappBlockClearRequest.test.ts --config ./vitest.config.mts` → RED.
+
+- [ ] **Step 2: Implement `request/route.ts`** (mirror `writeoff/request/route.ts` boilerplate):
+
+```typescript
+import { type NextRequest, NextResponse } from 'next/server'
+import { nanoid } from 'nanoid'
+import { requireAuth } from '@/lib/auth'
+import { canService } from '@/lib/access'
+import { BlockClearRequestCommandSchema } from '@/lib/events/schemas'
+import { createAndPublishEvent, EventPublishError } from '@/server/event-publisher'
+import { publishClearAuthorized } from '@/server/chatledger-publisher'
+import {
+  EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REQUESTED,
+  REASONS_REQUIRING_APPROVAL,
+} from '@/lib/events/config'
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await requireAuth(canService)
+    if ('error' in auth) return auth.error
+    const { user } = auth
+
+    const parsed = BlockClearRequestCommandSchema.safeParse(await request.json())
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: { code: 'VALIDATION_ERROR', message: 'Invalid request body', details: parsed.error.flatten().fieldErrors } },
+        { status: 400 },
+      )
+    }
+    const cmd = parsed.data
+    const operatorName = user.firstName
+      ? `${user.firstName}${user.lastName ? ` ${user.lastName}` : ''}`
+      : user.email || 'Unknown User'
+    const needsApproval = cmd.reasons.some((r) => (REASONS_REQUIRING_APPROVAL as readonly string[]).includes(r))
+
+    if (needsApproval) {
+      // Maker-checker: raise an approval request; the Python processor creates the pending row.
+      const result = await createAndPublishEvent({
+        typ: EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REQUESTED,
+        userId: String(user.id),
+        payload: {
+          canonicalCustomerId: cmd.canonicalCustomerId,
+          conversationId: cmd.conversationId,
+          customerName: cmd.customerName ?? '',
+          reasons: cmd.reasons,
+          justification: cmd.justification,
+          requestedBy: String(user.id),
+          requestedByName: operatorName,
+        },
+      })
+      return NextResponse.json(result, { status: 202 })
+    }
+
+    // Single-operator (windowed declines only): emit the authoritative clear directly.
+    const requestId = nanoid()
+    const { eventId } = await publishClearAuthorized({
+      canonical_customer_id: cmd.canonicalCustomerId,
+      reasons: cmd.reasons,
+      operator_id: String(user.id),
+      justification: cmd.justification,
+      request_id: requestId,
+      requested_at: new Date().toISOString(),
+    })
+    return NextResponse.json(
+      { eventId, requestId, status: 'accepted', message: 'Block clear submitted' },
+      { status: 202 },
+    )
+  } catch (error) {
+    if (error instanceof EventPublishError) {
+      return NextResponse.json(
+        { error: { code: 'EVENT_PUBLISH_FAILED', message: 'Failed to submit block clear. Please try again.' } },
+        { status: 503 },
+      )
+    }
+    console.error('[BlockClear Request] Error:', error)
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'An unexpected error occurred.' } },
+      { status: 500 },
+    )
+  }
+}
+```
+
+Add `customerName: z.string().optional()` to `BlockClearRequestCommandSchema` in `src/lib/events/schemas.ts`.
+
+- [ ] **Step 3: Implement `cancel/route.ts`** — mirror `writeoff/cancel/route.ts` exactly (requireAuth(canService); look up the request in `reapplication-block-clear-requests` by `requestId`; allow original `requestedBy` or `hasApprovalAuthority`; publish `EVENT_TYPE_BLOCK_CLEAR_APPROVAL_CANCELLED` with `BlockClearApprovalCancelledPayload`). Use `BlockClearCancelCommandSchema`.
+
+- [ ] **Step 4: Tests green** for both routes; Prettier; commit:
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm && pnpm exec vitest run tests/unit/routes/reappBlockClearRequest.test.ts tests/unit/routes/reappBlockClearCancel.test.ts --config ./vitest.config.mts
+pnpm exec prettier --write src/app/api/commands/reapp-block-clear src/lib/events/schemas.ts tests/unit/routes/reappBlockClear*.test.ts
+git add src/app/api/commands/reapp-block-clear/request src/app/api/commands/reapp-block-clear/cancel src/lib/events/schemas.ts tests/unit/routes/reappBlockClear*.test.ts
+git commit -m "feat(block-clear): request + cancel command routes"
+```
+
+---
+
+### Task 2: `approve` + `reject` routes (server-side maker≠checker)
+
+**Files:**
+- Create: `src/app/api/commands/reapp-block-clear/approve/route.ts`, `src/app/api/commands/reapp-block-clear/reject/route.ts`
+- Test: `tests/unit/routes/reappBlockClearApprove.test.ts`, `tests/unit/routes/reappBlockClearReject.test.ts`
+
+**Interfaces:** `POST .../approve`, `POST .../reject`.
+
+- [ ] **Step 1: Write failing tests** for approve covering: (a) happy path — checker ≠ requester, status pending → calls `publishClearAuthorized` with `operator_id = requestDoc.requestedBy`, `approval.approved_by = user.id`, `approval.approved_by ≠ operator_id`, `request_id = command.requestId`; then `createAndPublishEvent` `block_clear_approval.approved.v1`; returns 202; (b) **self-approval** — `requestDoc.requestedBy === user.id` → 403 `SELF_APPROVAL`, NO publish; (c) non-pending → 400; (d) not found → 404; (e) not `hasApprovalAuthority` → 403. Mock `getPayload` (so `payload.auth` returns the checker and `payload.find` returns the request doc), `@/server/chatledger-publisher`, `@/server/event-publisher`. RED.
+
+- [ ] **Step 2: Implement `approve/route.ts`** (mirror `writeoff/approve/route.ts`; the ledger-gRPC call is replaced by `publishClearAuthorized`):
+
+```typescript
+import { type NextRequest, NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import { hasApprovalAuthority } from '@/lib/access'
+import { BlockClearApproveCommandSchema } from '@/lib/events/schemas'
+import { createAndPublishEvent, EventPublishError } from '@/server/event-publisher'
+import { publishClearAuthorized } from '@/server/chatledger-publisher'
+import { EVENT_TYPE_BLOCK_CLEAR_APPROVAL_APPROVED } from '@/lib/events/config'
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = await getPayload({ config: configPromise })
+    const headersList = await headers()
+    const { user } = await payload.auth({ headers: new Headers(Array.from(headersList.entries())) })
+    if (!user) {
+      return NextResponse.json({ error: { code: 'UNAUTHENTICATED', message: 'Please log in to continue.' } }, { status: 401 })
+    }
+    if (!hasApprovalAuthority(user)) {
+      return NextResponse.json({ error: { code: 'FORBIDDEN', message: 'You do not have permission to approve block clears.' } }, { status: 403 })
+    }
+    const parsed = BlockClearApproveCommandSchema.safeParse(await request.json())
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: { code: 'VALIDATION_ERROR', message: 'Invalid request body', details: parsed.error.flatten().fieldErrors } },
+        { status: 400 },
+      )
+    }
+    const cmd = parsed.data
+    const found = await payload.find({
+      collection: 'reapplication-block-clear-requests',
+      where: { or: [{ requestId: { equals: cmd.requestId } }, { id: { equals: cmd.requestId } }] },
+      limit: 1,
+    })
+    if (found.docs.length === 0) {
+      return NextResponse.json({ error: { code: 'NOT_FOUND', message: 'Block-clear request not found.' } }, { status: 404 })
+    }
+    const doc = found.docs[0]
+    if (doc.status !== 'pending') {
+      return NextResponse.json({ error: { code: 'INVALID_STATE', message: `Request is already ${doc.status}.` } }, { status: 400 })
+    }
+    // Server-side maker != checker (closes the gap the write-off flow only guards in the UI).
+    if (String(doc.requestedBy) === String(user.id)) {
+      return NextResponse.json(
+        { error: { code: 'SELF_APPROVAL', message: 'You cannot approve your own request.' } },
+        { status: 403 },
+      )
+    }
+    const approverName = user.firstName
+      ? `${user.firstName}${user.lastName ? ` ${user.lastName}` : ''}`
+      : user.email || 'Unknown User'
+
+    // Emit the authoritative clear onto chatLedger with the approval attestation.
+    await publishClearAuthorized({
+      canonical_customer_id: doc.canonicalCustomerId,
+      reasons: doc.reasons,
+      operator_id: String(doc.requestedBy),
+      justification: doc.justification,
+      request_id: cmd.requestId,
+      requested_at: (doc.requestedAt ?? doc.createdAt) as string,
+      approval: {
+        approval_request_id: doc.requestNumber,
+        approved_by: String(user.id),
+        approved_by_name: approverName,
+        approved_at: new Date().toISOString(),
+        comment: cmd.comment,
+      },
+    })
+
+    const result = await createAndPublishEvent({
+      typ: EVENT_TYPE_BLOCK_CLEAR_APPROVAL_APPROVED,
+      userId: String(user.id),
+      payload: {
+        requestId: cmd.requestId,
+        requestNumber: cmd.requestNumber,
+        comment: cmd.comment,
+        approvedBy: String(user.id),
+        approvedByName: approverName,
+      },
+      requestId: cmd.requestId,
+    })
+    return NextResponse.json(result, { status: 202 })
+  } catch (error) {
+    if (error instanceof EventPublishError) {
+      return NextResponse.json({ error: { code: 'EVENT_PUBLISH_FAILED', message: 'Failed to approve block clear. Please try again.' } }, { status: 503 })
+    }
+    console.error('[BlockClear Approve] Error:', error)
+    return NextResponse.json({ error: { code: 'INTERNAL_ERROR', message: 'An unexpected error occurred.' } }, { status: 500 })
+  }
+}
+```
+
+- [ ] **Step 3: Implement `reject/route.ts`** — mirror `writeoff/reject/route.ts` (payload.auth + hasApprovalAuthority; `BlockClearRejectCommandSchema`; publish `EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REJECTED` with `BlockClearApprovalRejectedPayload`). No self-check needed on reject.
+
+- [ ] **Step 4: Tests green; Prettier; commit**
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm && pnpm exec vitest run tests/unit/routes/reappBlockClearApprove.test.ts tests/unit/routes/reappBlockClearReject.test.ts --config ./vitest.config.mts
+pnpm exec prettier --write src/app/api/commands/reapp-block-clear/approve src/app/api/commands/reapp-block-clear/reject tests/unit/routes/reappBlockClear{Approve,Reject}.test.ts
+git add src/app/api/commands/reapp-block-clear/approve src/app/api/commands/reapp-block-clear/reject tests/unit/routes/reappBlockClear{Approve,Reject}.test.ts
+git commit -m "feat(block-clear): approve + reject routes with server-side maker-checker"
+```
+
+---
+
+### Task 3: Companion fix — server-side maker≠checker on the write-off approve route
+
+**Files:**
+- Modify: `src/app/api/commands/writeoff/approve/route.ts`
+- Test: `tests/unit/routes/writeoffApproveSelfApproval.test.ts` (new — or extend an existing write-off approve test if present)
+
+**Context:** The existing write-off approve route enforces maker≠checker only in the UI (`ApprovalDetailDrawer` `isOwnRequest`); the API permits self-approval. Add the same server-side guard the block-clear approve route uses.
+
+- [ ] **Step 1: Write the failing test** — a write-off approve request where `writeOffDoc.requestedBy === user.id` must return 403 (no ledger call, no event publish). Mock `getPayload`/`payload.auth`/`payload.find` and the ledger client. RED (today it proceeds to the ledger call).
+
+- [ ] **Step 2: Add the guard** — in `writeoff/approve/route.ts`, immediately AFTER the existing `if (writeOffDoc.status !== 'pending')` check and BEFORE the `getLedgerClient()` call, insert:
+
+```typescript
+    // Segregation of duties: the approver must differ from the requester.
+    if (String(writeOffDoc.requestedBy) === String(user.id)) {
+      return NextResponse.json(
+        { error: { code: 'SELF_APPROVAL', message: 'You cannot approve your own request.' } },
+        { status: 403 },
+      )
+    }
+```
+
+- [ ] **Step 3: Test green** (the existing write-off approve suite still passes — the guard only fires for self-approval); Prettier; commit:
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm && pnpm exec vitest run tests/unit/routes/writeoffApproveSelfApproval.test.ts --config ./vitest.config.mts
+pnpm exec prettier --write src/app/api/commands/writeoff/approve/route.ts tests/unit/routes/writeoffApproveSelfApproval.test.ts
+git add src/app/api/commands/writeoff/approve/route.ts tests/unit/routes/writeoffApproveSelfApproval.test.ts
+git commit -m "fix(writeoff): server-side maker-checker guard on approve route"
+```
+
+---
+
+## Out of scope (Plan B3)
+
+The "Clear block" action on the blocked customer/conversation view, the ApprovalsView extension (a block-clear queue + detail drawer with the self-approval-disabled Approve button), and the React Query hooks (`usePendingBlockClears`, mutations) that call these routes.
+
+## Self-Review
+
+- **Spec coverage:** §12 maker-checker enforcement → Tasks 1 (tiering/raise) + 2 (server-side approve guard); §6 bundling (any default-class ⇒ approval) → Task 1 `needsApproval`; single-operator path → Task 1; companion write-off fix (spec §12.1) → Task 3.
+- **Contract:** routes consume B1's `publishClearAuthorized` / `createAndPublishEvent` / event-type constants / Zod schemas; `request_id` correlates approval rows to billieChat's outcome (projected by B1 Task 6). `operator_id`=maker, `approval.approved_by`=checker, guard guarantees they differ — satisfying billieChat's attestation guard (PR #110).
+- **Placeholder scan:** request + approve routes carry full code; cancel/reject reference their verbatim write-off templates with the named event/schema swaps.

--- a/docs/superpowers/plans/2026-06-28-manual-block-clear-crm-ui.md
+++ b/docs/superpowers/plans/2026-06-28-manual-block-clear-crm-ui.md
@@ -1,0 +1,128 @@
+# Manual Block Clear — billie-crm UI (Plan B3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** The operator UI for manual block clear: React Query hooks against the B2 command routes, a "Clear block" action on the blocked-customer view, and a block-clear approvals queue in the existing ApprovalsView (self-approval-disabled, mirroring write-offs).
+
+**Architecture:** Mirrors the existing write-off UI (`src/hooks/{mutations,queries}`, `src/components/ApprovalsView/*`, `src/lib/events/poll.ts`). Hooks POST to `/api/commands/reapp-block-clear/*` (B2), then poll the `reapplication-block-clear-requests` projection. Builds on B1 (PR #34) + B2 (same branch).
+
+**Tech Stack:** React 19, TanStack React Query, Payload admin (`@payloadcms/ui`), vitest + @testing-library/react (jsdom).
+
+## Global Constraints
+
+- Mirror the verbatim write-off templates: hooks `src/hooks/mutations/use{Approve,Reject,Cancel}WriteOff.ts` + `src/hooks/queries/usePendingApprovals.ts`; poll `src/lib/events/poll.ts` (`pollForWriteOffUpdate`); components `src/components/ApprovalsView/{ApprovalsView,ApprovalsList,ApprovalDetailDrawer,ApprovalActionModal}.tsx`. Read them first.
+- Routes (B2): `POST /api/commands/reapp-block-clear/{request,approve,reject,cancel}`. Request body shapes = the B1 Zod command schemas (`BlockClear{Request,Approve,Reject,Cancel}CommandSchema`). All return 202 `{ requestId, status: 'accepted' }`.
+- Projection read: `GET /api/reapplication-block-clear-requests?where[status][equals]=pending&...` (Payload REST for the collection slug `reapplication-block-clear-requests`).
+- Self-approval: the Approve button is disabled when `currentUserId === requestedBy` (the `isOwnRequest` pattern from `ApprovalDetailDrawer`). The server also enforces it (B2), so the UI guard is UX-only.
+- Role gating: current user via `useAuth()` from `@payloadcms/ui`; show "Clear block" to `admin/supervisor/operations` (`canService` roles); the approvals queue is `admin/supervisor` only (existing ApprovalsView access).
+- Field bindings (camelCase, `payload-types.ts`): `reapplicationBlock.{reason, blockedUntil, canonicalCustomerId, clearStatus, clearedAt, clearJustification, clearRequestId}`. Treat the customer/conversation as blocked when `reapplicationBlock?.reason && !reapplicationBlock?.clearedAt`.
+- Reason vocabulary for the request form: only offer `CLEARABLE_REASONS` (B1 `config.ts`); a selection containing any `REASONS_REQUIRING_APPROVAL` member shows "needs approval" copy.
+- Tests: hooks via the `tests/unit/hooks/use*.test.ts` pattern (createWrapper + fetch mock + fake timers). **Components: this plan's UI components are built to the write-off template; their visual layout/interaction must get a human QA pass in the running admin app — the automated tests cover logic/wiring, not pixels.** Prettier (single quotes, no semicolons, 100 cols).
+- New generated types: after any collection touch run `pnpm generate:types` (not expected here — no schema change).
+
+---
+
+### Task 1: React Query hooks + poll (fully tested)
+
+**Files:**
+- Modify: `src/lib/events/poll.ts` (add `pollForBlockClearUpdate`)
+- Create: `src/hooks/mutations/useRequestBlockClear.ts`, `useApproveBlockClear.ts`, `useRejectBlockClear.ts`, `useCancelBlockClear.ts`; `src/hooks/queries/usePendingBlockClears.ts`
+- Modify: `src/hooks/index.ts` (barrel exports)
+- Test: `tests/unit/hooks/useApproveBlockClear.test.ts`, `useRequestBlockClear.test.ts`
+
+**Interfaces produced:** `useRequestBlockClear()`, `useApproveBlockClear()`, `useRejectBlockClear()`, `useCancelBlockClear()`, `usePendingBlockClears(options)`.
+
+- [ ] **Step 1: Write failing tests** mirroring `tests/unit/hooks/useRejectWriteOff.test.ts`: 
+  - `useApproveBlockClear` — `approveAsync({ requestId, requestNumber, comment })` POSTs to `/api/commands/reapp-block-clear/approve` with that body; after a 202 it polls `/api/reapplication-block-clear-requests?...status=approved` and resolves; assert the POST URL + body.
+  - `useRequestBlockClear` — `requestAsync({ canonicalCustomerId, reasons, justification, conversationId?, customerName? })` POSTs to `/api/commands/reapp-block-clear/request`; assert URL + body. (Single-op returns immediately; the hook just returns the 202 — no projection poll needed for request, since single-op has no row; for the maker-checker path the row appears but the request hook need not poll. Keep request simple: POST + return.)
+  Run RED.
+
+- [ ] **Step 2: Add `pollForBlockClearUpdate`** to `poll.ts` (copy `pollForWriteOffUpdate`, swap the endpoint to `/api/reapplication-block-clear-requests` and the `expectedStatus` union to `'approved' | 'rejected' | 'cancelled'`).
+
+- [ ] **Step 3: Implement the mutation hooks** (each mirrors its write-off twin):
+  - `useApproveBlockClear` → POST `/api/commands/reapp-block-clear/approve`, then `pollForBlockClearUpdate(requestId, 'approved')`, then `queryClient.invalidateQueries({ queryKey: ['block-clear-requests'] })` and `['pending-block-clears']`; sonner toast on success/error.
+  - `useRejectBlockClear` → `/reject`, poll `'rejected'`.
+  - `useCancelBlockClear` → `/cancel`, poll `'cancelled'`.
+  - `useRequestBlockClear` → POST `/request`; no poll (single-op has no row, maker-checker row is eventual); invalidate `['pending-block-clears']`; toast.
+
+- [ ] **Step 4: Implement `usePendingBlockClears`** (mirror `usePendingApprovals`): `useQuery` fetching `/api/reapplication-block-clear-requests` with `where[status][equals]=pending`, `sort`, paging; `queryKey: ['pending-block-clears', options]`; `refetchInterval: 60_000`.
+
+- [ ] **Step 5: Barrel exports** in `src/hooks/index.ts` (add the 5 new hooks alongside the write-off ones).
+
+- [ ] **Step 6: Tests green; Prettier; commit**
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm && pnpm exec vitest run tests/unit/hooks/useApproveBlockClear.test.ts tests/unit/hooks/useRequestBlockClear.test.ts --config ./vitest.config.mts
+pnpm exec prettier --write src/hooks src/lib/events/poll.ts tests/unit/hooks/use{Approve,Request}BlockClear.test.ts
+git add src/hooks src/lib/events/poll.ts tests/unit/hooks/use{Approve,Request}BlockClear.test.ts
+git commit -m "feat(block-clear): react-query hooks + poll for block-clear requests"
+```
+
+---
+
+### Task 2: "Clear block" action on the blocked-customer view
+
+**Files:**
+- Create: `src/components/BlockClear/ClearBlockButton.tsx`, `src/components/BlockClear/ClearBlockModal.tsx`
+- Modify: the blocked-customer host — `src/components/ConversationDetailView/DecisionBanner/index.tsx` (render `ClearBlockButton` when a confirmed block is present) — and/or `src/components/ServicingView/ServicingView.tsx` near the AttentionStrip. (Choose the host the brief identifies; prefer DecisionBanner where the block + `canonicalCustomerId` are already in scope.)
+- Test: `tests/unit/components/ClearBlockModal.test.tsx`
+
+**Interfaces:** `<ClearBlockButton block={reapplicationBlock} conversationId? customerName? />` opens `<ClearBlockModal>` → on submit calls `useRequestBlockClear`.
+
+- [ ] **Step 1: Write a failing component test** (testing-library): rendering `ClearBlockModal` with the clearable reasons, selecting a reason + entering a justification (≥ N chars), submitting calls the (mocked) `requestAsync` with `{ canonicalCustomerId, reasons, justification }`; a default-class reason shows the "requires approval" notice; submit is disabled until a reason + valid justification are present. RED.
+
+- [ ] **Step 2: Implement `ClearBlockModal`** (model on `ApprovalActionModal`): a form with a reasons multiselect limited to `CLEARABLE_REASONS` (label each; show an "Approval required" badge when any selected reason ∈ `REASONS_REQUIRING_APPROVAL`), a justification textarea (min length, mirror `MIN_APPROVAL_COMMENT_LENGTH`), submit → `useRequestBlockClear().requestAsync({...})`, success toast + close. Pre-select the block's current `reason` if it's clearable.
+
+- [ ] **Step 3: Implement `ClearBlockButton`** — visible only to `canService` roles (`useAuth()`), only when `block?.reason && !block?.clearedAt`. Shows current `clearStatus` if a clear is already pending/rejected. Opens the modal. (`PEP`/`ACTIVE_LOAN`/`IDENTITY_CONFLICT` are not clearable — if the current `reason` is one of those, render a disabled state with a tooltip rather than the action.)
+
+- [ ] **Step 4: Wire into the host** (DecisionBanner): render `<ClearBlockButton block={reapplicationBlock} conversationId={conversation.id} customerName={...} />` where the block details are shown. Additive — do not alter the existing banner content.
+
+- [ ] **Step 5: Test green; Prettier; commit**
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm && pnpm exec vitest run tests/unit/components/ClearBlockModal.test.tsx --config ./vitest.config.mts
+pnpm exec prettier --write src/components/BlockClear src/components/ConversationDetailView/DecisionBanner/index.tsx tests/unit/components/ClearBlockModal.test.tsx
+git add src/components/BlockClear src/components/ConversationDetailView/DecisionBanner/index.tsx tests/unit/components/ClearBlockModal.test.tsx
+git commit -m "feat(block-clear): Clear-block action + modal on blocked-customer view"
+```
+
+**⚠️ Visual QA:** the modal/button layout, the reason multiselect, and the host placement need a human pass in the running admin app.
+
+---
+
+### Task 3: Block-clear approvals queue in ApprovalsView
+
+**Files:**
+- Create: `src/components/ApprovalsView/BlockClearList.tsx`, `src/components/ApprovalsView/BlockClearDetailDrawer.tsx`
+- Modify: `src/components/ApprovalsView/ApprovalsView.tsx` (add a "Block clears" tab/section alongside write-offs)
+- Test: `tests/unit/components/BlockClearDetailDrawer.test.tsx`
+
+**Interfaces:** a second queue in ApprovalsView listing pending `reapplication-block-clear-requests`, each row opening `BlockClearDetailDrawer` with Approve/Reject (self-approval-disabled) wired to the B3.1 mutations.
+
+- [ ] **Step 1: Write a failing component test** for `BlockClearDetailDrawer`: given a request whose `requestedBy === currentUserId`, the Approve button is disabled with the "Cannot approve own request" reason (mirror the `ApprovalDetailDrawer` `isOwnRequest` test); Approve calls `useApproveBlockClear`, Reject calls `useRejectBlockClear`. RED.
+
+- [ ] **Step 2: Implement `BlockClearList`** (parallel to `ApprovalsList`, isolated so the write-off list is untouched): use `usePendingBlockClears`, render rows showing `requestNumber`, `customerName`, `reasons`, requester, age; row click opens `BlockClearDetailDrawer`; pass `currentUserId`/`currentUserName`.
+
+- [ ] **Step 3: Implement `BlockClearDetailDrawer`** (parallel to `ApprovalDetailDrawer`): show the request detail (canonical id, reasons, justification, requester); the `isOwnRequest` self-approval-disabled Approve button; Approve/Reject open an `ApprovalActionModal` (reuse it) → `useApproveBlockClear`/`useRejectBlockClear`.
+
+- [ ] **Step 4: Add the queue to `ApprovalsView`** — a tab/section "Block clears" beside "Write-Off Approvals" (additive; do not change the write-off section), rendering `<BlockClearList currentUserId={userId} currentUserName={userName} />`, gated by the same `admin/supervisor` access already in ApprovalsView.
+
+- [ ] **Step 5: Test green; Prettier; commit**
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm && pnpm exec vitest run tests/unit/components/BlockClearDetailDrawer.test.tsx --config ./vitest.config.mts
+pnpm exec prettier --write src/components/ApprovalsView tests/unit/components/BlockClearDetailDrawer.test.tsx
+git add src/components/ApprovalsView tests/unit/components/BlockClearDetailDrawer.test.tsx
+git commit -m "feat(block-clear): block-clear approvals queue in ApprovalsView"
+```
+
+**⚠️ Visual QA:** the tab, list columns, and drawer layout need a human pass; consider an e2e (Playwright) follow-up mirroring any write-off approvals e2e.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §12/§13 UI surface → the request action (Task 2) + the approvals queue (Task 3); the hooks (Task 1) bind to the B2 routes. Self-approval-disabled mirrors write-off; server-side guard is the real enforcement (B2).
+- **Isolation:** new components are parallel (`BlockClear*`) — the working write-off ApprovalsView path is untouched (additive tab + a parallel list/drawer), accepting some duplication for safety over generalizing shared components we can't visually verify.
+- **Verification boundary:** hooks + form logic + the isOwnRequest/role gating are unit-tested; component *visual* layout is explicitly deferred to human QA.
+- **Placeholder scan:** hooks carry concrete wiring; components reference their verbatim write-off templates + the new data bindings.

--- a/event-processor/src/billie_servicing/handlers/__init__.py
+++ b/event-processor/src/billie_servicing/handlers/__init__.py
@@ -47,6 +47,12 @@ from .writeoff import (
     handle_writeoff_rejected,
     handle_writeoff_cancelled,
 )
+from .block_clear_approval import (
+    handle_block_clear_approval_requested,
+    handle_block_clear_approval_approved,
+    handle_block_clear_approval_rejected,
+    handle_block_clear_approval_cancelled,
+)
 from .notification import (
     handle_notification_sent,
     handle_notification_delivery_failed,
@@ -107,6 +113,11 @@ __all__ = [
     "handle_writeoff_approved",
     "handle_writeoff_rejected",
     "handle_writeoff_cancelled",
+    # Block-clear approval handlers (CRM-originated events)
+    "handle_block_clear_approval_requested",
+    "handle_block_clear_approval_approved",
+    "handle_block_clear_approval_rejected",
+    "handle_block_clear_approval_cancelled",
     # Notification handlers (platform → CRM read-only projections)
     "handle_notification_sent",
     "handle_notification_delivery_failed",

--- a/event-processor/src/billie_servicing/handlers/__init__.py
+++ b/event-processor/src/billie_servicing/handlers/__init__.py
@@ -21,6 +21,8 @@ from .identity_verification import (
 )
 from .reapplication import (
     handle_reapplication_blocked,
+    handle_reapplication_block_cleared,
+    handle_reapplication_block_clear_rejected,
 )
 from .conversation import (
     handle_conversation_started,
@@ -84,8 +86,10 @@ __all__ = [
     "handle_customer_verified",
     "handle_customer_identity_linked",
     "handle_customer_identity_merged",
-    # Re-application block (BTB-135)
+    # Re-application block (BTB-135) + cleared/rejected projection (Task 6)
     "handle_reapplication_blocked",
+    "handle_reapplication_block_cleared",
+    "handle_reapplication_block_clear_rejected",
     # Identity verification archival (PR #67)
     "handle_identity_report_archived",
     # Conversation handlers

--- a/event-processor/src/billie_servicing/handlers/block_clear_approval.py
+++ b/event-processor/src/billie_servicing/handlers/block_clear_approval.py
@@ -93,6 +93,7 @@ async def handle_block_clear_approval_requested(
             "reasons": reasons_json,
             "justification": payload.get("justification"),
             "status": "pending",
+            "requested_by_id": payload.get("requestedBy"),
             "requested_by_name": payload.get("requestedByName", ""),
             "requested_at": now,
             "created_at": now,

--- a/event-processor/src/billie_servicing/handlers/block_clear_approval.py
+++ b/event-processor/src/billie_servicing/handlers/block_clear_approval.py
@@ -1,0 +1,196 @@
+"""Block-clear approval event handlers for CRM-originated events.
+
+Handles events:
+- block_clear_approval.requested.v1
+- block_clear_approval.approved.v1
+- block_clear_approval.rejected.v1
+- block_clear_approval.cancelled.v1
+
+These events originate from the CRM (which publishes them onto Redis), and are
+routed back through this processor to populate the
+``reapplication_block_clear_requests`` projection on Postgres.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import string
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncpg
+import structlog
+
+from ..db import update_by_key, upsert
+from .sanitize import safe_str
+
+logger = structlog.get_logger()
+
+
+def _parse_payload(event: dict[str, Any]) -> dict[str, Any]:
+    """Parse the payload from event dict.
+
+    The payload may be a JSON string or already parsed dict.
+    """
+    payload = event.get("payload", {})
+    if isinstance(payload, str):
+        try:
+            return json.loads(payload)
+        except json.JSONDecodeError:
+            return {}
+    return payload
+
+
+def _generate_request_number() -> str:
+    """Generate a human-readable block-clear request number.
+
+    Format: RBC-YYYYMMDDHHMMSS-XXXX where XXXX is a random alphanumeric suffix.
+    """
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    suffix = "".join(random.choices(string.ascii_uppercase + string.digits, k=4))
+    return f"RBC-{timestamp}-{suffix}"
+
+
+async def handle_block_clear_approval_requested(
+    pool: asyncpg.Pool, parsed_event: dict[str, Any]
+) -> None:
+    """Handle block_clear_approval.requested.v1 — creates the projection row.
+
+    Uses ``ON CONFLICT (request_id) DO NOTHING`` so replays from the Redis
+    stream beyond the dedup TTL don't create duplicate rows (the schema's
+    unique constraint on request_id guarantees this).
+    """
+    payload = _parse_payload(parsed_event)
+
+    request_id = safe_str(parsed_event.get("conv", ""), "request_id")
+    event_id = safe_str(parsed_event.get("cause", ""), "event_id")
+
+    log = logger.bind(
+        request_id=request_id,
+        event_id=event_id,
+        canonical_customer_id=payload.get("canonicalCustomerId"),
+    )
+    log.info("Processing block_clear_approval.requested.v1")
+
+    now = datetime.now(UTC)
+
+    # reasons is a list — asyncpg has no list→jsonb codec, so serialise to JSON
+    # string here (mirrors the recognition_json pattern in reapplication.py).
+    reasons_json = json.dumps(payload.get("reasons") or [])
+
+    await upsert(
+        pool,
+        "reapplication_block_clear_requests",
+        conflict_columns=["request_id"],
+        values={
+            "request_id": request_id,
+            "event_id": event_id,
+            "request_number": _generate_request_number(),
+            "canonical_customer_id": payload.get("canonicalCustomerId"),
+            "conversation_id": payload.get("conversationId"),
+            "customer_name": payload.get("customerName", ""),
+            "reasons": reasons_json,
+            "justification": payload.get("justification"),
+            "status": "pending",
+            "requested_by_name": payload.get("requestedByName", ""),
+            "requested_at": now,
+            "created_at": now,
+            "updated_at": now,
+        },
+        do_nothing_on_conflict=True,
+    )
+
+    log.info("Block-clear request created (or skipped on replay)")
+
+
+async def handle_block_clear_approval_approved(
+    pool: asyncpg.Pool, parsed_event: dict[str, Any]
+) -> None:
+    """Handle block_clear_approval.approved.v1 — flips status and stamps approval details."""
+    payload = _parse_payload(parsed_event)
+    request_id = safe_str(parsed_event.get("conv", ""), "request_id")
+    event_id = safe_str(parsed_event.get("cause", ""), "event_id")
+
+    log = logger.bind(request_id=request_id, event_id=event_id)
+    log.info("Processing block_clear_approval.approved.v1")
+
+    now = datetime.now(UTC)
+
+    status = await update_by_key(
+        pool,
+        "reapplication_block_clear_requests",
+        key_column="request_id",
+        key_value=request_id,
+        values={
+            "status": "approved",
+            "approval_details_approved_by": payload.get("approvedBy"),
+            "approval_details_approved_by_name": payload.get("approvedByName", ""),
+            "approval_details_comment": payload.get("comment", ""),
+            "approval_details_approved_at": now,
+            "updated_at": now,
+        },
+    )
+
+    log.info("Block-clear request approved", asyncpg_status=status)
+
+
+async def handle_block_clear_approval_rejected(
+    pool: asyncpg.Pool, parsed_event: dict[str, Any]
+) -> None:
+    """Handle block_clear_approval.rejected.v1 — flips status and stamps rejection details."""
+    payload = _parse_payload(parsed_event)
+    request_id = safe_str(parsed_event.get("conv", ""), "request_id")
+    event_id = safe_str(parsed_event.get("cause", ""), "event_id")
+
+    log = logger.bind(request_id=request_id, event_id=event_id)
+    log.info("Processing block_clear_approval.rejected.v1")
+
+    now = datetime.now(UTC)
+
+    status = await update_by_key(
+        pool,
+        "reapplication_block_clear_requests",
+        key_column="request_id",
+        key_value=request_id,
+        values={
+            "status": "rejected",
+            "approval_details_rejected_by": payload.get("rejectedBy"),
+            "approval_details_rejected_by_name": payload.get("rejectedByName", ""),
+            "approval_details_reason": payload.get("reason", ""),
+            "approval_details_rejected_at": now,
+            "updated_at": now,
+        },
+    )
+
+    log.info("Block-clear request rejected", asyncpg_status=status)
+
+
+async def handle_block_clear_approval_cancelled(
+    pool: asyncpg.Pool, parsed_event: dict[str, Any]
+) -> None:
+    """Handle block_clear_approval.cancelled.v1 — flips status and stamps cancellation details."""
+    payload = _parse_payload(parsed_event)
+    request_id = safe_str(parsed_event.get("conv", ""), "request_id")
+    event_id = safe_str(parsed_event.get("cause", ""), "event_id")
+
+    log = logger.bind(request_id=request_id, event_id=event_id)
+    log.info("Processing block_clear_approval.cancelled.v1")
+
+    now = datetime.now(UTC)
+
+    status = await update_by_key(
+        pool,
+        "reapplication_block_clear_requests",
+        key_column="request_id",
+        key_value=request_id,
+        values={
+            "status": "cancelled",
+            "cancellation_details_cancelled_by": payload.get("cancelledBy"),
+            "cancellation_details_cancelled_by_name": payload.get("cancelledByName", ""),
+            "cancellation_details_cancelled_at": now,
+            "updated_at": now,
+        },
+    )
+
+    log.info("Block-clear request cancelled", asyncpg_status=status)

--- a/event-processor/src/billie_servicing/handlers/reapplication.py
+++ b/event-processor/src/billie_servicing/handlers/reapplication.py
@@ -200,16 +200,16 @@ async def handle_reapplication_block_cleared(
     blocking reason is confirmed gone (``prior_block_reason`` is absent OR in
     ``cleared_reasons``).  When a higher-precedence reason still blocks, stamp
     the audit fields but leave the reason column untouched.
+
+    Conversations are stamped by canonical customer id (not by conversation_id),
+    because billieChat sets ``conv = "ops:block-clear:{request_id}"`` on these
+    events — a synthetic ops key, not a real conversation id.  Using
+    ``update_by_key`` on ``reapplication_block_canonical_customer_id`` clears
+    all blocked conversations for the canonical in one pass; 0 matches is
+    harmless (no phantom INSERT).
     """
     payload = parse_payload(event)
     request_id = safe_str(payload.get("request_id"), "request_id")
-    conversation_id = (
-        safe_str(
-            payload.get("conversation_id") or event.get("cid") or event.get("conv"),
-            "conversation_id",
-        )
-        or None
-    )
 
     customer_id = (
         safe_str(
@@ -258,27 +258,30 @@ async def handle_reapplication_block_cleared(
             values=customer_values,
             insert_only_columns=["created_at"],
         )
-    else:
-        log.warning("Cleared event without resolvable customer id — no customer mirror")
 
-    # Conversation audit trail.
-    if conversation_id:
+        # Conversation audit trail — update all blocked conversations for this
+        # canonical (keyed by reapplication_block_canonical_customer_id, which
+        # handle_reapplication_blocked populates). UPDATE not upsert: 0 matches
+        # is harmless; no phantom row is inserted for the ops:block-clear:… conv.
         conv_values: dict[str, Any] = {
             "reapplication_block_clear_status": "cleared",
             "reapplication_block_cleared_at": cleared_at,
             "reapplication_block_cleared_by": operator_id,
             "reapplication_block_clear_justification": justification,
-            "reapplication_block_clear_request_id": request_id or None,
+            "reapplication_block_clear_request_id": request_id,
+            "updated_at": now,
         }
         if reason_is_gone:
             conv_values["reapplication_block_reason"] = None
-        await upsert_conversation(
+        await update_by_key(
             pool,
-            conversation_id=conversation_id,
-            set_values=conv_values,
+            "conversations",
+            key_column="reapplication_block_canonical_customer_id",
+            key_value=canonical,
+            values=conv_values,
         )
     else:
-        log.info("Cleared event has no conversation_id — customer mirror only")
+        log.warning("Cleared event without resolvable customer id — no customer mirror")
 
     # Flip the queue row to "approved" so the operator sees it was applied.
     if request_id:
@@ -306,16 +309,13 @@ async def handle_reapplication_block_clear_rejected(
     explicit rejection by the approver).  Stamps a "rejected" status so the
     operator can see the failure in the queue and on the customer / conversation
     views.
+
+    Like ``handle_reapplication_block_cleared``, conversations are stamped by
+    canonical customer id (not conversation_id) because billieChat sets
+    ``conv = "ops:block-clear:{request_id}"`` on these events.
     """
     payload = parse_payload(event)
     request_id = safe_str(payload.get("request_id"), "request_id")
-    conversation_id = (
-        safe_str(
-            payload.get("conversation_id") or event.get("cid") or event.get("conv"),
-            "conversation_id",
-        )
-        or None
-    )
 
     customer_id = (
         safe_str(
@@ -331,6 +331,14 @@ async def handle_reapplication_block_clear_rejected(
 
     now = datetime.now(UTC)
 
+    # Combine rejection_code + detail so operators see both the machine code
+    # and the human-readable explanation in the request row.
+    rejection_code = payload.get("rejection_code")
+    detail = payload.get("detail")
+    approval_reason = (
+        f"{rejection_code}: {detail or ''}" if rejection_code else detail
+    )
+
     # Flip the queue row to "rejected" and record the reason.
     if request_id:
         await update_by_key(
@@ -340,7 +348,7 @@ async def handle_reapplication_block_clear_rejected(
             key_value=request_id,
             values={
                 "status": "rejected",
-                "approval_details_reason": payload.get("detail"),
+                "approval_details_reason": approval_reason,
                 "updated_at": now,
             },
         )
@@ -359,17 +367,17 @@ async def handle_reapplication_block_clear_rejected(
             },
             insert_only_columns=["created_at"],
         )
+
+        # Update all blocked conversations for this canonical — same pattern as
+        # the cleared handler; UPDATE not upsert to avoid phantom rows.
+        await update_by_key(
+            pool,
+            "conversations",
+            key_column="reapplication_block_canonical_customer_id",
+            key_value=canonical,
+            values={"reapplication_block_clear_status": "rejected", "updated_at": now},
+        )
     else:
         log.warning("Rejected event without resolvable customer id — no customer mirror")
-
-    # Mirror onto conversation if present.
-    if conversation_id:
-        await upsert_conversation(
-            pool,
-            conversation_id=conversation_id,
-            set_values={
-                "reapplication_block_clear_status": "rejected",
-            },
-        )
 
     log.info("Re-application block clear rejected")

--- a/event-processor/src/billie_servicing/handlers/reapplication.py
+++ b/event-processor/src/billie_servicing/handlers/reapplication.py
@@ -24,7 +24,7 @@ from typing import Any
 import asyncpg
 import structlog
 
-from ..db import coerce_date, upsert, upsert_conversation
+from ..db import coerce_date, update_by_key, upsert, upsert_conversation
 from .identity import _merge_identity, resolve_canonical_customer_id
 from .sanitize import parse_payload, safe_str
 
@@ -182,3 +182,194 @@ async def handle_reapplication_blocked(pool: asyncpg.Pool, event: dict[str, Any]
         log.debug("Block reason not in re-attribution allowlist — block recorded only")
 
     log.info("Re-application block recorded")
+
+
+async def handle_reapplication_block_cleared(
+    pool: asyncpg.Pool, event: dict[str, Any]
+) -> None:
+    """Handle ``reapplication_block.cleared.v1``.
+
+    Emitted by billieChat's customerLiaisonAgent after an operator-authorised
+    clear is applied.  Projects the outcome back into three CRM tables:
+
+    * ``customers`` — compact mirror so the servicing view stops showing "blocked".
+    * ``conversations`` — operator audit trail (who cleared, why, request id).
+    * ``reapplication_block_clear_requests`` — flips the queue row to "approved".
+
+    §14 nuance: only NULL ``reapplication_block_reason`` when the previously-
+    blocking reason is confirmed gone (``prior_block_reason`` is absent OR in
+    ``cleared_reasons``).  When a higher-precedence reason still blocks, stamp
+    the audit fields but leave the reason column untouched.
+    """
+    payload = parse_payload(event)
+    request_id = safe_str(payload.get("request_id"), "request_id")
+    conversation_id = (
+        safe_str(
+            payload.get("conversation_id") or event.get("cid") or event.get("conv"),
+            "conversation_id",
+        )
+        or None
+    )
+
+    customer_id = (
+        safe_str(
+            payload.get("canonical_customer_id") or event.get("usr"),
+            "customer_id",
+        )
+        or None
+    )
+    canonical = await resolve_canonical_customer_id(pool, customer_id)
+
+    # §14: is the previously-blocking reason now gone?
+    cleared_reasons: list[str] = payload.get("cleared_reasons") or []
+    prior = payload.get("prior_block_reason")
+    reason_is_gone = prior is None or prior in cleared_reasons
+
+    cleared_at = coerce_date(payload.get("cleared_at"))
+    operator_id = payload.get("operator_id")
+    justification = payload.get("justification")
+
+    log = logger.bind(
+        canonical_customer_id=canonical,
+        request_id=request_id,
+        prior_block_reason=prior,
+        reason_is_gone=reason_is_gone,
+    )
+    log.info("Processing reapplication_block.cleared.v1")
+
+    now = datetime.now(UTC)
+
+    # Customer-level mirror.
+    if canonical:
+        customer_values: dict[str, Any] = {
+            "customer_id": canonical,
+            "reapplication_block_clear_status": "cleared",
+            "reapplication_block_cleared_at": cleared_at,
+            "updated_at": now,
+            "created_at": now,
+        }
+        if reason_is_gone:
+            # NULL the reason so the servicing view stops showing "blocked".
+            customer_values["reapplication_block_reason"] = None
+        await upsert(
+            pool,
+            "customers",
+            conflict_columns=["customer_id"],
+            values=customer_values,
+            insert_only_columns=["created_at"],
+        )
+    else:
+        log.warning("Cleared event without resolvable customer id — no customer mirror")
+
+    # Conversation audit trail.
+    if conversation_id:
+        conv_values: dict[str, Any] = {
+            "reapplication_block_clear_status": "cleared",
+            "reapplication_block_cleared_at": cleared_at,
+            "reapplication_block_cleared_by": operator_id,
+            "reapplication_block_clear_justification": justification,
+            "reapplication_block_clear_request_id": request_id or None,
+        }
+        if reason_is_gone:
+            conv_values["reapplication_block_reason"] = None
+        await upsert_conversation(
+            pool,
+            conversation_id=conversation_id,
+            set_values=conv_values,
+        )
+    else:
+        log.info("Cleared event has no conversation_id — customer mirror only")
+
+    # Flip the queue row to "approved" so the operator sees it was applied.
+    if request_id:
+        await update_by_key(
+            pool,
+            "reapplication_block_clear_requests",
+            key_column="request_id",
+            key_value=request_id,
+            values={
+                "status": "approved",
+                "updated_at": now,
+            },
+        )
+
+    log.info("Re-application block cleared")
+
+
+async def handle_reapplication_block_clear_rejected(
+    pool: asyncpg.Pool, event: dict[str, Any]
+) -> None:
+    """Handle ``reapplication_block.clear_rejected.v1``.
+
+    Emitted by billieChat when the clear was not authorised (e.g. a
+    single-operator attempt for a reason that requires maker-checker, or an
+    explicit rejection by the approver).  Stamps a "rejected" status so the
+    operator can see the failure in the queue and on the customer / conversation
+    views.
+    """
+    payload = parse_payload(event)
+    request_id = safe_str(payload.get("request_id"), "request_id")
+    conversation_id = (
+        safe_str(
+            payload.get("conversation_id") or event.get("cid") or event.get("conv"),
+            "conversation_id",
+        )
+        or None
+    )
+
+    customer_id = (
+        safe_str(
+            payload.get("canonical_customer_id") or event.get("usr"),
+            "customer_id",
+        )
+        or None
+    )
+    canonical = await resolve_canonical_customer_id(pool, customer_id)
+
+    log = logger.bind(canonical_customer_id=canonical, request_id=request_id)
+    log.info("Processing reapplication_block.clear_rejected.v1")
+
+    now = datetime.now(UTC)
+
+    # Flip the queue row to "rejected" and record the reason.
+    if request_id:
+        await update_by_key(
+            pool,
+            "reapplication_block_clear_requests",
+            key_column="request_id",
+            key_value=request_id,
+            values={
+                "status": "rejected",
+                "approval_details_reason": payload.get("detail"),
+                "updated_at": now,
+            },
+        )
+
+    # Stamp clear_status on the customer row so the servicing view shows it.
+    if canonical:
+        await upsert(
+            pool,
+            "customers",
+            conflict_columns=["customer_id"],
+            values={
+                "customer_id": canonical,
+                "reapplication_block_clear_status": "rejected",
+                "updated_at": now,
+                "created_at": now,
+            },
+            insert_only_columns=["created_at"],
+        )
+    else:
+        log.warning("Rejected event without resolvable customer id — no customer mirror")
+
+    # Mirror onto conversation if present.
+    if conversation_id:
+        await upsert_conversation(
+            pool,
+            conversation_id=conversation_id,
+            set_values={
+                "reapplication_block_clear_status": "rejected",
+            },
+        )
+
+    log.info("Re-application block clear rejected")

--- a/event-processor/src/billie_servicing/main.py
+++ b/event-processor/src/billie_servicing/main.py
@@ -51,6 +51,11 @@ from .handlers import (
     handle_writeoff_approved,
     handle_writeoff_rejected,
     handle_writeoff_cancelled,
+    # Block-clear approval handlers (CRM-originated events)
+    handle_block_clear_approval_requested,
+    handle_block_clear_approval_approved,
+    handle_block_clear_approval_rejected,
+    handle_block_clear_approval_cancelled,
     # Notification handlers (platform → CRM read-only projections)
     handle_notification_sent,
     handle_notification_delivery_failed,
@@ -187,6 +192,22 @@ def setup_handlers(processor: EventProcessor) -> None:
     processor.register_handler("writeoff.approved.v1", handle_writeoff_approved)
     processor.register_handler("writeoff.rejected.v1", handle_writeoff_rejected)
     processor.register_handler("writeoff.cancelled.v1", handle_writeoff_cancelled)
+
+    # =========================================================================
+    # Block-clear approval events (CRM-originated, manual parsing)
+    # =========================================================================
+    processor.register_handler(
+        "block_clear_approval.requested.v1", handle_block_clear_approval_requested
+    )
+    processor.register_handler(
+        "block_clear_approval.approved.v1", handle_block_clear_approval_approved
+    )
+    processor.register_handler(
+        "block_clear_approval.rejected.v1", handle_block_clear_approval_rejected
+    )
+    processor.register_handler(
+        "block_clear_approval.cancelled.v1", handle_block_clear_approval_cancelled
+    )
 
     # =========================================================================
     # Notification events (platform → CRM, billie_notifications_events SDK)

--- a/event-processor/src/billie_servicing/main.py
+++ b/event-processor/src/billie_servicing/main.py
@@ -24,8 +24,10 @@ from .handlers import (
     handle_customer_identity_merged,
     # Identity verification archival (PR #67)
     handle_identity_report_archived,
-    # Re-application block (BTB-135)
+    # Re-application block (BTB-135) + cleared/rejected projection (Task 6)
     handle_reapplication_blocked,
+    handle_reapplication_block_cleared,
+    handle_reapplication_block_clear_rejected,
     # Conversation handlers
     handle_conversation_started,
     handle_utterance,
@@ -160,6 +162,16 @@ def setup_handlers(processor: EventProcessor) -> None:
     # arrives before the final_credit_decision for the same application.
     processor.register_handler(
         "application.reapplication_blocked.v1", handle_reapplication_blocked
+    )
+
+    # Block-clear outcome events (Task 6) — emitted by billieChat after an
+    # operator-authorised clear is applied or rejected; projected back into the
+    # CRM's customers / conversations / reapplication_block_clear_requests tables.
+    processor.register_handler(
+        "reapplication_block.cleared.v1", handle_reapplication_block_cleared
+    )
+    processor.register_handler(
+        "reapplication_block.clear_rejected.v1", handle_reapplication_block_clear_rejected
     )
 
     # Identity verification report archival (PR #67)

--- a/event-processor/tests/test_block_clear_approval_handlers.py
+++ b/event-processor/tests/test_block_clear_approval_handlers.py
@@ -1,0 +1,252 @@
+"""Unit tests for block_clear_approval event handlers.
+
+Tests cover block_clear_approval.{requested,approved,rejected,cancelled}.v1 —
+the CRM-originated events processed by the event-processor.
+"""
+
+import json
+
+import pytest
+
+from billie_servicing.handlers.block_clear_approval import (
+    _generate_request_number,
+    _parse_payload,
+    handle_block_clear_approval_approved,
+    handle_block_clear_approval_cancelled,
+    handle_block_clear_approval_rejected,
+    handle_block_clear_approval_requested,
+)
+
+
+class TestPayloadParsing:
+    def test_parse_dict_payload(self):
+        assert _parse_payload({"payload": {"key": "value"}}) == {"key": "value"}
+
+    def test_parse_json_string_payload(self):
+        assert _parse_payload({"payload": '{"key": "value"}'}) == {"key": "value"}
+
+    def test_parse_empty_payload(self):
+        assert _parse_payload({}) == {}
+
+    def test_parse_invalid_json_payload(self):
+        assert _parse_payload({"payload": "not valid json"}) == {}
+
+
+class TestRequestNumberGeneration:
+    def test_generate_request_number_format(self):
+        result = _generate_request_number()
+        assert result.startswith("RBC-")
+        parts = result.split("-")
+        assert len(parts) == 3
+        assert len(parts[1]) == 14
+        assert len(parts[2]) == 4
+
+    def test_generate_unique_request_numbers(self):
+        numbers = {_generate_request_number() for _ in range(100)}
+        assert len(numbers) >= 90
+
+
+class TestBlockClearApprovalRequestedHandler:
+    @pytest.mark.asyncio
+    async def test_requested_creates_pending_row(self, mock_pool):
+        event = {
+            "conv": "req-1",
+            "cause": "evt-1",
+            "typ": "block_clear_approval.requested.v1",
+            "payload": {
+                "canonicalCustomerId": "c1",
+                "conversationId": "conv-1",
+                "customerName": "Jane Customer",
+                "reasons": ["PRIOR_DEFAULT"],
+                "justification": "manual assessment",
+                "requestedByName": "Jane Ops",
+            },
+        }
+        await handle_block_clear_approval_requested(mock_pool, event)
+        doc = mock_pool.last_insert("reapplication_block_clear_requests")
+        assert doc["request_id"] == "req-1"
+        assert doc["event_id"] == "evt-1"
+        assert doc["canonical_customer_id"] == "c1"
+        assert doc["conversation_id"] == "conv-1"
+        assert doc["customer_name"] == "Jane Customer"
+        assert doc["status"] == "pending"
+        assert doc["request_number"].startswith("RBC-")
+        assert doc["requested_by_name"] == "Jane Ops"
+        assert "requested_at" in doc
+        assert "created_at" in doc
+        assert "updated_at" in doc
+
+    @pytest.mark.asyncio
+    async def test_requested_reasons_json_encoded(self, mock_pool):
+        """reasons list must be json.dumps'd for the jsonb column."""
+        event = {
+            "conv": "req-2",
+            "cause": "evt-2",
+            "typ": "block_clear_approval.requested.v1",
+            "payload": {
+                "canonicalCustomerId": "c2",
+                "conversationId": "conv-2",
+                "reasons": ["PRIOR_DEFAULT", "ACTIVE_LOAN"],
+                "justification": "two reasons",
+                "requestedByName": "Ops User",
+            },
+        }
+        await handle_block_clear_approval_requested(mock_pool, event)
+        doc = mock_pool.last_insert("reapplication_block_clear_requests")
+        # The value stored must be the JSON-encoded string, not the raw list.
+        assert doc["reasons"] == json.dumps(["PRIOR_DEFAULT", "ACTIVE_LOAN"])
+
+    @pytest.mark.asyncio
+    async def test_requested_conflict_on_request_id(self, mock_pool):
+        event = {
+            "conv": "req-3",
+            "cause": "evt-3",
+            "typ": "block_clear_approval.requested.v1",
+            "payload": {
+                "canonicalCustomerId": "c3",
+                "conversationId": "conv-3",
+                "reasons": ["PRIOR_DEFAULT"],
+                "justification": "test",
+                "requestedByName": "Ops",
+            },
+        }
+        await handle_block_clear_approval_requested(mock_pool, event)
+        call = mock_pool.calls_against("reapplication_block_clear_requests")[0]
+        assert call.conflict_columns == ["request_id"]
+
+    @pytest.mark.asyncio
+    async def test_requested_defaults_for_optional_fields(self, mock_pool):
+        """customer_name and requested_by_name default to empty string."""
+        event = {
+            "conv": "req-4",
+            "cause": "evt-4",
+            "typ": "block_clear_approval.requested.v1",
+            "payload": {
+                "canonicalCustomerId": "c4",
+                "conversationId": "conv-4",
+                "reasons": [],
+                "justification": "minimal",
+            },
+        }
+        await handle_block_clear_approval_requested(mock_pool, event)
+        doc = mock_pool.last_insert("reapplication_block_clear_requests")
+        assert doc["customer_name"] == ""
+        assert doc["requested_by_name"] == ""
+
+    @pytest.mark.asyncio
+    async def test_requested_with_json_string_payload(self, mock_pool):
+        payload = {
+            "canonicalCustomerId": "c5",
+            "conversationId": "conv-5",
+            "reasons": ["PRIOR_DEFAULT"],
+            "justification": "json string payload",
+            "requestedByName": "Ops",
+        }
+        event = {
+            "conv": "req-5",
+            "cause": "evt-5",
+            "typ": "block_clear_approval.requested.v1",
+            "payload": json.dumps(payload),
+        }
+        await handle_block_clear_approval_requested(mock_pool, event)
+        doc = mock_pool.last_insert("reapplication_block_clear_requests")
+        assert doc["canonical_customer_id"] == "c5"
+
+
+class TestBlockClearApprovalApprovedHandler:
+    @pytest.mark.asyncio
+    async def test_approved_flips_status(self, mock_pool):
+        event = {
+            "conv": "req-1",
+            "cause": "evt-2",
+            "typ": "block_clear_approval.approved.v1",
+            "payload": {"approvedBy": "boss-1", "approvedByName": "Sam Sup", "comment": "ok"},
+        }
+        await handle_block_clear_approval_approved(mock_pool, event)
+        doc = mock_pool.last_update("reapplication_block_clear_requests")
+        assert doc["status"] == "approved"
+        assert doc["approval_details_approved_by"] == "boss-1"
+        assert doc["approval_details_approved_by_name"] == "Sam Sup"
+        assert doc["approval_details_comment"] == "ok"
+        assert "approval_details_approved_at" in doc
+        assert "updated_at" in doc
+
+    @pytest.mark.asyncio
+    async def test_approved_keys_on_request_id(self, mock_pool):
+        event = {
+            "conv": "req-10",
+            "cause": "evt-20",
+            "typ": "block_clear_approval.approved.v1",
+            "payload": {"approvedBy": "boss-2", "approvedByName": "Boss", "comment": ""},
+        }
+        await handle_block_clear_approval_approved(mock_pool, event)
+        call = mock_pool.calls_against("reapplication_block_clear_requests")[0]
+        assert call.where == {"request_id": "req-10"}
+
+
+class TestBlockClearApprovalRejectedHandler:
+    @pytest.mark.asyncio
+    async def test_rejected_flips_status(self, mock_pool):
+        event = {
+            "conv": "req-20",
+            "cause": "evt-30",
+            "typ": "block_clear_approval.rejected.v1",
+            "payload": {
+                "rejectedBy": "boss-3",
+                "rejectedByName": "Rejector",
+                "reason": "not enough evidence",
+            },
+        }
+        await handle_block_clear_approval_rejected(mock_pool, event)
+        doc = mock_pool.last_update("reapplication_block_clear_requests")
+        assert doc["status"] == "rejected"
+        assert doc["approval_details_rejected_by"] == "boss-3"
+        assert doc["approval_details_rejected_by_name"] == "Rejector"
+        assert doc["approval_details_reason"] == "not enough evidence"
+        assert "approval_details_rejected_at" in doc
+        assert "updated_at" in doc
+
+    @pytest.mark.asyncio
+    async def test_rejected_keys_on_request_id(self, mock_pool):
+        event = {
+            "conv": "req-21",
+            "cause": "evt-31",
+            "typ": "block_clear_approval.rejected.v1",
+            "payload": {"rejectedBy": "b", "rejectedByName": "B", "reason": "x"},
+        }
+        await handle_block_clear_approval_rejected(mock_pool, event)
+        call = mock_pool.calls_against("reapplication_block_clear_requests")[0]
+        assert call.where == {"request_id": "req-21"}
+
+
+class TestBlockClearApprovalCancelledHandler:
+    @pytest.mark.asyncio
+    async def test_cancelled_flips_status(self, mock_pool):
+        event = {
+            "conv": "req-30",
+            "cause": "evt-40",
+            "typ": "block_clear_approval.cancelled.v1",
+            "payload": {
+                "cancelledBy": "user-1",
+                "cancelledByName": "Original Requester",
+            },
+        }
+        await handle_block_clear_approval_cancelled(mock_pool, event)
+        doc = mock_pool.last_update("reapplication_block_clear_requests")
+        assert doc["status"] == "cancelled"
+        assert doc["cancellation_details_cancelled_by"] == "user-1"
+        assert doc["cancellation_details_cancelled_by_name"] == "Original Requester"
+        assert "cancellation_details_cancelled_at" in doc
+        assert "updated_at" in doc
+
+    @pytest.mark.asyncio
+    async def test_cancelled_keys_on_request_id(self, mock_pool):
+        event = {
+            "conv": "req-31",
+            "cause": "evt-41",
+            "typ": "block_clear_approval.cancelled.v1",
+            "payload": {"cancelledBy": "u", "cancelledByName": "U"},
+        }
+        await handle_block_clear_approval_cancelled(mock_pool, event)
+        call = mock_pool.calls_against("reapplication_block_clear_requests")[0]
+        assert call.where == {"request_id": "req-31"}

--- a/event-processor/tests/test_block_clear_projection.py
+++ b/event-processor/tests/test_block_clear_projection.py
@@ -109,7 +109,13 @@ async def test_cleared_flips_request_row_to_approved(mock_pool):
 
 
 async def test_cleared_stamps_conversation_audit_when_present(mock_pool):
-    """conversation_id in payload → operator/justification fields land on conversations."""
+    """Conversations updated via update_by_key on reapplication_block_canonical_customer_id.
+
+    The handler no longer keys by conversation_id from the payload (billieChat sets
+    conv = "ops:block-clear:..." which is a synthetic ops key, not a real conv row).
+    Instead it UPDATE-by-canonical so all blocked conversations for the canonical
+    receive the audit fields.
+    """
     event = {
         "typ": "reapplication_block.cleared.v1",
         "usr": "c4",
@@ -125,7 +131,7 @@ async def test_cleared_stamps_conversation_audit_when_present(mock_pool):
         },
     }
     await handle_reapplication_block_cleared(mock_pool, event)
-    conv = mock_pool.last_upsert("conversations")
+    conv = mock_pool.last_update("conversations")
     assert conv is not None
     assert conv["reapplication_block_clear_status"] == "cleared"
     assert conv["reapplication_block_cleared_by"] == "ops-3"
@@ -134,7 +140,7 @@ async def test_cleared_stamps_conversation_audit_when_present(mock_pool):
 
 
 async def test_cleared_no_conversation_id_updates_customer_only(mock_pool):
-    """No conversation_id → customer mirror updated, no conversations write."""
+    """No conversation_id → customer mirror updated; conversations updated by canonical (no INSERT)."""
     event = {
         "typ": "reapplication_block.cleared.v1",
         "usr": "c5",
@@ -148,7 +154,10 @@ async def test_cleared_no_conversation_id_updates_customer_only(mock_pool):
         },
     }
     await handle_reapplication_block_cleared(mock_pool, event)
+    # No INSERT (no phantom conversation row for the ops:block-clear:... conv key).
     assert not mock_pool.inserts_into("conversations")
+    # An UPDATE by canonical IS issued (harmless 0-match if no blocked convs yet).
+    assert mock_pool.last_update("conversations") is not None
     assert mock_pool.last_upsert("customers") is not None
 
 
@@ -228,3 +237,59 @@ async def test_rejected_stores_detail_on_request_row(mock_pool):
     await handle_reapplication_block_clear_rejected(mock_pool, event)
     req = mock_pool.last_update("reapplication_block_clear_requests")
     assert req["approval_details_reason"] == "manager declined"
+
+
+async def test_cleared_realistic_ops_conv_no_phantom_insert(mock_pool):
+    """ops:block-clear:... synthetic conv MUST NOT create a phantom conversations row.
+
+    billieChat emits cleared events with conv = "ops:block-clear:{request_id}"
+    (not a real conversation id).  The handler must stamp conversations via
+    UPDATE-by-canonical only — never INSERT a phantom row keyed by the ops conv.
+    """
+    event = {
+        "typ": "reapplication_block.cleared.v1",
+        "usr": "c1",
+        "conv": "ops:block-clear:req-1",
+        "payload": {
+            "canonical_customer_id": "c1",
+            "request_id": "req-1",
+            "cleared_reasons": ["SERVICEABILITY"],
+            "cleared_at": "2026-06-28T01:00:00+00:00",
+            "operator_id": "ops-1",
+            "justification": "x",
+            "prior_block_reason": "SERVICEABILITY",
+        },
+    }
+    await handle_reapplication_block_cleared(mock_pool, event)
+    # No phantom INSERT into conversations.
+    assert mock_pool.inserts_into("conversations") == []
+    # An UPDATE by canonical IS issued.
+    conv = mock_pool.last_update("conversations")
+    assert conv is not None
+    assert conv["reapplication_block_clear_status"] == "cleared"
+    assert conv["reapplication_block_reason"] is None
+
+
+async def test_rejected_updates_conversations_by_canonical_with_rejection_code(mock_pool):
+    """Rejected handler updates conversations by canonical and stores rejection_code in request row."""
+    event = {
+        "typ": "reapplication_block.clear_rejected.v1",
+        "usr": "c9",
+        "conv": "ops:block-clear:req-9",
+        "payload": {
+            "canonical_customer_id": "c9",
+            "request_id": "req-9",
+            "rejection_code": "APPROVAL_REQUIRED",
+            "detail": "single operator attempt",
+        },
+    }
+    await handle_reapplication_block_clear_rejected(mock_pool, event)
+    # No phantom INSERT into conversations.
+    assert mock_pool.inserts_into("conversations") == []
+    # Conversations UPDATE by canonical with rejected status.
+    conv = mock_pool.last_update("conversations")
+    assert conv is not None
+    assert conv["reapplication_block_clear_status"] == "rejected"
+    # Request row has both machine code and human detail.
+    req = mock_pool.last_update("reapplication_block_clear_requests")
+    assert req["approval_details_reason"] == "APPROVAL_REQUIRED: single operator attempt"

--- a/event-processor/tests/test_block_clear_projection.py
+++ b/event-processor/tests/test_block_clear_projection.py
@@ -1,0 +1,230 @@
+"""Tests for billieChat ``reapplication_block.cleared.v1`` /
+``reapplication_block.clear_rejected.v1`` projection handlers (Task 6).
+
+billieChat emits these after an operator clears or rejects a block-clear
+request; the CRM projects them back into the ``customers`` /
+``conversations`` / ``reapplication_block_clear_requests`` tables.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from billie_servicing.handlers.reapplication import (
+    handle_reapplication_block_clear_rejected,
+    handle_reapplication_block_cleared,
+)
+
+
+# ---------------------------------------------------------------------------
+# handle_reapplication_block_cleared
+# ---------------------------------------------------------------------------
+
+
+async def test_cleared_nulls_block_and_stamps_audit(mock_pool):
+    """Prior reason in cleared_reasons → NULL the block, stamp cleared audit."""
+    event = {
+        "typ": "reapplication_block.cleared.v1",
+        "usr": "c1",
+        "payload": {
+            "canonical_customer_id": "c1",
+            "request_id": "req-1",
+            "cleared_reasons": ["SERVICEABILITY"],
+            "cleared_at": "2026-06-28T01:00:00+00:00",
+            "operator_id": "ops-1",
+            "justification": "manual assessment",
+            "prior_block_reason": "SERVICEABILITY",
+        },
+    }
+    await handle_reapplication_block_cleared(mock_pool, event)
+    cust = mock_pool.last_upsert("customers")
+    assert cust["reapplication_block_reason"] is None
+    assert cust["reapplication_block_clear_status"] == "cleared"
+    req = mock_pool.last_update("reapplication_block_clear_requests")
+    assert req["status"] == "approved"
+
+
+async def test_cleared_leaves_reason_when_prior_still_blocks(mock_pool):
+    """Prior reason NOT in cleared_reasons → leave block reason, stamp audit only."""
+    event = {
+        "typ": "reapplication_block.cleared.v1",
+        "usr": "c2",
+        "payload": {
+            "canonical_customer_id": "c2",
+            "request_id": "req-2",
+            # SERVICEABILITY cleared, but the blocking reason is ACTIVE_LOAN
+            "cleared_reasons": ["SERVICEABILITY"],
+            "prior_block_reason": "ACTIVE_LOAN",
+            "cleared_at": "2026-06-28T01:00:00+00:00",
+            "operator_id": "ops-1",
+        },
+    }
+    await handle_reapplication_block_cleared(mock_pool, event)
+    cust = mock_pool.last_upsert("customers")
+    # reapplication_block_reason must NOT be in the upsert (left as-is on conflict).
+    assert "reapplication_block_reason" not in cust
+    # Audit fields must still be stamped.
+    assert cust["reapplication_block_clear_status"] == "cleared"
+    assert cust["reapplication_block_cleared_at"] is not None
+
+
+async def test_cleared_prior_none_also_nulls_reason(mock_pool):
+    """prior_block_reason absent (None) → treat as gone, NULL the block reason."""
+    event = {
+        "typ": "reapplication_block.cleared.v1",
+        "usr": "c3",
+        "payload": {
+            "canonical_customer_id": "c3",
+            "request_id": "req-3",
+            "cleared_reasons": ["SERVICEABILITY"],
+            "cleared_at": "2026-06-28T02:00:00+00:00",
+            "operator_id": "ops-2",
+            # prior_block_reason absent
+        },
+    }
+    await handle_reapplication_block_cleared(mock_pool, event)
+    cust = mock_pool.last_upsert("customers")
+    assert cust["reapplication_block_reason"] is None
+    assert cust["reapplication_block_clear_status"] == "cleared"
+
+
+async def test_cleared_flips_request_row_to_approved(mock_pool):
+    """Request row must be flipped to 'approved' so the queue shows it applied."""
+    event = {
+        "typ": "reapplication_block.cleared.v1",
+        "usr": "c1",
+        "payload": {
+            "canonical_customer_id": "c1",
+            "request_id": "req-99",
+            "cleared_reasons": ["PEP"],
+            "prior_block_reason": "PEP",
+            "cleared_at": "2026-06-28T01:00:00+00:00",
+            "operator_id": "ops-1",
+        },
+    }
+    await handle_reapplication_block_cleared(mock_pool, event)
+    req = mock_pool.last_update("reapplication_block_clear_requests")
+    assert req is not None
+    assert req["status"] == "approved"
+
+
+async def test_cleared_stamps_conversation_audit_when_present(mock_pool):
+    """conversation_id in payload → operator/justification fields land on conversations."""
+    event = {
+        "typ": "reapplication_block.cleared.v1",
+        "usr": "c4",
+        "payload": {
+            "canonical_customer_id": "c4",
+            "conversation_id": "conv-abc",
+            "request_id": "req-4",
+            "cleared_reasons": ["SERVICEABILITY"],
+            "prior_block_reason": "SERVICEABILITY",
+            "cleared_at": "2026-06-28T01:00:00+00:00",
+            "operator_id": "ops-3",
+            "justification": "approved after review",
+        },
+    }
+    await handle_reapplication_block_cleared(mock_pool, event)
+    conv = mock_pool.last_upsert("conversations")
+    assert conv is not None
+    assert conv["reapplication_block_clear_status"] == "cleared"
+    assert conv["reapplication_block_cleared_by"] == "ops-3"
+    assert conv["reapplication_block_clear_justification"] == "approved after review"
+    assert conv["reapplication_block_clear_request_id"] == "req-4"
+
+
+async def test_cleared_no_conversation_id_updates_customer_only(mock_pool):
+    """No conversation_id → customer mirror updated, no conversations write."""
+    event = {
+        "typ": "reapplication_block.cleared.v1",
+        "usr": "c5",
+        "payload": {
+            "canonical_customer_id": "c5",
+            "request_id": "req-5",
+            "cleared_reasons": ["SERVICEABILITY"],
+            "prior_block_reason": "SERVICEABILITY",
+            "cleared_at": "2026-06-28T01:00:00+00:00",
+            "operator_id": "ops-1",
+        },
+    }
+    await handle_reapplication_block_cleared(mock_pool, event)
+    assert not mock_pool.inserts_into("conversations")
+    assert mock_pool.last_upsert("customers") is not None
+
+
+async def test_cleared_follows_tombstone_to_canonical(mock_pool):
+    """Merged customer → cleared audit lands on the surviving canonical row."""
+    mock_pool.set_fetchval("CANONICAL-C6")
+    event = {
+        "typ": "reapplication_block.cleared.v1",
+        "usr": "alias-c6",
+        "payload": {
+            "canonical_customer_id": "alias-c6",
+            "request_id": "req-6",
+            "cleared_reasons": ["ACTIVE_LOAN"],
+            "prior_block_reason": "ACTIVE_LOAN",
+            "cleared_at": "2026-06-28T01:00:00+00:00",
+            "operator_id": "ops-1",
+        },
+    }
+    await handle_reapplication_block_cleared(mock_pool, event)
+    cust = mock_pool.last_upsert("customers")
+    assert cust["customer_id"] == "CANONICAL-C6"
+
+
+# ---------------------------------------------------------------------------
+# handle_reapplication_block_clear_rejected
+# ---------------------------------------------------------------------------
+
+
+async def test_rejected_stamps_clear_status(mock_pool):
+    """Rejection → request row gets status='rejected'."""
+    event = {
+        "typ": "reapplication_block.clear_rejected.v1",
+        "usr": "c1",
+        "payload": {
+            "canonical_customer_id": "c1",
+            "request_id": "req-1",
+            "rejection_code": "APPROVAL_REQUIRED",
+            "detail": "needs approval",
+        },
+    }
+    await handle_reapplication_block_clear_rejected(mock_pool, event)
+    req = mock_pool.last_update("reapplication_block_clear_requests")
+    # Handler may set either status="rejected" or reapplication_block_clear_status="rejected"
+    # on the request row; use .get() so the or short-circuits without KeyError.
+    assert req.get("reapplication_block_clear_status") == "rejected" or req.get("status") == "rejected"
+
+
+async def test_rejected_stamps_customer_clear_status(mock_pool):
+    """Rejection → customer row gets reapplication_block_clear_status='rejected'."""
+    event = {
+        "typ": "reapplication_block.clear_rejected.v1",
+        "usr": "c7",
+        "payload": {
+            "canonical_customer_id": "c7",
+            "request_id": "req-7",
+            "rejection_code": "APPROVAL_REQUIRED",
+            "detail": "insufficient justification",
+        },
+    }
+    await handle_reapplication_block_clear_rejected(mock_pool, event)
+    cust = mock_pool.last_upsert("customers")
+    assert cust is not None
+    assert cust["reapplication_block_clear_status"] == "rejected"
+
+
+async def test_rejected_stores_detail_on_request_row(mock_pool):
+    """The rejection detail is stored on the request row for the operator to see."""
+    event = {
+        "typ": "reapplication_block.clear_rejected.v1",
+        "usr": "c8",
+        "payload": {
+            "canonical_customer_id": "c8",
+            "request_id": "req-8",
+            "detail": "manager declined",
+        },
+    }
+    await handle_reapplication_block_clear_rejected(mock_pool, event)
+    req = mock_pool.last_update("reapplication_block_clear_requests")
+    assert req["approval_details_reason"] == "manager declined"

--- a/src/app/api/commands/reapp-block-clear/approve/route.ts
+++ b/src/app/api/commands/reapp-block-clear/approve/route.ts
@@ -1,0 +1,174 @@
+/**
+ * API Route: POST /api/commands/reapp-block-clear/approve
+ *
+ * Approve a pending reapplication block-clear request.
+ *
+ * Two actions in sequence:
+ *   1. publishClearAuthorized → chatLedger — the authoritative command that
+ *      billieChat's reapplicationBlock service will act on. Carries the
+ *      maker's operator_id and the checker's approval attestation.
+ *   2. createAndPublishEvent → internal CRM stream — updates the CRM
+ *      projection row (projection processor sets status → approved).
+ *
+ * Server-side maker≠checker (BTB-202 security requirement):
+ *   The route looks up the pending request, checks requestedBy ≠ user.id,
+ *   and returns 403 SELF_APPROVAL before any publish if they match.
+ *   This closes the gap that the write-off flow only guards in the UI.
+ *
+ * Returns 202 Accepted.
+ */
+
+import { type NextRequest, NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import { hasApprovalAuthority } from '@/lib/access'
+import { BlockClearApproveCommandSchema } from '@/lib/events/schemas'
+import { createAndPublishEvent, EventPublishError } from '@/server/event-publisher'
+import { publishClearAuthorized } from '@/server/chatledger-publisher'
+import { EVENT_TYPE_BLOCK_CLEAR_APPROVAL_APPROVED } from '@/lib/events/config'
+import type { BlockClearApprovalApprovedPayload } from '@/lib/events/types'
+
+export async function POST(request: NextRequest) {
+  try {
+    // 1. Authenticate user
+    const payload = await getPayload({ config: configPromise })
+    const headersList = await headers()
+    const { user } = await payload.auth({
+      headers: new Headers(Array.from(headersList.entries())),
+    })
+
+    if (!user) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHENTICATED', message: 'Please log in to continue.' } },
+        { status: 401 },
+      )
+    }
+
+    // 2. Check authorization — only supervisors/admins can approve
+    if (!hasApprovalAuthority(user)) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'FORBIDDEN',
+            message: 'You do not have permission to approve block clears.',
+          },
+        },
+        { status: 403 },
+      )
+    }
+
+    // 3. Parse and validate request body
+    const parsed = BlockClearApproveCommandSchema.safeParse(await request.json())
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid request body',
+            details: parsed.error.flatten().fieldErrors,
+          },
+        },
+        { status: 400 },
+      )
+    }
+    const cmd = parsed.data
+
+    // 4. Look up the pending request (404 if absent, 400 if not pending)
+    const found = await payload.find({
+      collection: 'reapplication-block-clear-requests',
+      where: {
+        or: [{ requestId: { equals: cmd.requestId } }, { id: { equals: cmd.requestId } }],
+      },
+      limit: 1,
+    })
+
+    if (found.docs.length === 0) {
+      return NextResponse.json(
+        { error: { code: 'NOT_FOUND', message: 'Block-clear request not found.' } },
+        { status: 404 },
+      )
+    }
+
+    const doc = found.docs[0]
+
+    if (doc.status !== 'pending') {
+      return NextResponse.json(
+        { error: { code: 'INVALID_STATE', message: `Request is already ${doc.status}.` } },
+        { status: 400 },
+      )
+    }
+
+    // 5. Server-side maker≠checker (closes the UI-only gap in the write-off flow).
+    //    operator_id  = doc.requestedBy  (MAKER — the person who raised the request)
+    //    approved_by  = user.id          (CHECKER — the current approver)
+    //    The guard guarantees they differ before any publish call is made.
+    if (String(doc.requestedBy) === String(user.id)) {
+      return NextResponse.json(
+        { error: { code: 'SELF_APPROVAL', message: 'You cannot approve your own request.' } },
+        { status: 403 },
+      )
+    }
+
+    const approverName = user.firstName
+      ? `${user.firstName}${user.lastName ? ` ${user.lastName}` : ''}`
+      : user.email || 'Unknown User'
+
+    // 6. Emit the authoritative clear onto chatLedger with the approval attestation.
+    //    operator_id  = MAKER (doc.requestedBy)
+    //    approved_by  = CHECKER (user.id) — guaranteed ≠ operator_id by guard above
+    await publishClearAuthorized({
+      canonical_customer_id: doc.canonicalCustomerId,
+      reasons: doc.reasons,
+      operator_id: String(doc.requestedBy),
+      justification: doc.justification,
+      request_id: cmd.requestId,
+      requested_at: (doc.requestedAt ?? doc.createdAt) as string,
+      approval: {
+        approval_request_id: doc.requestNumber,
+        approved_by: String(user.id),
+        approved_by_name: approverName,
+        approved_at: new Date().toISOString(),
+        comment: cmd.comment,
+      },
+    })
+
+    // 7. Publish the CRM-internal approval event (updates the projection row).
+    const eventPayload: BlockClearApprovalApprovedPayload = {
+      requestId: cmd.requestId,
+      requestNumber: cmd.requestNumber,
+      comment: cmd.comment,
+      approvedBy: String(user.id),
+      approvedByName: approverName,
+    }
+
+    const result = await createAndPublishEvent({
+      typ: EVENT_TYPE_BLOCK_CLEAR_APPROVAL_APPROVED,
+      userId: String(user.id),
+      payload: eventPayload,
+      requestId: cmd.requestId,
+    })
+
+    // 8. Return 202 Accepted
+    return NextResponse.json(result, { status: 202 })
+  } catch (error) {
+    console.error('[BlockClear Approve] Error:', error)
+
+    if (error instanceof EventPublishError) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'EVENT_PUBLISH_FAILED',
+            message: 'Failed to approve block clear. Please try again.',
+          },
+        },
+        { status: 503 },
+      )
+    }
+
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'An unexpected error occurred.' } },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/commands/reapp-block-clear/approve/route.ts
+++ b/src/app/api/commands/reapp-block-clear/approve/route.ts
@@ -77,6 +77,7 @@ export async function POST(request: NextRequest) {
     // 4. Look up the pending request (404 if absent, 400 if not pending)
     const found = await payload.find({
       collection: 'reapplication-block-clear-requests',
+      depth: 0, // enforce scalar relationship IDs — the maker≠checker comparison depends on it
       where: {
         or: [{ requestId: { equals: cmd.requestId } }, { id: { equals: cmd.requestId } }],
       },
@@ -117,13 +118,18 @@ export async function POST(request: NextRequest) {
     // 6. Emit the authoritative clear onto chatLedger with the approval attestation.
     //    operator_id  = MAKER (doc.requestedBy)
     //    approved_by  = CHECKER (user.id) — guaranteed ≠ operator_id by guard above
+    //
+    // NOTE: the two publishes below (publishClearAuthorized + createAndPublishEvent) are NOT
+    // atomic. request_id is billieChat's idempotency key, so a retry will not double-apply
+    // the clear on billieChat's side. A partial failure (chatLedger ok, CRM stream fails)
+    // leaves the CRM request row in `pending` (ops-visible) — future outbox/saga work.
     await publishClearAuthorized({
       canonical_customer_id: doc.canonicalCustomerId,
       reasons: doc.reasons,
       operator_id: String(doc.requestedBy),
       justification: doc.justification,
       request_id: cmd.requestId,
-      requested_at: (doc.requestedAt ?? doc.createdAt) as string,
+      requested_at: doc.requestedAt ?? doc.createdAt ?? new Date().toISOString(),
       approval: {
         approval_request_id: doc.requestNumber,
         approved_by: String(user.id),
@@ -136,7 +142,7 @@ export async function POST(request: NextRequest) {
     // 7. Publish the CRM-internal approval event (updates the projection row).
     const eventPayload: BlockClearApprovalApprovedPayload = {
       requestId: cmd.requestId,
-      requestNumber: cmd.requestNumber,
+      requestNumber: doc.requestNumber, // use server-derived value, not client-supplied
       comment: cmd.comment,
       approvedBy: String(user.id),
       approvedByName: approverName,

--- a/src/app/api/commands/reapp-block-clear/approve/route.ts
+++ b/src/app/api/commands/reapp-block-clear/approve/route.ts
@@ -26,7 +26,7 @@ import { hasApprovalAuthority } from '@/lib/access'
 import { BlockClearApproveCommandSchema } from '@/lib/events/schemas'
 import { createAndPublishEvent, EventPublishError } from '@/server/event-publisher'
 import { publishClearAuthorized } from '@/server/chatledger-publisher'
-import { EVENT_TYPE_BLOCK_CLEAR_APPROVAL_APPROVED } from '@/lib/events/config'
+import { EVENT_TYPE_BLOCK_CLEAR_APPROVAL_APPROVED, type ClearableReason } from '@/lib/events/config'
 import type { BlockClearApprovalApprovedPayload } from '@/lib/events/types'
 
 export async function POST(request: NextRequest) {
@@ -111,6 +111,20 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // 5b. Data-integrity guard — these fields are always set by the request route;
+    //     guard both narrows the types and protects against a corrupt row.
+    if (
+      !doc.canonicalCustomerId ||
+      !doc.justification ||
+      !doc.requestNumber ||
+      !Array.isArray(doc.reasons)
+    ) {
+      return NextResponse.json(
+        { error: { code: 'DATA_INTEGRITY', message: 'Stored block-clear request is incomplete.' } },
+        { status: 500 },
+      )
+    }
+
     const approverName = user.firstName
       ? `${user.firstName}${user.lastName ? ` ${user.lastName}` : ''}`
       : user.email || 'Unknown User'
@@ -125,7 +139,7 @@ export async function POST(request: NextRequest) {
     // leaves the CRM request row in `pending` (ops-visible) — future outbox/saga work.
     await publishClearAuthorized({
       canonical_customer_id: doc.canonicalCustomerId,
-      reasons: doc.reasons,
+      reasons: doc.reasons as ClearableReason[],
       operator_id: String(doc.requestedBy),
       justification: doc.justification,
       request_id: cmd.requestId,

--- a/src/app/api/commands/reapp-block-clear/approve/route.ts
+++ b/src/app/api/commands/reapp-block-clear/approve/route.ts
@@ -117,6 +117,7 @@ export async function POST(request: NextRequest) {
       !doc.canonicalCustomerId ||
       !doc.justification ||
       !doc.requestNumber ||
+      !doc.requestedBy ||
       !Array.isArray(doc.reasons)
     ) {
       return NextResponse.json(

--- a/src/app/api/commands/reapp-block-clear/cancel/route.ts
+++ b/src/app/api/commands/reapp-block-clear/cancel/route.ts
@@ -48,20 +48,24 @@ export async function POST(request: NextRequest) {
       limit: 1,
     })
 
-    if (existingRequest.docs.length > 0) {
-      const originalRequest = existingRequest.docs[0]
-      const isOriginalRequester = String(originalRequest.requestedBy) === String(user.id)
-      if (!isOriginalRequester && !hasApprovalAuthority(user)) {
-        return NextResponse.json(
-          {
-            error: {
-              code: 'FORBIDDEN',
-              message: 'Only the original requester or a supervisor can cancel this request.',
-            },
+    if (existingRequest.docs.length === 0) {
+      return NextResponse.json(
+        { error: { code: 'NOT_FOUND', message: 'Block clear request not found.' } },
+        { status: 404 },
+      )
+    }
+    const originalRequest = existingRequest.docs[0]
+    const isOriginalRequester = String(originalRequest.requestedBy) === String(user.id)
+    if (!isOriginalRequester && !hasApprovalAuthority(user)) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'FORBIDDEN',
+            message: 'Only the original requester or a supervisor can cancel this request.',
           },
-          { status: 403 },
-        )
-      }
+        },
+        { status: 403 },
+      )
     }
 
     // 4. Build event payload

--- a/src/app/api/commands/reapp-block-clear/cancel/route.ts
+++ b/src/app/api/commands/reapp-block-clear/cancel/route.ts
@@ -44,6 +44,7 @@ export async function POST(request: NextRequest) {
     // 3. Authorization: only the original requester or a supervisor/admin can cancel
     const existingRequest = await payload.find({
       collection: 'reapplication-block-clear-requests',
+      depth: 0, // enforce scalar relationship IDs — the requester comparison depends on it
       where: { requestId: { equals: command.requestId } },
       limit: 1,
     })

--- a/src/app/api/commands/reapp-block-clear/cancel/route.ts
+++ b/src/app/api/commands/reapp-block-clear/cancel/route.ts
@@ -1,0 +1,107 @@
+/**
+ * API Route: POST /api/commands/reapp-block-clear/cancel
+ *
+ * Cancel a pending reapplication block-clear approval request.
+ * Publishes a block_clear_approval.cancelled.v1 event to the internal CRM stream.
+ *
+ * Only the original requester or a supervisor/admin can cancel.
+ *
+ * Returns 202 Accepted.
+ */
+
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { canService, hasApprovalAuthority } from '@/lib/access'
+import { BlockClearCancelCommandSchema } from '@/lib/events/schemas'
+import { EVENT_TYPE_BLOCK_CLEAR_APPROVAL_CANCELLED } from '@/lib/events/config'
+import type { BlockClearApprovalCancelledPayload } from '@/lib/events/types'
+import { createAndPublishEvent, EventPublishError } from '@/server/event-publisher'
+
+export async function POST(request: NextRequest) {
+  try {
+    // 1. Authenticate — servicing role required
+    const auth = await requireAuth(canService)
+    if ('error' in auth) return auth.error
+    const { user, payload } = auth
+
+    // 2. Parse and validate body
+    const body = await request.json()
+    const parseResult = BlockClearCancelCommandSchema.safeParse(body)
+    if (!parseResult.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid request body',
+            details: parseResult.error.flatten().fieldErrors,
+          },
+        },
+        { status: 400 },
+      )
+    }
+    const command = parseResult.data
+
+    // 3. Authorization: only the original requester or a supervisor/admin can cancel
+    const existingRequest = await payload.find({
+      collection: 'reapplication-block-clear-requests',
+      where: { requestId: { equals: command.requestId } },
+      limit: 1,
+    })
+
+    if (existingRequest.docs.length > 0) {
+      const originalRequest = existingRequest.docs[0]
+      const isOriginalRequester = String(originalRequest.requestedBy) === String(user.id)
+      if (!isOriginalRequester && !hasApprovalAuthority(user)) {
+        return NextResponse.json(
+          {
+            error: {
+              code: 'FORBIDDEN',
+              message: 'Only the original requester or a supervisor can cancel this request.',
+            },
+          },
+          { status: 403 },
+        )
+      }
+    }
+
+    // 4. Build event payload
+    const eventPayload: BlockClearApprovalCancelledPayload = {
+      requestId: command.requestId,
+      requestNumber: command.requestNumber,
+      cancelledBy: String(user.id),
+      cancelledByName: user.firstName
+        ? `${user.firstName}${user.lastName ? ` ${user.lastName}` : ''}`
+        : user.email || 'Unknown User',
+    }
+
+    // 5. Publish event (use requestId as conv for correlation)
+    const result = await createAndPublishEvent({
+      typ: EVENT_TYPE_BLOCK_CLEAR_APPROVAL_CANCELLED,
+      userId: String(user.id),
+      payload: eventPayload,
+      requestId: command.requestId,
+    })
+
+    // 6. Return 202 Accepted
+    return NextResponse.json(result, { status: 202 })
+  } catch (error) {
+    console.error('[BlockClear Cancel] Error:', error)
+
+    if (error instanceof EventPublishError) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'EVENT_PUBLISH_FAILED',
+            message: 'Failed to cancel block clear. Please try again.',
+          },
+        },
+        { status: 503 },
+      )
+    }
+
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'An unexpected error occurred.' } },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/commands/reapp-block-clear/reject/route.ts
+++ b/src/app/api/commands/reapp-block-clear/reject/route.ts
@@ -1,0 +1,110 @@
+/**
+ * API Route: POST /api/commands/reapp-block-clear/reject
+ *
+ * Reject a pending reapplication block-clear request.
+ * Publishes a block_clear_approval.rejected.v1 event to the internal CRM stream.
+ * The Python event processor updates the projection row to status=rejected.
+ *
+ * Authorization: supervisor or admin only (hasApprovalAuthority).
+ * No self-check on reject — any authorized user can reject any pending request.
+ *
+ * Returns 202 Accepted.
+ */
+
+import { type NextRequest, NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import { hasApprovalAuthority } from '@/lib/access'
+import { BlockClearRejectCommandSchema } from '@/lib/events/schemas'
+import { EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REJECTED } from '@/lib/events/config'
+import type { BlockClearApprovalRejectedPayload } from '@/lib/events/types'
+import { createAndPublishEvent, EventPublishError } from '@/server/event-publisher'
+
+export async function POST(request: NextRequest) {
+  try {
+    // 1. Authenticate user
+    const payload = await getPayload({ config: configPromise })
+    const headersList = await headers()
+    const { user } = await payload.auth({
+      headers: new Headers(Array.from(headersList.entries())),
+    })
+
+    if (!user) {
+      return NextResponse.json(
+        { error: { code: 'UNAUTHENTICATED', message: 'Please log in to continue.' } },
+        { status: 401 },
+      )
+    }
+
+    // 2. Check authorization — only supervisors/admins can reject
+    if (!hasApprovalAuthority(user)) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'FORBIDDEN',
+            message: 'You do not have permission to reject block clears.',
+          },
+        },
+        { status: 403 },
+      )
+    }
+
+    // 3. Parse and validate request body
+    const parsed = BlockClearRejectCommandSchema.safeParse(await request.json())
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid request body',
+            details: parsed.error.flatten().fieldErrors,
+          },
+        },
+        { status: 400 },
+      )
+    }
+    const cmd = parsed.data
+
+    // 4. Build event payload with user info
+    const eventPayload: BlockClearApprovalRejectedPayload = {
+      requestId: cmd.requestId,
+      requestNumber: cmd.requestNumber,
+      reason: cmd.reason,
+      rejectedBy: String(user.id),
+      rejectedByName: user.firstName
+        ? `${user.firstName}${user.lastName ? ` ${user.lastName}` : ''}`
+        : user.email || 'Unknown User',
+    }
+
+    // 5. Publish event to Redis (use requestId as conv for correlation)
+    const result = await createAndPublishEvent({
+      typ: EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REJECTED,
+      userId: String(user.id),
+      payload: eventPayload,
+      requestId: cmd.requestId,
+    })
+
+    // 6. Return 202 Accepted
+    return NextResponse.json(result, { status: 202 })
+  } catch (error) {
+    console.error('[BlockClear Reject] Error:', error)
+
+    if (error instanceof EventPublishError) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'EVENT_PUBLISH_FAILED',
+            message: 'Failed to reject block clear. Please try again.',
+          },
+        },
+        { status: 503 },
+      )
+    }
+
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'An unexpected error occurred.' } },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/commands/reapp-block-clear/request/route.ts
+++ b/src/app/api/commands/reapp-block-clear/request/route.ts
@@ -1,0 +1,116 @@
+/**
+ * API Route: POST /api/commands/reapp-block-clear/request
+ *
+ * Submit a reapplication block-clear request.
+ *
+ * Tiering:
+ *   - Single-operator (windowed declines only, e.g. SERVICEABILITY):
+ *     Emits reapplication_block.clear_authorized.v1 directly onto chatLedger.
+ *     billieChat's Broker routes it to the reapplicationBlock service, which
+ *     processes the clear immediately — no approval workflow.
+ *
+ *   - Maker-checker (high-risk reasons, e.g. PRIOR_DEFAULT, PRIOR_SERIOUS_ARREARS):
+ *     Emits block_clear_approval.requested.v1 onto the internal CRM stream.
+ *     The Python event processor creates a pending row; a supervisor approves
+ *     via the separate /approve route, which then posts the clear_authorized event.
+ *
+ * Returns 202 Accepted.
+ */
+
+import { type NextRequest, NextResponse } from 'next/server'
+import { nanoid } from 'nanoid'
+import { requireAuth } from '@/lib/auth'
+import { canService } from '@/lib/access'
+import { BlockClearRequestCommandSchema } from '@/lib/events/schemas'
+import { createAndPublishEvent, EventPublishError } from '@/server/event-publisher'
+import { publishClearAuthorized } from '@/server/chatledger-publisher'
+import {
+  EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REQUESTED,
+  REASONS_REQUIRING_APPROVAL,
+} from '@/lib/events/config'
+import type { BlockClearApprovalRequestedPayload } from '@/lib/events/types'
+
+export async function POST(request: NextRequest) {
+  try {
+    // 1. Authenticate — servicing role required
+    const auth = await requireAuth(canService)
+    if ('error' in auth) return auth.error
+    const { user } = auth
+
+    // 2. Parse and validate body
+    const parsed = BlockClearRequestCommandSchema.safeParse(await request.json())
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Invalid request body',
+            details: parsed.error.flatten().fieldErrors,
+          },
+        },
+        { status: 400 },
+      )
+    }
+    const cmd = parsed.data
+
+    const operatorName = user.firstName
+      ? `${user.firstName}${user.lastName ? ` ${user.lastName}` : ''}`
+      : user.email || 'Unknown User'
+
+    // 3. Tiering decision: does any reason require approval?
+    const needsApproval = cmd.reasons.some((r) =>
+      (REASONS_REQUIRING_APPROVAL as readonly string[]).includes(r),
+    )
+
+    if (needsApproval) {
+      // Maker-checker path: raise approval request; Python processor creates pending row.
+      const eventPayload: BlockClearApprovalRequestedPayload = {
+        canonicalCustomerId: cmd.canonicalCustomerId,
+        conversationId: cmd.conversationId,
+        customerName: cmd.customerName ?? '',
+        reasons: cmd.reasons,
+        justification: cmd.justification,
+        requestedBy: String(user.id),
+        requestedByName: operatorName,
+      }
+      const result = await createAndPublishEvent({
+        typ: EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REQUESTED,
+        userId: String(user.id),
+        payload: eventPayload,
+      })
+      return NextResponse.json(result, { status: 202 })
+    }
+
+    // Single-operator path: emit the authoritative clear directly to chatLedger.
+    const requestId = nanoid()
+    const { eventId } = await publishClearAuthorized({
+      canonical_customer_id: cmd.canonicalCustomerId,
+      reasons: cmd.reasons,
+      operator_id: String(user.id),
+      justification: cmd.justification,
+      request_id: requestId,
+      requested_at: new Date().toISOString(),
+    })
+    return NextResponse.json(
+      { eventId, requestId, status: 'accepted', message: 'Block clear submitted' },
+      { status: 202 },
+    )
+  } catch (error) {
+    if (error instanceof EventPublishError) {
+      return NextResponse.json(
+        {
+          error: {
+            code: 'EVENT_PUBLISH_FAILED',
+            message: 'Failed to submit block clear. Please try again.',
+          },
+        },
+        { status: 503 },
+      )
+    }
+    console.error('[BlockClear Request] Error:', error)
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'An unexpected error occurred.' } },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/commands/reapp-block-clear/request/route.ts
+++ b/src/app/api/commands/reapp-block-clear/request/route.ts
@@ -96,6 +96,7 @@ export async function POST(request: NextRequest) {
       { status: 202 },
     )
   } catch (error) {
+    console.error('[BlockClear Request] Error:', error)
     if (error instanceof EventPublishError) {
       return NextResponse.json(
         {
@@ -107,7 +108,6 @@ export async function POST(request: NextRequest) {
         { status: 503 },
       )
     }
-    console.error('[BlockClear Request] Error:', error)
     return NextResponse.json(
       { error: { code: 'INTERNAL_ERROR', message: 'An unexpected error occurred.' } },
       { status: 500 },

--- a/src/app/api/commands/writeoff/approve/route.ts
+++ b/src/app/api/commands/writeoff/approve/route.ts
@@ -40,7 +40,12 @@ export async function POST(request: NextRequest) {
     // 2. Check authorization - only supervisors/admins can approve
     if (!hasApprovalAuthority(user)) {
       return NextResponse.json(
-        { error: { code: 'FORBIDDEN', message: 'You do not have permission to approve write-offs.' } },
+        {
+          error: {
+            code: 'FORBIDDEN',
+            message: 'You do not have permission to approve write-offs.',
+          },
+        },
         { status: 403 },
       )
     }
@@ -65,15 +70,16 @@ export async function POST(request: NextRequest) {
     const command = parseResult.data
 
     // 4. Look up the write-off request to get account details
+    // depth: 0 is REQUIRED — without it Payload populates relationships (default depth 2),
+    // so writeOffDoc.requestedBy would be an object and String() would yield '[object Object]',
+    // silently bypassing the maker≠checker guard below.
     const writeOffRequest = await payload.find({
       collection: 'write-off-requests',
       where: {
-        or: [
-          { requestId: { equals: command.requestId } },
-          { id: { equals: command.requestId } },
-        ],
+        or: [{ requestId: { equals: command.requestId } }, { id: { equals: command.requestId } }],
       },
       limit: 1,
+      depth: 0,
     })
 
     if (writeOffRequest.docs.length === 0) {
@@ -90,6 +96,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: { code: 'INVALID_STATE', message: `Request is already ${writeOffDoc.status}.` } },
         { status: 400 },
+      )
+    }
+
+    // Segregation of duties: the approver must differ from the requester.
+    if (String(writeOffDoc.requestedBy) === String(user.id)) {
+      return NextResponse.json(
+        { error: { code: 'SELF_APPROVAL', message: 'You cannot approve your own request.' } },
+        { status: 403 },
       )
     }
 

--- a/src/collections/Conversations.ts
+++ b/src/collections/Conversations.ts
@@ -322,6 +322,32 @@ export const Conversations: CollectionConfig = {
               'Identity-recognition match context for a review halt (band, posterior, case_id, candidates with per-signal evidence). Stored verbatim from the event.',
           },
         },
+        // BTB-202: manual block-clear audit fields
+        {
+          name: 'clearStatus',
+          type: 'text',
+          admin: { description: 'Status of the most recent block-clear request (e.g. approved, rejected)' },
+        },
+        {
+          name: 'clearedAt',
+          type: 'date',
+          admin: { description: 'When the block was cleared' },
+        },
+        {
+          name: 'clearedBy',
+          type: 'text',
+          admin: { description: 'User ID who cleared the block' },
+        },
+        {
+          name: 'clearJustification',
+          type: 'text',
+          admin: { description: 'Justification provided for the clear' },
+        },
+        {
+          name: 'clearRequestId',
+          type: 'text',
+          admin: { description: 'ID of the ReapplicationBlockClearRequest that cleared this block' },
+        },
       ],
     },
     {

--- a/src/collections/Customers.ts
+++ b/src/collections/Customers.ts
@@ -316,6 +316,17 @@ export const Customers: CollectionConfig = {
           type: 'text',
           admin: { description: 'Application that was halted by the block' },
         },
+        // BTB-202: manual block-clear audit fields
+        {
+          name: 'clearStatus',
+          type: 'text',
+          admin: { description: 'Status of the most recent block-clear request (e.g. approved, rejected)' },
+        },
+        {
+          name: 'clearedAt',
+          type: 'date',
+          admin: { description: 'When the block was cleared' },
+        },
       ],
     },
     {

--- a/src/collections/ReapplicationBlockClearRequests.ts
+++ b/src/collections/ReapplicationBlockClearRequests.ts
@@ -1,0 +1,265 @@
+import type { CollectionConfig, Access } from 'payload'
+import { hideFromNonAdmins, isAdmin, hasApprovalAuthority, canService, hasAnyRole } from '@/lib/access'
+
+/**
+ * Access control: Any authenticated user with a valid role can read clear requests
+ */
+const canRead: Access = ({ req }) => {
+  return hasAnyRole(req.user)
+}
+
+/**
+ * Access control: Operations, Supervisor, and Admin can create clear requests
+ */
+const canCreate: Access = ({ req }) => {
+  return canService(req.user)
+}
+
+/**
+ * Access control: Only Admin and Supervisor can update (approve/reject)
+ */
+const canUpdate: Access = ({ req }) => {
+  return hasApprovalAuthority(req.user)
+}
+
+/**
+ * Access control: Only Admin can delete clear requests
+ */
+const canDelete: Access = ({ req }) => {
+  return isAdmin(req.user)
+}
+
+/**
+ * Reapplication Block Clear Requests Collection
+ *
+ * Stores requests to clear a customer's reapplication block, requiring
+ * approval workflow. Part of the manual block-clear feature (BTB-202).
+ */
+export const ReapplicationBlockClearRequests: CollectionConfig = {
+  slug: 'reapplication-block-clear-requests',
+  admin: {
+    useAsTitle: 'requestNumber',
+    group: 'Servicing',
+    defaultColumns: ['requestNumber', 'status', 'canonicalCustomerId', 'customerName', 'createdAt'],
+    description: 'Reapplication block clear requests requiring approval',
+    // Hide from sidebar for non-admins
+    hidden: hideFromNonAdmins,
+  },
+  access: {
+    read: canRead,
+    create: canCreate,
+    update: canUpdate,
+    delete: canDelete,
+  },
+  hooks: {
+    beforeChange: [
+      async ({ data, operation }) => {
+        // Generate request number on create (only if not provided by event processor)
+        if (operation === 'create' && !data.requestNumber) {
+          const timestamp = Date.now().toString(36).toUpperCase()
+          const random = Math.random().toString(36).substring(2, 6).toUpperCase()
+          data.requestNumber = `RBC-${timestamp}-${random}`
+        }
+        return data
+      },
+    ],
+  },
+  fields: [
+    // ==========================================================================
+    // Event Sourcing Fields
+    // These fields link the projection to the original events for correlation
+    // and polling. Populated by the Python event processor.
+    // ==========================================================================
+    {
+      name: 'requestId',
+      type: 'text',
+      required: true,
+      unique: true,
+      index: true,
+      admin: {
+        description: 'Event correlation ID (conv field). Groups related events in a workflow.',
+        position: 'sidebar',
+      },
+    },
+    {
+      name: 'eventId',
+      type: 'text',
+      index: true,
+      admin: {
+        description: 'Event ID for polling lookup (cause field). Used by client to find projection after command.',
+        position: 'sidebar',
+      },
+    },
+    // ==========================================================================
+    // Request Identification
+    // ==========================================================================
+    {
+      name: 'requestNumber',
+      type: 'text',
+      admin: {
+        readOnly: true,
+        description: 'Human-readable request reference number (e.g., RBC-20241211...). Auto-generated if not provided.',
+      },
+      index: true,
+    },
+    {
+      name: 'canonicalCustomerId',
+      type: 'text',
+      required: true,
+      index: true,
+      admin: {
+        description: 'The canonical customer ID whose reapplication block is being cleared',
+      },
+    },
+    {
+      name: 'conversationId',
+      type: 'text',
+      admin: {
+        description: 'The conversation (application) ID associated with the block',
+      },
+    },
+    {
+      name: 'customerName',
+      type: 'text',
+      admin: {
+        description: 'Customer name for display purposes',
+      },
+    },
+    {
+      name: 'reasons',
+      type: 'json',
+      admin: {
+        description: 'List of reasons for the clear request (e.g. ["SERVICEABILITY"])',
+      },
+    },
+    {
+      name: 'justification',
+      type: 'textarea',
+      admin: {
+        description: 'Supporting justification for the clear request',
+      },
+    },
+    {
+      name: 'status',
+      type: 'select',
+      required: true,
+      defaultValue: 'pending',
+      options: [
+        { label: 'Pending Approval', value: 'pending' },
+        { label: 'Approved', value: 'approved' },
+        { label: 'Rejected', value: 'rejected' },
+        { label: 'Cancelled', value: 'cancelled' },
+      ],
+      index: true,
+      admin: {
+        description: 'Current status of the clear request',
+      },
+    },
+    // Requestor information
+    {
+      name: 'requestedBy',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: {
+        description: 'User who submitted the request',
+      },
+    },
+    {
+      name: 'requestedByName',
+      type: 'text',
+      admin: {
+        description: 'Requestor name for audit purposes',
+      },
+    },
+    // Approval information (for approved/rejected status)
+    {
+      name: 'approvalDetails',
+      type: 'group',
+      admin: {
+        condition: (data) => data?.status === 'approved' || data?.status === 'rejected',
+      },
+      fields: [
+        {
+          name: 'approvedBy',
+          type: 'text',
+          admin: {
+            description: 'User ID who approved (from event)',
+          },
+        },
+        {
+          name: 'approvedByName',
+          type: 'text',
+        },
+        {
+          name: 'approvedAt',
+          type: 'date',
+        },
+        {
+          name: 'comment',
+          type: 'textarea',
+          admin: {
+            description: 'Approval or rejection comment',
+          },
+        },
+        {
+          name: 'rejectedBy',
+          type: 'text',
+          admin: {
+            description: 'User ID who rejected (from event)',
+          },
+        },
+        {
+          name: 'rejectedByName',
+          type: 'text',
+        },
+        {
+          name: 'rejectedAt',
+          type: 'date',
+        },
+        {
+          name: 'reason',
+          type: 'textarea',
+          admin: {
+            description: 'Rejection reason (from event)',
+          },
+        },
+      ],
+    },
+    // Cancellation information (for cancelled status)
+    {
+      name: 'cancellationDetails',
+      type: 'group',
+      admin: {
+        condition: (data) => data?.status === 'cancelled',
+      },
+      fields: [
+        {
+          name: 'cancelledBy',
+          type: 'text',
+          admin: {
+            description: 'User ID who cancelled (from event)',
+          },
+        },
+        {
+          name: 'cancelledByName',
+          type: 'text',
+        },
+        {
+          name: 'cancelledAt',
+          type: 'date',
+        },
+      ],
+    },
+    // Audit fields
+    {
+      name: 'requestedAt',
+      type: 'date',
+      admin: {
+        readOnly: true,
+        description: 'Timestamp when request was submitted',
+      },
+      defaultValue: () => new Date().toISOString(),
+    },
+  ],
+  timestamps: true,
+}

--- a/src/components/ApprovalsView/ApprovalsView.tsx
+++ b/src/components/ApprovalsView/ApprovalsView.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { stringify } from 'qs-esm'
 import { ApprovalsList } from './ApprovalsList'
+import { BlockClearList } from './BlockClearList'
 import { HistoryTab } from './HistoryTab'
 import { Breadcrumb } from '@/components/Breadcrumb'
 import styles from './styles.module.css'
@@ -50,7 +51,7 @@ export const ApprovalsView: React.FC<ApprovalsViewProps> = ({
     queryFn: async () => {
       const queryString = stringify(
         { where: { status: { equals: 'pending' } }, limit: 0 },
-        { addQueryPrefix: true }
+        { addQueryPrefix: true },
       )
       const res = await fetch(`/api/write-off-requests${queryString}`)
       if (!res.ok) return 0
@@ -68,8 +69,8 @@ export const ApprovalsView: React.FC<ApprovalsViewProps> = ({
           <span className={styles.accessDeniedIcon}>🔒</span>
           <h2 className={styles.accessDeniedTitle}>Access Denied</h2>
           <p className={styles.accessDeniedText}>
-            You don&apos;t have permission to view the approvals queue.
-            This area is restricted to supervisors and administrators.
+            You don&apos;t have permission to view the approvals queue. This area is restricted to
+            supervisors and administrators.
           </p>
         </div>
       </div>
@@ -83,9 +84,7 @@ export const ApprovalsView: React.FC<ApprovalsViewProps> = ({
 
       {/* Header */}
       <div className={styles.approvalsHeader}>
-        <h1 className={styles.approvalsTitle}>
-          Write-Off Approvals
-        </h1>
+        <h1 className={styles.approvalsTitle}>Write-Off Approvals</h1>
       </div>
 
       {/* Tab Navigation */}
@@ -125,6 +124,28 @@ export const ApprovalsView: React.FC<ApprovalsViewProps> = ({
       {activeTab === 'pending' && (
         <div role="tabpanel" id="panel-pending" aria-labelledby="tab-pending">
           <ApprovalsList currentUserId={userId} currentUserName={userName} />
+
+          {/* Block-clear requests queue — additive section, parallel to write-offs */}
+          <div
+            style={{
+              marginTop: '2.5rem',
+              borderTop: '1px solid var(--border)',
+              paddingTop: '1.5rem',
+            }}
+            data-testid="block-clears-section"
+          >
+            <h2
+              style={{
+                fontSize: '1.125rem',
+                fontWeight: 600,
+                margin: '0 0 1rem 0',
+                color: 'inherit',
+              }}
+            >
+              Block Clear Requests
+            </h2>
+            <BlockClearList currentUserId={userId} currentUserName={userName} />
+          </div>
         </div>
       )}
       {activeTab === 'history' && (

--- a/src/components/ApprovalsView/BlockClearDetailDrawer.tsx
+++ b/src/components/ApprovalsView/BlockClearDetailDrawer.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import React, { useState, useCallback } from 'react'
+import { ContextDrawer, CopyButton } from '@/components/ui'
+import type { BlockClearRequest } from '@/hooks/queries/usePendingBlockClears'
+import { useApproveBlockClear } from '@/hooks/mutations/useApproveBlockClear'
+import { useRejectBlockClear } from '@/hooks/mutations/useRejectBlockClear'
+import { formatDateMedium } from '@/lib/formatters'
+import { ApprovalActionModal, type ActionType } from './ApprovalActionModal'
+import styles from './styles.module.css'
+
+export interface BlockClearDetailDrawerProps {
+  request: BlockClearRequest | null
+  isOpen: boolean
+  onClose: () => void
+  /** Current user's ID for segregation of duties check */
+  currentUserId?: string
+  /** Current user's name for audit trail */
+  currentUserName?: string
+}
+
+/**
+ * Drawer showing detailed information about a reapplication block-clear request.
+ * Includes approve/reject actions with segregation of duties (self-approval disabled).
+ *
+ * Parallel to ApprovalDetailDrawer — does not modify the write-off approval path.
+ */
+export const BlockClearDetailDrawer: React.FC<BlockClearDetailDrawerProps> = ({
+  request,
+  isOpen,
+  onClose,
+  currentUserId,
+  currentUserName: _currentUserName,
+}) => {
+  const [modalOpen, setModalOpen] = useState(false)
+  const [modalAction, setModalAction] = useState<ActionType>('approve')
+
+  const { approveAsync, isPending: isApproving } = useApproveBlockClear()
+  const { rejectAsync, isPending: isRejecting } = useRejectBlockClear()
+
+  const isPending = isApproving || isRejecting
+
+  // Segregation of duties: cannot approve own request.
+  // Handle requestedBy being either a string ID or a populated user object.
+  // Mirrors ApprovalDetailDrawer.getRequestedById exactly.
+  const getRequestedById = (): string | undefined => {
+    if (!request?.requestedBy) return undefined
+    if (typeof request.requestedBy === 'object' && request.requestedBy !== null) {
+      return String((request.requestedBy as { id?: string | number }).id)
+    }
+    return String(request.requestedBy)
+  }
+
+  const requestedById = getRequestedById()
+  const isOwnRequest = Boolean(
+    currentUserId && requestedById && String(currentUserId) === requestedById,
+  )
+
+  const handleApproveClick = useCallback(() => {
+    setModalAction('approve')
+    setModalOpen(true)
+  }, [])
+
+  const handleRejectClick = useCallback(() => {
+    setModalAction('reject')
+    setModalOpen(true)
+  }, [])
+
+  const handleModalClose = useCallback(() => {
+    setModalOpen(false)
+  }, [])
+
+  const handleModalConfirm = useCallback(
+    async (comment: string) => {
+      if (!request) return
+
+      // Use requestId for event correlation, fallback to id for older records
+      const requestId = request.requestId || request.id
+
+      if (modalAction === 'approve') {
+        await approveAsync({
+          requestId,
+          requestNumber: request.requestNumber,
+          comment,
+        })
+      } else {
+        await rejectAsync({
+          requestId,
+          requestNumber: request.requestNumber,
+          reason: comment,
+        })
+      }
+
+      setModalOpen(false)
+      onClose()
+    },
+    [request, modalAction, approveAsync, rejectAsync, onClose],
+  )
+
+  if (!request) return null
+
+  const requestDate = new Date(request.requestedAt || request.createdAt)
+
+  return (
+    <ContextDrawer isOpen={isOpen} onClose={onClose} title="Block-Clear Request Details">
+      {/* Request Number Header */}
+      <div className={styles.detailHeader}>
+        <span className={styles.detailRequestNumber}>{request.requestNumber}</span>
+      </div>
+
+      {/* Customer Section */}
+      <div className={styles.detailSection}>
+        <h4 className={styles.detailSectionTitle}>Customer</h4>
+        <div className={styles.detailGrid}>
+          <div className={styles.detailItem}>
+            <span className={styles.detailLabel}>Customer Name</span>
+            <span className={styles.detailValue}>{request.customerName || 'Unknown Customer'}</span>
+          </div>
+          <div className={styles.detailItem}>
+            <span className={styles.detailLabel}>Canonical Customer ID</span>
+            <span className={`${styles.detailValue} ${styles.detailValueMono}`}>
+              {request.canonicalCustomerId}
+              <CopyButton value={request.canonicalCustomerId} label="Copy canonical customer ID" />
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Block Reasons Section */}
+      <div className={styles.detailSection}>
+        <h4 className={styles.detailSectionTitle}>Block Reasons</h4>
+        <ul data-testid="block-reasons-list" style={{ margin: 0, paddingLeft: '1.25rem' }}>
+          {request.reasons.map((reason) => (
+            <li key={reason} style={{ textTransform: 'capitalize', marginBottom: '0.25rem' }}>
+              {reason.replace(/_/g, ' ')}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Justification Section */}
+      <div className={styles.detailSection}>
+        <h4 className={styles.detailSectionTitle}>Justification</h4>
+        {request.justification ? (
+          <div className={styles.detailNotes}>{request.justification}</div>
+        ) : (
+          <div className={`${styles.detailNotes} ${styles.detailNoNotes}`}>
+            No justification provided.
+          </div>
+        )}
+      </div>
+
+      {/* Request Details Section */}
+      <div className={styles.detailSection}>
+        <h4 className={styles.detailSectionTitle}>Request Details</h4>
+        <div className={styles.detailGrid}>
+          <div className={styles.detailItem}>
+            <span className={styles.detailLabel}>Requested By</span>
+            <span className={styles.detailValue}>{request.requestedByName || 'Unknown User'}</span>
+          </div>
+          <div className={styles.detailItem}>
+            <span className={styles.detailLabel}>Requested At</span>
+            <span className={styles.detailValue}>{formatDateMedium(requestDate)}</span>
+          </div>
+          <div className={styles.detailItem}>
+            <span className={styles.detailLabel}>Status</span>
+            <span className={styles.detailValue} style={{ textTransform: 'capitalize' }}>
+              {request.status}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      {request.status === 'pending' && (
+        <div className={styles.actionButtons}>
+          <button
+            type="button"
+            className={`${styles.actionBtn} ${styles.actionBtnApprove}`}
+            onClick={handleApproveClick}
+            disabled={isPending || isOwnRequest}
+            title={isOwnRequest ? 'Cannot approve your own request' : 'Approve this request'}
+            data-testid="approve-button"
+          >
+            ✓ Approve
+            {isOwnRequest && (
+              <span className={styles.actionBtnDisabledReason}>Cannot approve own request</span>
+            )}
+          </button>
+          <button
+            type="button"
+            className={`${styles.actionBtn} ${styles.actionBtnReject}`}
+            onClick={handleRejectClick}
+            disabled={isPending}
+            data-testid="reject-button"
+          >
+            ✕ Reject
+          </button>
+        </div>
+      )}
+
+      {/* Approval Action Modal */}
+      <ApprovalActionModal
+        isOpen={modalOpen}
+        onClose={handleModalClose}
+        onConfirm={handleModalConfirm}
+        actionType={modalAction}
+        requestNumber={request.requestNumber}
+        isPending={isPending}
+      />
+    </ContextDrawer>
+  )
+}
+
+export default BlockClearDetailDrawer

--- a/src/components/ApprovalsView/BlockClearList.tsx
+++ b/src/components/ApprovalsView/BlockClearList.tsx
@@ -1,0 +1,245 @@
+'use client'
+
+import React, { useState, useCallback, useRef, useEffect } from 'react'
+import {
+  usePendingBlockClears,
+  type BlockClearRequest,
+  type PendingBlockClearsOptions,
+} from '@/hooks/queries/usePendingBlockClears'
+import { formatDateShort } from '@/lib/formatters'
+import { BlockClearDetailDrawer } from './BlockClearDetailDrawer'
+import styles from './styles.module.css'
+
+export interface BlockClearListProps {
+  /** Initial sort option */
+  initialSort?: PendingBlockClearsOptions['sort']
+  /** Current user's ID for segregation of duties */
+  currentUserId?: string
+  /** Current user's name for audit trail */
+  currentUserName?: string
+}
+
+/**
+ * Table component displaying the queue of pending reapplication block-clear requests.
+ * Supports sorting, pagination, and row click to view details.
+ *
+ * Parallel to ApprovalsList — does not modify the write-off approval path.
+ */
+export const BlockClearList: React.FC<BlockClearListProps> = ({
+  initialSort = 'oldest',
+  currentUserId,
+  currentUserName,
+}) => {
+  const [page, setPage] = useState(1)
+  const [sort, setSort] = useState<PendingBlockClearsOptions['sort']>(initialSort)
+  const [selectedRequest, setSelectedRequest] = useState<BlockClearRequest | null>(null)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const { data, isLoading, isError, error, refetch, isFetching } = usePendingBlockClears({
+    page,
+    limit: 20,
+    sort,
+  })
+
+  const handleSortChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSort(e.target.value as PendingBlockClearsOptions['sort'])
+    setPage(1)
+  }, [])
+
+  const handleRowClick = useCallback((request: BlockClearRequest) => {
+    setSelectedRequest(request)
+    setDrawerOpen(true)
+  }, [])
+
+  const handleCloseDrawer = useCallback(() => {
+    setDrawerOpen(false)
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current)
+    }
+    closeTimeoutRef.current = setTimeout(() => {
+      setSelectedRequest(null)
+      closeTimeoutRef.current = null
+    }, 300)
+  }, [])
+
+  const handleRefresh = useCallback(() => {
+    refetch()
+  }, [refetch])
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className={styles.loadingState} data-testid="block-clears-loading">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className={styles.loadingRow} />
+        ))}
+      </div>
+    )
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <div className={styles.errorState} data-testid="block-clears-error">
+        <span className={styles.errorStateIcon}>⚠️</span>
+        <p className={styles.errorStateText}>
+          {error instanceof Error ? error.message : 'Failed to load block-clear requests'}
+        </p>
+        <button type="button" className={styles.retryBtn} onClick={() => refetch()}>
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  // Empty state
+  if (!data?.docs.length) {
+    return (
+      <div className={styles.emptyState} data-testid="block-clears-empty">
+        <span className={styles.emptyStateIcon}>✅</span>
+        <h3 className={styles.emptyStateTitle}>No pending block-clear requests</h3>
+        <p className={styles.emptyStateText}>
+          All block-clear requests have been processed. Check back later.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {/* Controls */}
+      <div className={styles.approvalsControls}>
+        <select
+          className={styles.sortSelect}
+          value={sort}
+          onChange={handleSortChange}
+          data-testid="block-clears-sort"
+        >
+          <option value="oldest">Oldest First</option>
+          <option value="newest">Newest First</option>
+        </select>
+        <button
+          type="button"
+          className={styles.refreshBtn}
+          onClick={handleRefresh}
+          disabled={isFetching}
+          data-testid="block-clears-refresh"
+        >
+          <svg
+            className={`${styles.refreshIcon} ${isFetching ? styles.refreshIconSpinning : ''}`}
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M14 8A6 6 0 1 1 8 2" />
+            <path d="M14 2v6h-6" />
+          </svg>
+          Refresh
+        </button>
+      </div>
+
+      {/* Table */}
+      <table
+        className={styles.queueTable}
+        data-testid="block-clears-table"
+        aria-label="Pending block-clear requests"
+      >
+        <thead className={styles.queueTableHeader}>
+          <tr>
+            <th>Request #</th>
+            <th>Customer</th>
+            <th>Reasons</th>
+            <th>Requestor</th>
+            <th>Age</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.docs.map((request) => {
+            const requestDate = new Date(request.requestedAt || request.createdAt)
+            const isSelected = selectedRequest?.id === request.id && drawerOpen
+            const ageDays = Math.floor((Date.now() - requestDate.getTime()) / (1000 * 60 * 60 * 24))
+
+            return (
+              <tr
+                key={request.id}
+                className={`${styles.queueTableRow} ${isSelected ? styles.queueTableRowSelected : ''}`}
+                onClick={() => handleRowClick(request)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    handleRowClick(request)
+                  }
+                }}
+                tabIndex={0}
+                role="button"
+                aria-label={`View block-clear request ${request.requestNumber} for ${request.customerName || 'unknown customer'}`}
+                data-testid={`block-clear-row-${request.id}`}
+              >
+                <td className={styles.cellDate}>{request.requestNumber}</td>
+                <td className={styles.cellCustomer}>
+                  {request.customerName || 'Unknown Customer'}
+                </td>
+                <td className={styles.cellRequestor}>{request.reasons.join(', ')}</td>
+                <td className={styles.cellRequestor}>{request.requestedByName || 'Unknown'}</td>
+                <td className={styles.cellDate}>
+                  {ageDays === 0 ? formatDateShort(requestDate) : `${ageDays}d`}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+
+      {/* Pagination */}
+      {data.totalPages > 1 && (
+        <div className={styles.pagination}>
+          <span className={styles.paginationInfo}>
+            Page {data.page} of {data.totalPages} ({data.totalDocs} total requests)
+          </span>
+          <div className={styles.paginationButtons}>
+            <button
+              type="button"
+              className={styles.paginationBtn}
+              onClick={() => setPage((p) => p - 1)}
+              disabled={!data.hasPrevPage}
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              className={styles.paginationBtn}
+              onClick={() => setPage((p) => p + 1)}
+              disabled={!data.hasNextPage}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Detail Drawer */}
+      <BlockClearDetailDrawer
+        request={selectedRequest}
+        isOpen={drawerOpen}
+        onClose={handleCloseDrawer}
+        currentUserId={currentUserId}
+        currentUserName={currentUserName}
+      />
+    </>
+  )
+}
+
+export default BlockClearList

--- a/src/components/ApprovalsView/BlockClearList.tsx
+++ b/src/components/ApprovalsView/BlockClearList.tsx
@@ -35,6 +35,10 @@ export const BlockClearList: React.FC<BlockClearListProps> = ({
   const [selectedRequest, setSelectedRequest] = useState<BlockClearRequest | null>(null)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  // Capture "now" once at mount (lazy initializer) rather than calling the impure
+  // Date.now() during render — row ages are relative to this reference. Day-grain
+  // ageing doesn't need to tick live; a remount/refetch re-reads it.
+  const [nowMs] = useState(() => Date.now())
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -170,7 +174,7 @@ export const BlockClearList: React.FC<BlockClearListProps> = ({
           {data.docs.map((request) => {
             const requestDate = new Date(request.requestedAt || request.createdAt)
             const isSelected = selectedRequest?.id === request.id && drawerOpen
-            const ageDays = Math.floor((Date.now() - requestDate.getTime()) / (1000 * 60 * 60 * 24))
+            const ageDays = Math.floor((nowMs - requestDate.getTime()) / (1000 * 60 * 60 * 24))
 
             return (
               <tr
@@ -192,7 +196,7 @@ export const BlockClearList: React.FC<BlockClearListProps> = ({
                 <td className={styles.cellCustomer}>
                   {request.customerName || 'Unknown Customer'}
                 </td>
-                <td className={styles.cellRequestor}>{request.reasons.join(', ')}</td>
+                <td className={styles.cellRequestor}>{(request.reasons ?? []).join(', ') || '—'}</td>
                 <td className={styles.cellRequestor}>{request.requestedByName || 'Unknown'}</td>
                 <td className={styles.cellDate}>
                   {ageDays === 0 ? formatDateShort(requestDate) : `${ageDays}d`}

--- a/src/components/ApprovalsView/index.ts
+++ b/src/components/ApprovalsView/index.ts
@@ -10,6 +10,12 @@ export type { ApprovalDetailDrawerProps } from './ApprovalDetailDrawer'
 export { ApprovalActionModal } from './ApprovalActionModal'
 export type { ApprovalActionModalProps, ActionType } from './ApprovalActionModal'
 
+export { BlockClearList } from './BlockClearList'
+export type { BlockClearListProps } from './BlockClearList'
+
+export { BlockClearDetailDrawer } from './BlockClearDetailDrawer'
+export type { BlockClearDetailDrawerProps } from './BlockClearDetailDrawer'
+
 export { HistoryTab } from './HistoryTab'
 export type { HistoryTabProps } from './HistoryTab'
 

--- a/src/components/BlockClear/BlockClear.module.css
+++ b/src/components/BlockClear/BlockClear.module.css
@@ -1,0 +1,265 @@
+/* BlockClear — ClearBlockModal + ClearBlockButton styles */
+
+/* ===== Modal Overlay ===== */
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.modalContent {
+  background: var(--theme-elevation-50, #1a1a1a);
+  border: 1px solid var(--theme-elevation-200, #333);
+  border-radius: 12px;
+  max-width: 520px;
+  width: 100%;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--theme-elevation-200, #333);
+}
+
+.modalTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--theme-text, #fff);
+}
+
+.modalCloseBtn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--theme-elevation-500, #888);
+  font-size: 16px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.modalCloseBtn:hover:not(:disabled) {
+  background: var(--theme-elevation-100, #2a2a2a);
+}
+
+.modalCloseBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.modalBody {
+  padding: 20px;
+}
+
+.modalFooter {
+  display: flex;
+  gap: 12px;
+  padding: 16px 20px;
+  border-top: 1px solid var(--theme-elevation-200, #333);
+}
+
+/* ===== Approval Notice ===== */
+.approvalNotice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 6px;
+  font-size: 13px;
+  color: #f59e0b;
+  margin-bottom: 16px;
+}
+
+/* ===== Form Fields ===== */
+.fieldGroup {
+  margin-bottom: 16px;
+}
+
+.fieldLabel {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--theme-text, #fff);
+}
+
+.checkboxList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--theme-text, #fff);
+  cursor: pointer;
+}
+
+.checkboxLabel input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.checkboxLabel input[type='checkbox']:disabled {
+  cursor: not-allowed;
+}
+
+.approvalBadge {
+  display: inline-block;
+  padding: 2px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 4px;
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  margin-left: 4px;
+}
+
+.textarea {
+  width: 100%;
+  padding: 12px;
+  border: 1px solid var(--theme-elevation-200, #444);
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 100px;
+  outline: none;
+  background: var(--theme-elevation-100, #2a2a2a);
+  color: var(--theme-text, #fff);
+  box-sizing: border-box;
+}
+
+.textarea:focus {
+  box-shadow: 0 0 0 2px #3b82f6;
+  border-color: #3b82f6;
+}
+
+.textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.charCount {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--theme-elevation-500, #888);
+}
+
+/* ===== Modal Buttons ===== */
+.cancelBtn {
+  flex: 1;
+  padding: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  border: 1px solid var(--theme-elevation-200, #444);
+  border-radius: 6px;
+  background: var(--theme-elevation-100, #2a2a2a);
+  color: var(--theme-text, #fff);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.cancelBtn:hover:not(:disabled) {
+  background: var(--theme-elevation-150, #333);
+}
+
+.cancelBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.submitBtn {
+  flex: 1;
+  padding: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  border: none;
+  border-radius: 6px;
+  background: #3b82f6;
+  color: #fff;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.submitBtn:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+.submitBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ===== ClearBlockButton (inline trigger) ===== */
+.clearBlockContainer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.clearBlockBtn {
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  border-radius: 6px;
+  background: rgba(59, 130, 246, 0.1);
+  color: #3b82f6;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.clearBlockBtn:hover {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.6);
+}
+
+.clearBlockBtnDisabled {
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid var(--theme-elevation-200, #444);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--theme-elevation-400, #666);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.clearStatusPending {
+  font-size: 12px;
+  color: #f59e0b;
+}
+
+.clearStatusRejected {
+  font-size: 12px;
+  color: #ef4444;
+}

--- a/src/components/BlockClear/ClearBlockButton.tsx
+++ b/src/components/BlockClear/ClearBlockButton.tsx
@@ -48,12 +48,22 @@ export function ClearBlockButton({ block, conversationId, customerName }: ClearB
   return (
     <>
       <div className={styles.clearBlockContainer}>
-        {isClearable ? (
+        {isClearable && canonicalCustomerId ? (
           <button
             type="button"
             className={styles.clearBlockBtn}
             onClick={() => setModalOpen(true)}
             data-testid="clear-block-btn"
+          >
+            Clear block
+          </button>
+        ) : isClearable && !canonicalCustomerId ? (
+          <button
+            type="button"
+            className={styles.clearBlockBtnDisabled}
+            disabled
+            title="Customer identity not yet resolved — can't clear here."
+            data-testid="clear-block-btn-disabled"
           >
             Clear block
           </button>

--- a/src/components/BlockClear/ClearBlockButton.tsx
+++ b/src/components/BlockClear/ClearBlockButton.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useAuth } from '@payloadcms/ui'
+import { canService } from '@/lib/access'
+import { CLEARABLE_REASONS } from '@/lib/events/config'
+import type { ClearableReason } from '@/lib/events/config'
+import { ClearBlockModal } from './ClearBlockModal'
+import styles from './BlockClear.module.css'
+
+export interface ClearBlockButtonProps {
+  block?: {
+    reason?: string | null
+    canonicalCustomerId?: string | null
+    clearStatus?: string | null
+    clearedAt?: string | null
+  } | null
+  conversationId?: string
+  customerName?: string
+}
+
+/**
+ * Inline trigger for the Clear-block workflow.
+ *
+ * Role gate: only admin, supervisor, and operations users see this button.
+ * Visible only when a block has an uncleared reason.
+ *
+ * If the current block reason is not clearable by operators
+ * (e.g. ACTIVE_LOAN, PEP, IDENTITY_CONFLICT) the button is rendered
+ * disabled with an explanatory tooltip rather than hidden.
+ *
+ * If a clear request is already pending or was previously rejected, a status
+ * label is shown alongside the button.
+ */
+export function ClearBlockButton({ block, conversationId, customerName }: ClearBlockButtonProps) {
+  const { user } = useAuth()
+  const [modalOpen, setModalOpen] = useState(false)
+
+  // Role gate — only canService roles (admin, supervisor, operations)
+  if (!canService(user)) return null
+
+  // Only render when there is a live block (has a reason and hasn't been cleared)
+  if (!block?.reason || block.clearedAt) return null
+
+  const isClearable = CLEARABLE_REASONS.includes(block.reason as ClearableReason)
+  const canonicalCustomerId = block.canonicalCustomerId
+
+  return (
+    <>
+      <div className={styles.clearBlockContainer}>
+        {isClearable ? (
+          <button
+            type="button"
+            className={styles.clearBlockBtn}
+            onClick={() => setModalOpen(true)}
+            data-testid="clear-block-btn"
+          >
+            Clear block
+          </button>
+        ) : (
+          <button
+            type="button"
+            className={styles.clearBlockBtnDisabled}
+            disabled
+            title="This block type can't be cleared here"
+            data-testid="clear-block-btn-disabled"
+          >
+            Clear block
+          </button>
+        )}
+
+        {block.clearStatus === 'pending' && (
+          <span className={styles.clearStatusPending}>(Approval pending)</span>
+        )}
+        {block.clearStatus === 'rejected' && (
+          <span className={styles.clearStatusRejected}>(Previously rejected)</span>
+        )}
+      </div>
+
+      {isClearable && canonicalCustomerId && (
+        <ClearBlockModal
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
+          canonicalCustomerId={canonicalCustomerId}
+          currentReason={block.reason}
+          conversationId={conversationId}
+          customerName={customerName}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/BlockClear/ClearBlockModal.tsx
+++ b/src/components/BlockClear/ClearBlockModal.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import React, { useState, useCallback, useEffect, useRef } from 'react'
+import { MIN_APPROVAL_COMMENT_LENGTH } from '@/lib/constants'
+import { CLEARABLE_REASONS, REASONS_REQUIRING_APPROVAL } from '@/lib/events/config'
+import type { ClearableReason } from '@/lib/events/config'
+import { formatBlockReason } from '@/lib/reapplicationBlock'
+import { useRequestBlockClear } from '@/hooks/mutations/useRequestBlockClear'
+import styles from './BlockClear.module.css'
+
+export interface ClearBlockModalProps {
+  isOpen: boolean
+  onClose: () => void
+  canonicalCustomerId: string
+  currentReason?: string | null
+  conversationId?: string
+  customerName?: string
+}
+
+/**
+ * Modal for submitting a reapplication block-clear request.
+ *
+ * Presents a multi-select of clearable reasons (CLEARABLE_REASONS) and a
+ * mandatory justification field. When the operator selects a reason in
+ * REASONS_REQUIRING_APPROVAL, the modal shows an approval notice and labels
+ * the submit button "Request approval" (maker-checker path). Otherwise it
+ * goes direct (single-operator path).
+ *
+ * Pre-selects the block's current reason when it is clearable.
+ */
+export function ClearBlockModal({
+  isOpen,
+  onClose,
+  canonicalCustomerId,
+  currentReason,
+  conversationId,
+  customerName,
+}: ClearBlockModalProps) {
+  const { requestAsync, isPending } = useRequestBlockClear()
+  const modalRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const [selectedReasons, setSelectedReasons] = useState<string[]>([])
+  const [justification, setJustification] = useState('')
+
+  // Reset form state when modal opens; pre-select current reason if clearable.
+  useEffect(() => {
+    if (isOpen) {
+      const isClearable =
+        currentReason != null && CLEARABLE_REASONS.includes(currentReason as ClearableReason)
+      setSelectedReasons(isClearable ? [currentReason!] : [])
+      setJustification('')
+      setTimeout(() => textareaRef.current?.focus(), 0)
+    }
+  }, [isOpen, currentReason])
+
+  // Keyboard handler: Escape closes the modal (unless a submission is in-flight).
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape' && !isPending) {
+        onClose()
+      }
+    },
+    [isPending, onClose],
+  )
+
+  const toggleReason = useCallback((reason: string) => {
+    setSelectedReasons((prev) =>
+      prev.includes(reason) ? prev.filter((r) => r !== reason) : [...prev, reason],
+    )
+  }, [])
+
+  const requiresApproval = selectedReasons.some((r) =>
+    REASONS_REQUIRING_APPROVAL.includes(r as (typeof REASONS_REQUIRING_APPROVAL)[number]),
+  )
+
+  const charCount = justification.trim().length
+  const isValid = selectedReasons.length > 0 && charCount >= MIN_APPROVAL_COMMENT_LENGTH
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!isValid) return
+
+      try {
+        await requestAsync({
+          canonicalCustomerId,
+          reasons: selectedReasons,
+          justification: justification.trim(),
+          conversationId,
+          customerName,
+        })
+        onClose()
+      } catch {
+        // Error is surfaced by the mutation hook's onError handler; keep modal open.
+      }
+    },
+    [
+      isValid,
+      requestAsync,
+      canonicalCustomerId,
+      selectedReasons,
+      justification,
+      conversationId,
+      customerName,
+      onClose,
+    ],
+  )
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className={styles.modalOverlay}
+      onClick={isPending ? undefined : onClose}
+      onKeyDown={handleKeyDown}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="clear-block-modal-title"
+      data-testid="clear-block-modal"
+    >
+      <div
+        ref={modalRef}
+        className={styles.modalContent}
+        onClick={(e) => e.stopPropagation()}
+        role="document"
+      >
+        <div className={styles.modalHeader}>
+          <h2 id="clear-block-modal-title" className={styles.modalTitle}>
+            Clear Re-application Block
+          </h2>
+          <button
+            type="button"
+            className={styles.modalCloseBtn}
+            onClick={onClose}
+            disabled={isPending}
+            aria-label="Close modal"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className={styles.modalBody}>
+            {requiresApproval && (
+              <div className={styles.approvalNotice} data-testid="approval-notice">
+                Approval required — this clear will be sent for supervisor approval before taking
+                effect.
+              </div>
+            )}
+
+            <div className={styles.fieldGroup}>
+              <label className={styles.fieldLabel}>Reasons for clearing *</label>
+              <div className={styles.checkboxList}>
+                {CLEARABLE_REASONS.map((reason) => (
+                  <label key={reason} className={styles.checkboxLabel}>
+                    <input
+                      type="checkbox"
+                      checked={selectedReasons.includes(reason)}
+                      onChange={() => toggleReason(reason)}
+                      disabled={isPending}
+                      data-testid={`reason-checkbox-${reason}`}
+                    />
+                    <span>{formatBlockReason(reason)}</span>
+                    {REASONS_REQUIRING_APPROVAL.includes(
+                      reason as (typeof REASONS_REQUIRING_APPROVAL)[number],
+                    ) && <span className={styles.approvalBadge}>Approval required</span>}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className={styles.fieldGroup}>
+              <label className={styles.fieldLabel} htmlFor="block-clear-justification">
+                Justification *
+              </label>
+              <textarea
+                ref={textareaRef}
+                id="block-clear-justification"
+                className={styles.textarea}
+                placeholder="Enter your justification for clearing this block..."
+                value={justification}
+                onChange={(e) => setJustification(e.target.value)}
+                rows={4}
+                disabled={isPending}
+                data-testid="justification-input"
+              />
+              <div className={styles.charCount}>
+                {charCount}/{MIN_APPROVAL_COMMENT_LENGTH} characters minimum
+                {charCount >= MIN_APPROVAL_COMMENT_LENGTH && ' ✓'}
+              </div>
+            </div>
+          </div>
+
+          <div className={styles.modalFooter}>
+            <button
+              type="button"
+              className={styles.cancelBtn}
+              onClick={onClose}
+              disabled={isPending}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className={styles.submitBtn}
+              disabled={!isValid || isPending}
+              data-testid="submit-button"
+            >
+              {isPending ? 'Submitting...' : requiresApproval ? 'Request approval' : 'Clear block'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/BlockClear/index.ts
+++ b/src/components/BlockClear/index.ts
@@ -1,0 +1,4 @@
+export { ClearBlockButton } from './ClearBlockButton'
+export type { ClearBlockButtonProps } from './ClearBlockButton'
+export { ClearBlockModal } from './ClearBlockModal'
+export type { ClearBlockModalProps } from './ClearBlockModal'

--- a/src/components/ConversationDetailView/DecisionBanner/index.tsx
+++ b/src/components/ConversationDetailView/DecisionBanner/index.tsx
@@ -15,6 +15,7 @@ import {
   signalLabel,
 } from '@/lib/recognition'
 import { formatDateOnly } from '@/lib/formatters'
+import { ClearBlockButton } from '@/components/BlockClear'
 import styles from './styles.module.css'
 
 type ReapplicationBlock = NonNullable<ConversationDetail['reapplicationBlock']>
@@ -163,6 +164,13 @@ export function DecisionBanner({ conversation }: DecisionBannerProps) {
             </div>
           )}
         </div>
+      )}
+      {isBlockDecline && (
+        <ClearBlockButton
+          block={block}
+          conversationId={conversation.conversationId}
+          customerName={conversation.customer?.fullName ?? undefined}
+        />
       )}
     </div>
   )

--- a/src/components/ServicingView/ServicingView.tsx
+++ b/src/components/ServicingView/ServicingView.tsx
@@ -23,6 +23,7 @@ import type { SelectedFee } from './FeeList'
 import { AccountRail } from './AccountRail'
 import { AttentionStrip } from './AttentionStrip'
 import { ContextPane } from './ContextPane'
+import { ClearBlockButton } from '@/components/BlockClear'
 import { getAttentionItems, sortAccountsForRail } from '@/lib/accountTriage'
 import { usePendingWriteOff } from '@/hooks/queries/usePendingWriteOff'
 import { useTrackCustomerView } from '@/hooks/useTrackCustomerView'
@@ -104,7 +105,8 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
   const feesCount = useFeesCount(selectedAccountId)
 
   // Check for pending write-off (fail open: allow action if query errors)
-  const { data: pendingWriteOff, isError: pendingWriteOffError } = usePendingWriteOff(selectedAccountId)
+  const { data: pendingWriteOff, isError: pendingWriteOffError } =
+    usePendingWriteOff(selectedAccountId)
   // Only block if we have confirmed pending data; allow if error/loading (fail open for UX)
   const hasPendingWriteOff = !pendingWriteOffError && !!pendingWriteOff
 
@@ -117,10 +119,17 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
         // NOTE: pending-write-off detection is intentionally scoped to the SELECTED account because
         // `usePendingWriteOff` is a per-account query and the design avoids firing extra fetches for
         // every account on the rail. A customer-level pending-write-off query would be a follow-up.
-        pendingWriteOffAccountIds: selectedAccountId && hasPendingWriteOff ? [selectedAccountId] : [],
+        pendingWriteOffAccountIds:
+          selectedAccountId && hasPendingWriteOff ? [selectedAccountId] : [],
         reapplicationBlock: customer?.reapplicationBlock ?? null,
       }),
-    [customer?.vulnerableFlag, customer?.reapplicationBlock, accounts, selectedAccountId, hasPendingWriteOff]
+    [
+      customer?.vulnerableFlag,
+      customer?.reapplicationBlock,
+      accounts,
+      selectedAccountId,
+      hasPendingWriteOff,
+    ],
   )
 
   // Auto-select runs ONCE per mount (the component fully remounts on customer
@@ -306,12 +315,7 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
     return (
       <div className={styles.container}>
         {/* Breadcrumb navigation (Story 6.3) */}
-        <Breadcrumb
-          items={[
-            { label: `Customer ${customerId}` },
-            { label: 'Loading...' },
-          ]}
-        />
+        <Breadcrumb items={[{ label: `Customer ${customerId}` }, { label: 'Loading...' }]} />
         <div className={styles.header}>
           <h1 className={styles.headerTitle}>Customer Servicing</h1>
         </div>
@@ -334,10 +338,7 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
     <div className={styles.container}>
       {/* Breadcrumb navigation (Story 6.3) */}
       <Breadcrumb
-        items={[
-          { label: `Customer ${customerId}` },
-          { label: customer?.fullName || 'Loading...' },
-        ]}
+        items={[{ label: `Customer ${customerId}` }, { label: customer?.fullName || 'Loading...' }]}
       />
       <div className={styles.header}>
         <h1 className={styles.headerTitle}>Customer Servicing</h1>
@@ -348,6 +349,21 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
 
       {/* Customer-level attention chips (replaces the vulnerable banner) */}
       <AttentionStrip items={attentionItems} onSelectAccount={handleSwitchAccount} />
+
+      {/* Customer-level block-clear action (BTB-202). No conversationId — resolution
+          is a new application, not scoped to a single conversation. Self-gating:
+          only canService roles see this; disabled for non-clearable reasons (e.g.
+          ACTIVE_LOAN). canonicalCustomerId is the business key on the customer row. */}
+      {customer && (
+        <ClearBlockButton
+          block={
+            customer.reapplicationBlock
+              ? { ...customer.reapplicationBlock, canonicalCustomerId: customer.customerId }
+              : null
+          }
+          customerName={customer.fullName ?? undefined}
+        />
+      )}
 
       {/* Three-pane cockpit: triaged rail · account work-surface · customer context */}
       <div className={styles.cockpit}>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -40,12 +40,19 @@ export { useTriggerPortfolioRecalc } from './mutations/useTriggerPortfolioRecalc
 
 // Export Center mutations (E5)
 export { useCreateExportJob } from './mutations/useCreateExportJob'
-export type { CreateExportJobRequest, CreateExportJobResponse } from './mutations/useCreateExportJob'
+export type {
+  CreateExportJobRequest,
+  CreateExportJobResponse,
+} from './mutations/useCreateExportJob'
 export { useRetryExport } from './mutations/useRetryExport'
 
 // Investigation mutations (E6)
 export { useBatchQuery } from './mutations/useBatchQuery'
-export type { BatchQueryRequest, BatchQueryAccountResult, BatchQueryResponse } from './mutations/useBatchQuery'
+export type {
+  BatchQueryRequest,
+  BatchQueryAccountResult,
+  BatchQueryResponse,
+} from './mutations/useBatchQuery'
 export { useRandomSample } from './mutations/useRandomSample'
 export type { RandomSampleRequest, RandomSampleResponse } from './mutations/useRandomSample'
 
@@ -58,11 +65,7 @@ export {
   usePostIdentityRiskAssessment,
 } from './queries/useAssessments'
 export { useStatementFile, rawStatementFileUrl } from './queries/useStatementFile'
-export type {
-  StatementSlot,
-  StatementFileContent,
-  CsvData,
-} from './queries/useStatementFile'
+export type { StatementSlot, StatementFileContent, CsvData } from './queries/useStatementFile'
 
 // Notifications (E-notifications)
 export { useNotifications } from './queries/useNotifications'
@@ -78,6 +81,29 @@ export type { NotificationBodyData } from './queries/useNotificationBody'
 export { useSetNotificationSuppression } from './mutations/useSetNotificationSuppression'
 export type { SetSuppressionParams } from './mutations/useSetNotificationSuppression'
 export { useClearNotificationSuppression } from './mutations/useClearNotificationSuppression'
+
+// Block-Clear mutations (B3)
+export { useRequestBlockClear } from './mutations/useRequestBlockClear'
+export type { RequestBlockClearParams } from './mutations/useRequestBlockClear'
+export { useApproveBlockClear } from './mutations/useApproveBlockClear'
+export type {
+  ApproveBlockClearParams,
+  ApproveBlockClearResult,
+} from './mutations/useApproveBlockClear'
+export { useRejectBlockClear } from './mutations/useRejectBlockClear'
+export type {
+  RejectBlockClearParams,
+  RejectBlockClearResult,
+} from './mutations/useRejectBlockClear'
+export { useCancelBlockClear } from './mutations/useCancelBlockClear'
+export type {
+  CancelBlockClearParams,
+  CancelBlockClearResult,
+} from './mutations/useCancelBlockClear'
+
+// Block-Clear queries (B3)
+export { usePendingBlockClears } from './queries/usePendingBlockClears'
+export type { BlockClearRequest, PendingBlockClearsOptions } from './queries/usePendingBlockClears'
 
 // Re-export types from canonical location
 export type {

--- a/src/hooks/mutations/useApproveBlockClear.ts
+++ b/src/hooks/mutations/useApproveBlockClear.ts
@@ -1,0 +1,142 @@
+/**
+ * Approve Block-Clear Mutation Hook (Event-Sourced)
+ *
+ * Approves a reapplication block-clear request via the command API, which
+ * publishes an event to the CRM stream and chatLedger. Then polls for the
+ * status change in the reapplication-block-clear-requests collection.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { showErrorToast } from '@/lib/utils/error-toast'
+import { pollForBlockClearUpdate, PollTimeoutError } from '@/lib/events/poll'
+import type { BlockClearApproveCommand } from '@/lib/events/schemas'
+import type { PublishEventResponse } from '@/lib/events/types'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ApproveBlockClearParams {
+  /** Block-clear request ID */
+  requestId: string
+  /** Human-readable request number (e.g., BC-20241211...) */
+  requestNumber: string
+  /** Mandatory approval comment (min 10 chars) */
+  comment: string
+}
+
+export interface ApproveBlockClearResult {
+  id: string
+  requestNumber: string
+  requestId: string
+  status: 'approved'
+}
+
+// =============================================================================
+// API Functions
+// =============================================================================
+
+/**
+ * Publish approve command via the command API.
+ */
+async function publishApproveCommand(
+  params: ApproveBlockClearParams,
+): Promise<PublishEventResponse> {
+  const command: BlockClearApproveCommand = {
+    requestId: params.requestId,
+    requestNumber: params.requestNumber,
+    comment: params.comment.trim(),
+  }
+
+  const res = await fetch('/api/commands/reapp-block-clear/approve', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(command),
+  })
+
+  if (!res.ok) {
+    const error = await res
+      .json()
+      .catch(() => ({ error: { message: 'Failed to approve request' } }))
+    throw new Error(error.error?.message || 'Failed to approve block-clear request')
+  }
+
+  return res.json()
+}
+
+/**
+ * Approve block-clear request and poll for the status change.
+ */
+async function approveBlockClear(
+  params: ApproveBlockClearParams,
+): Promise<ApproveBlockClearResult> {
+  // 1. Publish the command event
+  await publishApproveCommand(params)
+
+  // 2. Poll for the status to change to 'approved'
+  const projection = await pollForBlockClearUpdate<ApproveBlockClearResult>(
+    params.requestId,
+    'approved',
+    {
+      maxAttempts: 10,
+      intervalMs: 500,
+      initialDelayMs: 100,
+    },
+  )
+
+  return projection
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Mutation hook for approving a reapplication block-clear request.
+ *
+ * Uses event sourcing: publishes command → polls for status change.
+ */
+export function useApproveBlockClear() {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: approveBlockClear,
+    retry: 0, // Don't retry on failure - let user retry manually
+
+    onSuccess: (data) => {
+      toast.success(`Block-clear request ${data.requestNumber} approved`, {
+        description: 'The reapplication block has been cleared.',
+      })
+      queryClient.invalidateQueries({ queryKey: ['block-clear-requests'] })
+      queryClient.invalidateQueries({ queryKey: ['pending-block-clears'] })
+    },
+
+    onError: (error) => {
+      // Handle polling timeout specifically
+      if (error instanceof PollTimeoutError) {
+        toast.warning('Approval submitted but confirmation delayed', {
+          description:
+            'Your approval was accepted but is taking longer than expected. Please refresh to see the status.',
+        })
+        queryClient.invalidateQueries({ queryKey: ['block-clear-requests'] })
+        queryClient.invalidateQueries({ queryKey: ['pending-block-clears'] })
+        return
+      }
+
+      showErrorToast(error, {
+        title: 'Failed to approve request',
+        action: 'approve-block-clear',
+      })
+    },
+  })
+
+  return {
+    approve: mutation.mutate,
+    approveAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    isError: mutation.isError,
+    error: mutation.error,
+  }
+}

--- a/src/hooks/mutations/useCancelBlockClear.ts
+++ b/src/hooks/mutations/useCancelBlockClear.ts
@@ -1,0 +1,134 @@
+/**
+ * Cancel Block-Clear Mutation Hook (Event-Sourced)
+ *
+ * Cancels a pending reapplication block-clear request via the command API,
+ * which publishes an event to the CRM stream. Then polls for the status change.
+ *
+ * Typically used by the original requester to withdraw their request.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { showErrorToast } from '@/lib/utils/error-toast'
+import { pollForBlockClearUpdate, PollTimeoutError } from '@/lib/events/poll'
+import type { BlockClearCancelCommand } from '@/lib/events/schemas'
+import type { PublishEventResponse } from '@/lib/events/types'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface CancelBlockClearParams {
+  /** Block-clear request ID */
+  requestId: string
+  /** Human-readable request number (e.g., BC-20241211...) */
+  requestNumber: string
+}
+
+export interface CancelBlockClearResult {
+  id: string
+  requestNumber: string
+  requestId: string
+  status: 'cancelled'
+}
+
+// =============================================================================
+// API Functions
+// =============================================================================
+
+/**
+ * Publish cancel command via the command API.
+ */
+async function publishCancelCommand(params: CancelBlockClearParams): Promise<PublishEventResponse> {
+  const command: BlockClearCancelCommand = {
+    requestId: params.requestId,
+    requestNumber: params.requestNumber,
+  }
+
+  const res = await fetch('/api/commands/reapp-block-clear/cancel', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(command),
+  })
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ error: { message: 'Failed to cancel request' } }))
+    throw new Error(error.error?.message || 'Failed to cancel block-clear request')
+  }
+
+  return res.json()
+}
+
+/**
+ * Cancel block-clear request and poll for the status change.
+ */
+async function cancelBlockClear(params: CancelBlockClearParams): Promise<CancelBlockClearResult> {
+  // 1. Publish the command event
+  await publishCancelCommand(params)
+
+  // 2. Poll for the status to change to 'cancelled'
+  const projection = await pollForBlockClearUpdate<CancelBlockClearResult>(
+    params.requestId,
+    'cancelled',
+    {
+      maxAttempts: 10,
+      intervalMs: 500,
+      initialDelayMs: 100,
+    },
+  )
+
+  return projection
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Mutation hook for cancelling a reapplication block-clear request.
+ *
+ * Uses event sourcing: publishes command → polls for status change.
+ */
+export function useCancelBlockClear() {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: cancelBlockClear,
+    retry: 0, // Don't retry on failure - let user retry manually
+
+    onSuccess: (data) => {
+      toast.success(`Block-clear request ${data.requestNumber} cancelled`, {
+        description: 'The request has been withdrawn.',
+      })
+      queryClient.invalidateQueries({ queryKey: ['block-clear-requests'] })
+      queryClient.invalidateQueries({ queryKey: ['pending-block-clears'] })
+    },
+
+    onError: (error) => {
+      // Handle polling timeout specifically
+      if (error instanceof PollTimeoutError) {
+        toast.warning('Cancellation submitted but confirmation delayed', {
+          description:
+            'Your cancellation was accepted but is taking longer than expected. Please refresh to see the status.',
+        })
+        queryClient.invalidateQueries({ queryKey: ['block-clear-requests'] })
+        queryClient.invalidateQueries({ queryKey: ['pending-block-clears'] })
+        return
+      }
+
+      showErrorToast(error, {
+        title: 'Failed to cancel request',
+        action: 'cancel-block-clear',
+      })
+    },
+  })
+
+  return {
+    cancel: mutation.mutate,
+    cancelAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    isError: mutation.isError,
+    error: mutation.error,
+  }
+}

--- a/src/hooks/mutations/useRejectBlockClear.ts
+++ b/src/hooks/mutations/useRejectBlockClear.ts
@@ -1,0 +1,135 @@
+/**
+ * Reject Block-Clear Mutation Hook (Event-Sourced)
+ *
+ * Rejects a reapplication block-clear request via the command API, which
+ * publishes an event to the CRM stream. Then polls for the status change.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { showErrorToast } from '@/lib/utils/error-toast'
+import { pollForBlockClearUpdate, PollTimeoutError } from '@/lib/events/poll'
+import type { BlockClearRejectCommand } from '@/lib/events/schemas'
+import type { PublishEventResponse } from '@/lib/events/types'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface RejectBlockClearParams {
+  /** Block-clear request ID */
+  requestId: string
+  /** Human-readable request number (e.g., BC-20241211...) */
+  requestNumber: string
+  /** Mandatory rejection reason (min 10 chars) */
+  reason: string
+}
+
+export interface RejectBlockClearResult {
+  id: string
+  requestNumber: string
+  requestId: string
+  status: 'rejected'
+}
+
+// =============================================================================
+// API Functions
+// =============================================================================
+
+/**
+ * Publish reject command via the command API.
+ */
+async function publishRejectCommand(params: RejectBlockClearParams): Promise<PublishEventResponse> {
+  const command: BlockClearRejectCommand = {
+    requestId: params.requestId,
+    requestNumber: params.requestNumber,
+    reason: params.reason.trim(),
+  }
+
+  const res = await fetch('/api/commands/reapp-block-clear/reject', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(command),
+  })
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ error: { message: 'Failed to reject request' } }))
+    throw new Error(error.error?.message || 'Failed to reject block-clear request')
+  }
+
+  return res.json()
+}
+
+/**
+ * Reject block-clear request and poll for the status change.
+ */
+async function rejectBlockClear(params: RejectBlockClearParams): Promise<RejectBlockClearResult> {
+  // 1. Publish the command event
+  await publishRejectCommand(params)
+
+  // 2. Poll for the status to change to 'rejected'
+  const projection = await pollForBlockClearUpdate<RejectBlockClearResult>(
+    params.requestId,
+    'rejected',
+    {
+      maxAttempts: 10,
+      intervalMs: 500,
+      initialDelayMs: 100,
+    },
+  )
+
+  return projection
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Mutation hook for rejecting a reapplication block-clear request.
+ *
+ * Uses event sourcing: publishes command → polls for status change.
+ */
+export function useRejectBlockClear() {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: rejectBlockClear,
+    retry: 0, // Don't retry on failure - let user retry manually
+
+    onSuccess: (data) => {
+      toast.success(`Block-clear request ${data.requestNumber} rejected`, {
+        description: 'The request has been rejected.',
+      })
+      queryClient.invalidateQueries({ queryKey: ['block-clear-requests'] })
+      queryClient.invalidateQueries({ queryKey: ['pending-block-clears'] })
+    },
+
+    onError: (error) => {
+      // Handle polling timeout specifically
+      if (error instanceof PollTimeoutError) {
+        toast.warning('Rejection submitted but confirmation delayed', {
+          description:
+            'Your rejection was accepted but is taking longer than expected. Please refresh to see the status.',
+        })
+        queryClient.invalidateQueries({ queryKey: ['block-clear-requests'] })
+        queryClient.invalidateQueries({ queryKey: ['pending-block-clears'] })
+        return
+      }
+
+      showErrorToast(error, {
+        title: 'Failed to reject request',
+        action: 'reject-block-clear',
+      })
+    },
+  })
+
+  return {
+    reject: mutation.mutate,
+    rejectAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    isError: mutation.isError,
+    error: mutation.error,
+  }
+}

--- a/src/hooks/mutations/useRequestBlockClear.ts
+++ b/src/hooks/mutations/useRequestBlockClear.ts
@@ -90,6 +90,7 @@ export function useRequestBlockClear() {
         description: 'Your request has been submitted for processing.',
       })
       queryClient.invalidateQueries({ queryKey: ['pending-block-clears'] })
+      queryClient.invalidateQueries({ queryKey: ['conversation'] })
     },
 
     onError: (error) => {

--- a/src/hooks/mutations/useRequestBlockClear.ts
+++ b/src/hooks/mutations/useRequestBlockClear.ts
@@ -1,0 +1,111 @@
+/**
+ * Request Block-Clear Mutation Hook (Event-Sourced)
+ *
+ * Submits a reapplication block-clear request via the command API.
+ *
+ * Single-operator path (windowed declines): emits clear_authorized.v1 directly
+ * to chatLedger — no projection row created, no poll needed.
+ *
+ * Maker-checker path (high-risk reasons): emits block_clear_approval.requested.v1
+ * to the CRM internal stream — a pending row is created and the request hook
+ * returns immediately (caller waits for approval via useApproveBlockClear).
+ *
+ * In both cases the hook returns after the 202; it does NOT poll.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { showErrorToast } from '@/lib/utils/error-toast'
+import type { BlockClearRequestCommand } from '@/lib/events/schemas'
+import type { PublishEventResponse } from '@/lib/events/types'
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface RequestBlockClearParams {
+  /** Canonical customer ID from billie-platform-services */
+  canonicalCustomerId: string
+  /** Reasons for the block clear (at least one required) */
+  reasons: string[]
+  /** Operator justification for the clear */
+  justification: string
+  /** Optional conversation ID (context for the request) */
+  conversationId?: string
+  /** Optional customer display name */
+  customerName?: string
+}
+
+// =============================================================================
+// API Functions
+// =============================================================================
+
+/**
+ * Publish request command via the command API.
+ */
+async function publishRequestCommand(
+  params: RequestBlockClearParams,
+): Promise<PublishEventResponse> {
+  const command: BlockClearRequestCommand = {
+    canonicalCustomerId: params.canonicalCustomerId,
+    reasons: params.reasons as BlockClearRequestCommand['reasons'],
+    justification: params.justification,
+    conversationId: params.conversationId,
+    customerName: params.customerName,
+  }
+
+  const res = await fetch('/api/commands/reapp-block-clear/request', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(command),
+  })
+
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({ error: { message: 'Failed to submit request' } }))
+    throw new Error(error.error?.message || 'Failed to submit block-clear request')
+  }
+
+  return res.json()
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Mutation hook for submitting a reapplication block-clear request.
+ *
+ * Returns immediately after 202 — does NOT poll for a projection row
+ * (single-operator path has no row; maker-checker row is eventual).
+ */
+export function useRequestBlockClear() {
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation({
+    mutationFn: publishRequestCommand,
+    retry: 0, // Don't retry on failure - let user retry manually
+
+    onSuccess: () => {
+      toast.success('Block-clear request submitted', {
+        description: 'Your request has been submitted for processing.',
+      })
+      queryClient.invalidateQueries({ queryKey: ['pending-block-clears'] })
+    },
+
+    onError: (error) => {
+      showErrorToast(error, {
+        title: 'Failed to submit request',
+        action: 'request-block-clear',
+      })
+    },
+  })
+
+  return {
+    request: mutation.mutate,
+    requestAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    isSuccess: mutation.isSuccess,
+    isError: mutation.isError,
+    error: mutation.error,
+  }
+}

--- a/src/hooks/queries/useCustomer.ts
+++ b/src/hooks/queries/useCustomer.ts
@@ -110,6 +110,10 @@ export interface CustomerData {
     blockedUntil?: string | null
     blockedAt?: string | null
     applicationNumber?: string | null
+    /** BTB-202: status of the most recent block-clear request (e.g. 'pending', 'approved', 'rejected'). */
+    clearStatus?: string | null
+    /** BTB-202: ISO timestamp when the block was cleared. Guard used by ClearBlockButton. */
+    clearedAt?: string | null
   } | null
   /** Latest LAB EVS identity verification result (PR #67). */
   identityVerification?: {
@@ -136,16 +140,16 @@ interface CustomerApiResponse {
 
 async function fetchCustomer(customerId: string): Promise<CustomerData> {
   const res = await fetch(`/api/customer/${customerId}`)
-  
+
   if (!res.ok) {
     if (res.status === 404) {
       throw new Error('Customer not found')
     }
     throw new Error('Failed to fetch customer')
   }
-  
+
   const data: CustomerApiResponse = await res.json()
-  
+
   // Merge customer and accounts into CustomerData shape
   return {
     ...data.customer,
@@ -155,11 +159,11 @@ async function fetchCustomer(customerId: string): Promise<CustomerData> {
 
 /**
  * Hook to fetch a single customer by customerId.
- * 
+ *
  * Automatically tracks loan account versions for conflict detection.
  * When customer data is loaded, each loan account's version (updatedAt)
  * is stored in the version store for later comparison during mutations.
- * 
+ *
  * @param customerId - The customer's unique ID
  * @returns TanStack Query result with customer data
  */

--- a/src/hooks/queries/usePendingBlockClears.ts
+++ b/src/hooks/queries/usePendingBlockClears.ts
@@ -1,0 +1,90 @@
+import { useQuery } from '@tanstack/react-query'
+import { stringify } from 'qs-esm'
+
+export interface BlockClearRequest {
+  id: string
+  /** Event correlation ID for the block-clear request workflow */
+  requestId?: string
+  requestNumber: string
+  canonicalCustomerId: string
+  customerName?: string
+  conversationId?: string
+  reasons: string[]
+  justification: string
+  status: 'pending' | 'approved' | 'rejected' | 'cancelled'
+  requestedAt?: string
+  /** User who requested — can be a string ID or populated user object */
+  requestedBy?:
+    | string
+    | { id: string | number; email?: string; firstName?: string; lastName?: string }
+  requestedByName?: string
+  createdAt: string
+  updatedAt: string
+}
+
+interface PendingBlockClearsResponse {
+  docs: BlockClearRequest[]
+  totalDocs: number
+  limit: number
+  page: number
+  totalPages: number
+  hasNextPage: boolean
+  hasPrevPage: boolean
+}
+
+export interface PendingBlockClearsOptions {
+  page?: number
+  limit?: number
+  sort?: 'oldest' | 'newest'
+  /** Enable/disable the query (default: true) */
+  enabled?: boolean
+}
+
+async function fetchPendingBlockClears(
+  options: PendingBlockClearsOptions = {},
+): Promise<PendingBlockClearsResponse> {
+  const { page = 1, limit = 20, sort = 'oldest' } = options
+
+  // Map sort options to Payload sort format
+  const sortMap: Record<string, string> = {
+    oldest: 'createdAt', // ascending (oldest first - FIFO)
+    newest: '-createdAt', // descending (newest first)
+  }
+
+  const queryString = stringify(
+    {
+      where: {
+        status: { equals: 'pending' },
+      },
+      limit,
+      page,
+      sort: sortMap[sort] || 'createdAt',
+    },
+    { addQueryPrefix: true },
+  )
+
+  const res = await fetch(`/api/reapplication-block-clear-requests${queryString}`)
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch pending block-clear requests')
+  }
+
+  return res.json()
+}
+
+/**
+ * Hook to fetch all pending reapplication block-clear requests for the approval queue.
+ * Returns paginated results sorted by creation date (oldest first by default).
+ * Auto-refreshes every 60 seconds.
+ */
+export function usePendingBlockClears(options: PendingBlockClearsOptions = {}) {
+  const { enabled = true, ...queryOptions } = options
+
+  return useQuery({
+    queryKey: ['pending-block-clears', queryOptions],
+    queryFn: () => fetchPendingBlockClears(queryOptions),
+    staleTime: 30_000, // 30 seconds
+    refetchInterval: enabled ? 60_000 : false, // Poll every 60 seconds for new requests
+    enabled,
+  })
+}

--- a/src/lib/events/config.ts
+++ b/src/lib/events/config.ts
@@ -23,8 +23,7 @@ export const REDIS_PUBLISH_STREAM =
  * This is configured here for reference but consumed by the Python service.
  * Default: 'inbox:billie-servicing'
  */
-export const REDIS_EXTERNAL_STREAM =
-  process.env.REDIS_EXTERNAL_STREAM ?? 'inbox:billie-servicing'
+export const REDIS_EXTERNAL_STREAM = process.env.REDIS_EXTERNAL_STREAM ?? 'inbox:billie-servicing'
 
 // =============================================================================
 // Event Types (Write-Off)
@@ -99,3 +98,65 @@ export const ALL_CRM_EVENT_TYPES = [
   EVENT_TYPE_WRITEOFF_REJECTED,
   EVENT_TYPE_WRITEOFF_CANCELLED,
 ] as const
+
+// =============================================================================
+// Event Types (Block Clear)
+// =============================================================================
+
+/**
+ * The chatLedger stream that billieChat consumes.
+ * Default: 'chatLedger'
+ */
+export const CHATLEDGER_STREAM = process.env.CHATLEDGER_STREAM ?? 'chatLedger'
+
+/**
+ * Event type for block clear approval request.
+ */
+export const EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REQUESTED =
+  process.env.EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REQUESTED ?? 'block_clear_approval.requested.v1'
+
+/**
+ * Event type for block clear approval approved.
+ */
+export const EVENT_TYPE_BLOCK_CLEAR_APPROVAL_APPROVED =
+  process.env.EVENT_TYPE_BLOCK_CLEAR_APPROVAL_APPROVED ?? 'block_clear_approval.approved.v1'
+
+/**
+ * Event type for block clear approval rejected.
+ */
+export const EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REJECTED =
+  process.env.EVENT_TYPE_BLOCK_CLEAR_APPROVAL_REJECTED ?? 'block_clear_approval.rejected.v1'
+
+/**
+ * Event type for block clear approval cancelled.
+ */
+export const EVENT_TYPE_BLOCK_CLEAR_APPROVAL_CANCELLED =
+  process.env.EVENT_TYPE_BLOCK_CLEAR_APPROVAL_CANCELLED ?? 'block_clear_approval.cancelled.v1'
+
+/**
+ * Event type for reapplication block clear authorized (posted to chatLedger).
+ */
+export const EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED =
+  process.env.EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED ??
+  'reapplication_block.clear_authorized.v1'
+
+/**
+ * Single source of truth for the clear vocabulary (mirrors billieChat enums).
+ */
+export const CLEARABLE_REASONS = [
+  'PRIOR_DEFAULT',
+  'PRIOR_SERIOUS_ARREARS',
+  'ID_VERIFICATION',
+  'SERVICEABILITY',
+  'ACCOUNT_CONDUCT',
+] as const
+
+/**
+ * Reasons that require approval before clearing.
+ */
+export const REASONS_REQUIRING_APPROVAL = ['PRIOR_DEFAULT', 'PRIOR_SERIOUS_ARREARS'] as const
+
+/**
+ * Type alias for clearable reason.
+ */
+export type ClearableReason = (typeof CLEARABLE_REASONS)[number]

--- a/src/lib/events/poll.ts
+++ b/src/lib/events/poll.ts
@@ -69,7 +69,7 @@ function sleep(ms: number): Promise<void> {
  */
 export async function pollForWriteOffRequest<T = unknown>(
   eventId: string,
-  options?: PollOptions
+  options?: PollOptions,
 ): Promise<T> {
   const { maxAttempts = 10, intervalMs = 500, initialDelayMs = 100 } = options ?? {}
 
@@ -121,7 +121,7 @@ export async function pollForWriteOffRequest<T = unknown>(
 export async function pollForWriteOffUpdate<T = unknown>(
   requestId: string,
   expectedStatus: 'approved' | 'rejected' | 'cancelled',
-  options?: PollOptions
+  options?: PollOptions,
 ): Promise<T> {
   const { maxAttempts = 10, intervalMs = 500, initialDelayMs = 100 } = options ?? {}
 
@@ -160,6 +160,59 @@ export async function pollForWriteOffUpdate<T = unknown>(
 }
 
 /**
+ * Poll for a reapplication block-clear request update by requestId and expected status.
+ *
+ * Used for approve/reject/cancel operations where we're updating
+ * an existing request and waiting for the status change.
+ *
+ * @param requestId - The request ID to look for
+ * @param expectedStatus - The status we're waiting for
+ * @param options - Polling configuration
+ * @returns The updated block-clear request document
+ * @throws PollTimeoutError if not found within max attempts
+ */
+export async function pollForBlockClearUpdate<T = unknown>(
+  requestId: string,
+  expectedStatus: 'approved' | 'rejected' | 'cancelled',
+  options?: PollOptions,
+): Promise<T> {
+  const { maxAttempts = 10, intervalMs = 500, initialDelayMs = 100 } = options ?? {}
+
+  // Initial delay to give the event processor time to start
+  await sleep(initialDelayMs)
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const query = stringify({
+        where: {
+          requestId: { equals: requestId },
+          status: { equals: expectedStatus },
+        },
+        limit: 1,
+      })
+
+      const res = await fetch(`/api/reapplication-block-clear-requests?${query}`)
+
+      if (res.ok) {
+        const data = await res.json()
+        if (data.docs && data.docs.length > 0) {
+          return data.docs[0] as T
+        }
+      }
+    } catch {
+      // Ignore fetch errors and continue polling
+    }
+
+    // Don't sleep after the last attempt
+    if (attempt < maxAttempts) {
+      await sleep(intervalMs)
+    }
+  }
+
+  throw new PollTimeoutError(requestId, maxAttempts)
+}
+
+/**
  * Generic polling function for any projection.
  *
  * @param fetchFn - Function that fetches and checks for the projection
@@ -169,10 +222,14 @@ export async function pollForWriteOffUpdate<T = unknown>(
  */
 export async function pollUntil<T>(
   fetchFn: () => Promise<T | null | undefined>,
-  options?: PollOptions & { label?: string }
+  options?: PollOptions & { label?: string },
 ): Promise<T> {
-  const { maxAttempts = 10, intervalMs = 500, initialDelayMs = 100, label = 'projection' } =
-    options ?? {}
+  const {
+    maxAttempts = 10,
+    intervalMs = 500,
+    initialDelayMs = 100,
+    label = 'projection',
+  } = options ?? {}
 
   // Initial delay
   await sleep(initialDelayMs)

--- a/src/lib/events/schemas.ts
+++ b/src/lib/events/schemas.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod'
+import { CLEARABLE_REASONS } from '../events/config'
 
 // =============================================================================
 // Write-Off Request Schema
@@ -100,11 +101,7 @@ export type WriteOffCancelCommand = z.infer<typeof WriteOffCancelCommandSchema>
  * Suppression mode the CRM is allowed to set.
  * (No `off` — clearing is a separate DELETE / clearSuppression call.)
  */
-export const NotificationSuppressionModeSchema = z.enum([
-  'all',
-  'non_essential',
-  'marketing_only',
-])
+export const NotificationSuppressionModeSchema = z.enum(['all', 'non_essential', 'marketing_only'])
 
 /**
  * Schema for setting a per-customer notification kill switch.
@@ -114,14 +111,64 @@ export const NotificationSuppressionCommandSchema = z.object({
   customerId: z.string().min(1, 'Customer ID is required'),
   mode: NotificationSuppressionModeSchema,
   reason: z.string().min(1, 'Reason is required').max(500),
-  expiresAt: z
-    .string()
-    .datetime({ message: 'expiresAt must be an ISO 8601 timestamp' })
-    .nullish(),
+  expiresAt: z.string().datetime({ message: 'expiresAt must be an ISO 8601 timestamp' }).nullish(),
   correlationId: z.string().optional(),
 })
 
 export type NotificationSuppressionCommand = z.infer<typeof NotificationSuppressionCommandSchema>
+
+// =============================================================================
+// Block Clear Schemas
+// =============================================================================
+
+/**
+ * Valid clearable reasons.
+ */
+const ClearableReasonSchema = z.enum(CLEARABLE_REASONS)
+
+/**
+ * Schema for the block clear request command (input from client).
+ */
+export const BlockClearRequestCommandSchema = z.object({
+  canonicalCustomerId: z.string().min(1, 'Canonical customer ID is required'),
+  conversationId: z.string().optional(),
+  reasons: z.array(ClearableReasonSchema).min(1, 'At least one reason is required'),
+  justification: z.string().min(1, 'Justification is required'),
+})
+
+export type BlockClearRequestCommand = z.infer<typeof BlockClearRequestCommandSchema>
+
+/**
+ * Schema for the block clear approval command (input from client).
+ */
+export const BlockClearApproveCommandSchema = z.object({
+  requestId: z.string().min(1, 'Request ID is required'),
+  requestNumber: z.string().min(1, 'Request number is required'),
+  comment: z.string().min(10, 'Approval comment must be at least 10 characters'),
+})
+
+export type BlockClearApproveCommand = z.infer<typeof BlockClearApproveCommandSchema>
+
+/**
+ * Schema for the block clear rejection command (input from client).
+ */
+export const BlockClearRejectCommandSchema = z.object({
+  requestId: z.string().min(1, 'Request ID is required'),
+  requestNumber: z.string().min(1, 'Request number is required'),
+  reason: z.string().min(10, 'Rejection reason must be at least 10 characters'),
+})
+
+export type BlockClearRejectCommand = z.infer<typeof BlockClearRejectCommandSchema>
+
+/**
+ * Schema for the block clear cancellation command (input from client).
+ */
+export const BlockClearCancelCommandSchema = z.object({
+  requestId: z.string().min(1, 'Request ID is required'),
+  requestNumber: z.string().min(1, 'Request number is required'),
+})
+
+export type BlockClearCancelCommand = z.infer<typeof BlockClearCancelCommandSchema>
 
 // =============================================================================
 // Response Schemas

--- a/src/lib/events/schemas.ts
+++ b/src/lib/events/schemas.ts
@@ -6,7 +6,7 @@
  */
 
 import { z } from 'zod'
-import { CLEARABLE_REASONS } from '../events/config'
+import { CLEARABLE_REASONS } from './config'
 
 // =============================================================================
 // Write-Off Request Schema

--- a/src/lib/events/schemas.ts
+++ b/src/lib/events/schemas.ts
@@ -132,6 +132,7 @@ const ClearableReasonSchema = z.enum(CLEARABLE_REASONS)
 export const BlockClearRequestCommandSchema = z.object({
   canonicalCustomerId: z.string().min(1, 'Canonical customer ID is required'),
   conversationId: z.string().optional(),
+  customerName: z.string().optional(),
   reasons: z.array(ClearableReasonSchema).min(1, 'At least one reason is required'),
   justification: z.string().min(1, 'Justification is required'),
 })

--- a/src/lib/events/types.ts
+++ b/src/lib/events/types.ts
@@ -5,6 +5,8 @@
  * These follow the LedgerMessage format for consistency with the event ecosystem.
  */
 
+import type { ClearableReason } from './config'
+
 // =============================================================================
 // CRM Event Envelope
 // =============================================================================
@@ -193,5 +195,72 @@ export interface PublishEventError {
   error: {
     code: string
     message: string
+  }
+}
+
+// =============================================================================
+// Block Clear Payloads
+// =============================================================================
+
+/**
+ * Payload for block_clear_approval.requested.v1 event.
+ */
+export interface BlockClearApprovalRequestedPayload {
+  canonicalCustomerId: string
+  conversationId?: string
+  reasons: ClearableReason[]
+  justification: string
+  requestedBy: string
+  requestedByName: string
+}
+
+/**
+ * Payload for block_clear_approval.approved.v1 event.
+ */
+export interface BlockClearApprovalApprovedPayload {
+  requestId: string
+  requestNumber: string
+  comment: string
+  approvedBy: string
+  approvedByName: string
+}
+
+/**
+ * Payload for block_clear_approval.rejected.v1 event.
+ */
+export interface BlockClearApprovalRejectedPayload {
+  requestId: string
+  requestNumber: string
+  reason: string
+  rejectedBy: string
+  rejectedByName: string
+}
+
+/**
+ * Payload for block_clear_approval.cancelled.v1 event.
+ */
+export interface BlockClearApprovalCancelledPayload {
+  requestId: string
+  requestNumber: string
+  cancelledBy: string
+  cancelledByName: string
+}
+
+/**
+ * The authoritative command billieChat consumes off chatLedger (spec §7.1).
+ */
+export interface ReapplicationBlockClearAuthorizedPayload {
+  canonical_customer_id: string
+  reasons: ClearableReason[] | 'ALL_CLEARABLE'
+  operator_id: string
+  justification: string
+  request_id: string
+  requested_at: string
+  approval?: {
+    approval_request_id: string
+    approved_by: string
+    approved_by_name: string
+    approved_at: string
+    comment: string
   }
 }

--- a/src/lib/events/types.ts
+++ b/src/lib/events/types.ts
@@ -207,6 +207,7 @@ export interface PublishEventError {
  */
 export interface BlockClearApprovalRequestedPayload {
   canonicalCustomerId: string
+  customerName: string
   conversationId?: string
   reasons: ClearableReason[]
   justification: string

--- a/src/lib/schemas/conversations.ts
+++ b/src/lib/schemas/conversations.ts
@@ -37,17 +37,21 @@ export type ConversationsQuery = z.infer<typeof ConversationsQuerySchema>
 
 export const ConversationSummarySchema = z.object({
   conversationId: z.string(),
-  customer: z.object({
-    fullName: z.string().nullable().optional(),
-    customerId: z.string().nullable().optional(),
-  }).optional(),
+  customer: z
+    .object({
+      fullName: z.string().nullable().optional(),
+      customerId: z.string().nullable().optional(),
+    })
+    .optional(),
   applicationNumber: z.string().nullable().optional(),
   status: z.string().nullable().optional(),
   decisionStatus: z.string().nullable().optional(),
-  application: z.object({
-    loanAmount: z.number().nullable().optional(),
-    purpose: z.string().nullable().optional(),
-  }).optional(),
+  application: z
+    .object({
+      loanAmount: z.number().nullable().optional(),
+      purpose: z.string().nullable().optional(),
+    })
+    .optional(),
   messageCount: z.number().default(0),
   lastMessageAt: z.string().nullable().optional(),
   updatedAt: z.string().nullable().optional(),
@@ -155,6 +159,11 @@ export const ReapplicationBlockSchema = z.object({
   dispositionKind: z.enum(['review', 'block']).nullable().optional(),
   manualReviewCandidate: z.boolean().nullable().optional(),
   recognition: RecognitionSchema.nullable().optional(),
+  clearStatus: z.string().nullish(),
+  clearedAt: z.string().nullish(),
+  clearedBy: z.string().nullish(),
+  clearJustification: z.string().nullish(),
+  clearRequestId: z.string().nullish(),
 })
 
 /** Archived KYC artifact availability (S3 locations stay server-side). */
@@ -182,24 +191,30 @@ export const ConversationDetailSchema = z.object({
   startedAt: z.union([z.string(), z.date()]).nullable().optional(),
   updatedAt: z.union([z.string(), z.date()]).nullable().optional(),
   lastMessageAt: z.union([z.string(), z.date()]).nullable().optional(),
-  customer: z.object({
-    fullName: z.string().nullable().optional(),
-    customerId: z.string().nullable().optional(),
-    payloadId: z.string().nullable().optional(),
-  }).optional(),
-  application: z.object({
-    loanAmount: z.number().nullable().optional(),
-    purpose: z.string().nullable().optional(),
-    term: z.number().nullable().optional(),
-  }).optional(),
+  customer: z
+    .object({
+      fullName: z.string().nullable().optional(),
+      customerId: z.string().nullable().optional(),
+      payloadId: z.string().nullable().optional(),
+    })
+    .optional(),
+  application: z
+    .object({
+      loanAmount: z.number().nullable().optional(),
+      purpose: z.string().nullable().optional(),
+      term: z.number().nullable().optional(),
+    })
+    .optional(),
   utterances: z.array(UtteranceSchema).default([]),
   assessments: z.record(z.string(), z.unknown()).optional(),
   statementCapture: z.unknown().optional(),
   noticeboard: z.array(NoticeboardEntrySchema).default([]),
-  summary: z.object({
-    purpose: z.string().nullable().optional(),
-    facts: z.array(z.object({ fact: z.string() })).optional(),
-  }).optional(),
+  summary: z
+    .object({
+      purpose: z.string().nullable().optional(),
+      facts: z.array(z.object({ fact: z.string() })).optional(),
+    })
+    .optional(),
   messageCount: z.number().default(0),
 })
 

--- a/src/migrations/20260628_120000_reapplication_block_clear_requests.ts
+++ b/src/migrations/20260628_120000_reapplication_block_clear_requests.ts
@@ -1,0 +1,60 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    CREATE TYPE "public"."enum_reapplication_block_clear_requests_status" AS ENUM('pending', 'approved', 'rejected', 'cancelled');
+    CREATE TABLE "reapplication_block_clear_requests" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+      "request_id" varchar NOT NULL,
+      "event_id" varchar,
+      "request_number" varchar,
+      "canonical_customer_id" varchar NOT NULL,
+      "conversation_id" varchar,
+      "customer_name" varchar,
+      "reasons" jsonb,
+      "justification" varchar,
+      "status" "enum_reapplication_block_clear_requests_status" DEFAULT 'pending' NOT NULL,
+      "requested_by_id" uuid,
+      "requested_by_name" varchar,
+      "requested_at" timestamp(3) with time zone,
+      "approval_details_approved_by" varchar,
+      "approval_details_approved_by_name" varchar,
+      "approval_details_approved_at" timestamp(3) with time zone,
+      "approval_details_comment" varchar,
+      "approval_details_rejected_by" varchar,
+      "approval_details_rejected_by_name" varchar,
+      "approval_details_reason" varchar,
+      "approval_details_rejected_at" timestamp(3) with time zone,
+      "cancellation_details_cancelled_by" varchar,
+      "cancellation_details_cancelled_by_name" varchar,
+      "cancellation_details_cancelled_at" timestamp(3) with time zone,
+      "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+      "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+    );
+    CREATE UNIQUE INDEX "rbcr_request_id_idx" ON "reapplication_block_clear_requests" ("request_id");
+    CREATE INDEX "rbcr_status_created_idx" ON "reapplication_block_clear_requests" ("status","created_at");
+    ALTER TABLE "reapplication_block_clear_requests" ADD CONSTRAINT "rbcr_requested_by_fk" FOREIGN KEY ("requested_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+
+    ALTER TABLE "conversations" ADD COLUMN "reapplication_block_clear_status" varchar;
+    ALTER TABLE "conversations" ADD COLUMN "reapplication_block_cleared_at" timestamp(3) with time zone;
+    ALTER TABLE "conversations" ADD COLUMN "reapplication_block_cleared_by" varchar;
+    ALTER TABLE "conversations" ADD COLUMN "reapplication_block_clear_justification" varchar;
+    ALTER TABLE "conversations" ADD COLUMN "reapplication_block_clear_request_id" varchar;
+    ALTER TABLE "customers" ADD COLUMN "reapplication_block_clear_status" varchar;
+    ALTER TABLE "customers" ADD COLUMN "reapplication_block_cleared_at" timestamp(3) with time zone;
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+    DROP TABLE "reapplication_block_clear_requests" CASCADE;
+    DROP TYPE "public"."enum_reapplication_block_clear_requests_status";
+    ALTER TABLE "conversations" DROP COLUMN "reapplication_block_clear_status";
+    ALTER TABLE "conversations" DROP COLUMN "reapplication_block_cleared_at";
+    ALTER TABLE "conversations" DROP COLUMN "reapplication_block_cleared_by";
+    ALTER TABLE "conversations" DROP COLUMN "reapplication_block_clear_justification";
+    ALTER TABLE "conversations" DROP COLUMN "reapplication_block_clear_request_id";
+    ALTER TABLE "customers" DROP COLUMN "reapplication_block_clear_status";
+    ALTER TABLE "customers" DROP COLUMN "reapplication_block_cleared_at";
+  `)
+}

--- a/src/migrations/20260628_120000_reapplication_block_clear_requests.ts
+++ b/src/migrations/20260628_120000_reapplication_block_clear_requests.ts
@@ -33,6 +33,8 @@ export async function up({ db }: MigrateUpArgs): Promise<void> {
     );
     CREATE UNIQUE INDEX "rbcr_request_id_idx" ON "reapplication_block_clear_requests" ("request_id");
     CREATE INDEX "rbcr_status_created_idx" ON "reapplication_block_clear_requests" ("status","created_at");
+    CREATE INDEX "rbcr_event_id_idx" ON "reapplication_block_clear_requests" ("event_id");
+    CREATE INDEX "rbcr_request_number_idx" ON "reapplication_block_clear_requests" ("request_number");
     ALTER TABLE "reapplication_block_clear_requests" ADD CONSTRAINT "rbcr_requested_by_fk" FOREIGN KEY ("requested_by_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
 
     ALTER TABLE "conversations" ADD COLUMN "reapplication_block_clear_status" varchar;

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -6,6 +6,7 @@ import * as migration_20260618_065013_reapplication_block_recognition from './20
 import * as migration_20260619_011621 from './20260619_011621';
 import * as migration_20260619_061320_payload_385_upgrade from './20260619_061320_payload_385_upgrade';
 import * as migration_20260624_094132 from './20260624_094132';
+import * as migration_20260628_120000_reapplication_block_clear_requests from './20260628_120000_reapplication_block_clear_requests';
 
 export const migrations = [
   {
@@ -46,6 +47,11 @@ export const migrations = [
   {
     up: migration_20260624_094132.up,
     down: migration_20260624_094132.down,
-    name: '20260624_094132'
+    name: '20260624_094132',
+  },
+  {
+    up: migration_20260628_120000_reapplication_block_clear_requests.up,
+    down: migration_20260628_120000_reapplication_block_clear_requests.down,
+    name: '20260628_120000_reapplication_block_clear_requests',
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -74,6 +74,7 @@ export interface Config {
     applications: Application;
     'loan-accounts': LoanAccount;
     'write-off-requests': WriteOffRequest;
+    'reapplication-block-clear-requests': ReapplicationBlockClearRequest;
     'contact-notes': ContactNote;
     notifications: Notification;
     'collection-cases': CollectionCase;
@@ -91,6 +92,7 @@ export interface Config {
     applications: ApplicationsSelect<false> | ApplicationsSelect<true>;
     'loan-accounts': LoanAccountsSelect<false> | LoanAccountsSelect<true>;
     'write-off-requests': WriteOffRequestsSelect<false> | WriteOffRequestsSelect<true>;
+    'reapplication-block-clear-requests': ReapplicationBlockClearRequestsSelect<false> | ReapplicationBlockClearRequestsSelect<true>;
     'contact-notes': ContactNotesSelect<false> | ContactNotesSelect<true>;
     notifications: NotificationsSelect<false> | NotificationsSelect<true>;
     'collection-cases': CollectionCasesSelect<false> | CollectionCasesSelect<true>;
@@ -312,6 +314,14 @@ export interface Customer {
      * Application that was halted by the block
      */
     applicationNumber?: string | null;
+    /**
+     * Status of the most recent block-clear request (e.g. approved, rejected)
+     */
+    clearStatus?: string | null;
+    /**
+     * When the block was cleared
+     */
+    clearedAt?: string | null;
   };
   /**
    * Latest LAB EVS identity verification result
@@ -705,6 +715,26 @@ export interface Conversation {
       | number
       | boolean
       | null;
+    /**
+     * Status of the most recent block-clear request (e.g. approved, rejected)
+     */
+    clearStatus?: string | null;
+    /**
+     * When the block was cleared
+     */
+    clearedAt?: string | null;
+    /**
+     * User ID who cleared the block
+     */
+    clearedBy?: string | null;
+    /**
+     * Justification provided for the clear
+     */
+    clearJustification?: string | null;
+    /**
+     * ID of the ReapplicationBlockClearRequest that cleared this block
+     */
+    clearRequestId?: string | null;
   };
   /**
    * Archived identity verification artifacts (S3)
@@ -1197,6 +1227,103 @@ export interface WriteOffRequest {
   createdAt: string;
 }
 /**
+ * Reapplication block clear requests requiring approval
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "reapplication-block-clear-requests".
+ */
+export interface ReapplicationBlockClearRequest {
+  id: string;
+  /**
+   * Event correlation ID (conv field). Groups related events in a workflow.
+   */
+  requestId: string;
+  /**
+   * Event ID for polling lookup (cause field). Used by client to find projection after command.
+   */
+  eventId?: string | null;
+  /**
+   * Human-readable request reference number (e.g., RBC-20241211...). Auto-generated if not provided.
+   */
+  requestNumber?: string | null;
+  /**
+   * The canonical customer ID whose reapplication block is being cleared
+   */
+  canonicalCustomerId: string;
+  /**
+   * The conversation (application) ID associated with the block
+   */
+  conversationId?: string | null;
+  /**
+   * Customer name for display purposes
+   */
+  customerName?: string | null;
+  /**
+   * List of reasons for the clear request (e.g. ["SERVICEABILITY"])
+   */
+  reasons?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  /**
+   * Supporting justification for the clear request
+   */
+  justification?: string | null;
+  /**
+   * Current status of the clear request
+   */
+  status: 'pending' | 'approved' | 'rejected' | 'cancelled';
+  /**
+   * User who submitted the request
+   */
+  requestedBy?: (string | null) | User;
+  /**
+   * Requestor name for audit purposes
+   */
+  requestedByName?: string | null;
+  approvalDetails?: {
+    /**
+     * User ID who approved (from event)
+     */
+    approvedBy?: string | null;
+    approvedByName?: string | null;
+    approvedAt?: string | null;
+    /**
+     * Approval or rejection comment
+     */
+    comment?: string | null;
+    /**
+     * User ID who rejected (from event)
+     */
+    rejectedBy?: string | null;
+    rejectedByName?: string | null;
+    rejectedAt?: string | null;
+    /**
+     * Rejection reason (from event)
+     */
+    reason?: string | null;
+  };
+  cancellationDetails?: {
+    /**
+     * User ID who cancelled (from event)
+     */
+    cancelledBy?: string | null;
+    cancelledByName?: string | null;
+    cancelledAt?: string | null;
+  };
+  /**
+   * Timestamp when request was submitted
+   */
+  requestedAt?: string | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * Customer interaction notes — immutable audit trail
  *
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1451,6 +1578,10 @@ export interface PayloadLockedDocument {
         value: string | WriteOffRequest;
       } | null)
     | ({
+        relationTo: 'reapplication-block-clear-requests';
+        value: string | ReapplicationBlockClearRequest;
+      } | null)
+    | ({
         relationTo: 'contact-notes';
         value: string | ContactNote;
       } | null)
@@ -1606,6 +1737,8 @@ export interface CustomersSelect<T extends boolean = true> {
         blockedUntil?: T;
         blockedAt?: T;
         applicationNumber?: T;
+        clearStatus?: T;
+        clearedAt?: T;
       };
   identityVerification?:
     | T
@@ -1696,6 +1829,11 @@ export interface ConversationsSelect<T extends boolean = true> {
         dispositionKind?: T;
         manualReviewCandidate?: T;
         recognition?: T;
+        clearStatus?: T;
+        clearedAt?: T;
+        clearedBy?: T;
+        clearJustification?: T;
+        clearRequestId?: T;
       };
   identityVerificationReport?:
     | T
@@ -1946,6 +2084,45 @@ export interface WriteOffRequestsSelect<T extends boolean = true> {
         approvedBy?: T;
         approvedByName?: T;
         approvedAt?: T;
+        rejectedBy?: T;
+        rejectedByName?: T;
+        rejectedAt?: T;
+        reason?: T;
+      };
+  cancellationDetails?:
+    | T
+    | {
+        cancelledBy?: T;
+        cancelledByName?: T;
+        cancelledAt?: T;
+      };
+  requestedAt?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "reapplication-block-clear-requests_select".
+ */
+export interface ReapplicationBlockClearRequestsSelect<T extends boolean = true> {
+  requestId?: T;
+  eventId?: T;
+  requestNumber?: T;
+  canonicalCustomerId?: T;
+  conversationId?: T;
+  customerName?: T;
+  reasons?: T;
+  justification?: T;
+  status?: T;
+  requestedBy?: T;
+  requestedByName?: T;
+  approvalDetails?:
+    | T
+    | {
+        approvedBy?: T;
+        approvedByName?: T;
+        approvedAt?: T;
+        comment?: T;
         rejectedBy?: T;
         rejectedByName?: T;
         rejectedAt?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -16,6 +16,7 @@ import { Conversations } from './collections/Conversations'
 import { Applications } from './collections/Applications'
 import { LoanAccounts } from './collections/LoanAccounts'
 import { WriteOffRequests } from './collections/WriteOffRequests'
+import { ReapplicationBlockClearRequests } from './collections/ReapplicationBlockClearRequests'
 import { ContactNotes } from './collections/ContactNotes'
 import { Notifications } from './collections/Notifications'
 import { CollectionsCases } from './collections/CollectionsCases'
@@ -128,7 +129,7 @@ export default buildConfig({
       },
     },
   },
-  collections: [Users, Media, Customers, Conversations, Applications, LoanAccounts, WriteOffRequests, ContactNotes, Notifications, CollectionsCases],
+  collections: [Users, Media, Customers, Conversations, Applications, LoanAccounts, WriteOffRequests, ReapplicationBlockClearRequests, ContactNotes, Notifications, CollectionsCases],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || 'build-placeholder-not-for-production',
   typescript: {

--- a/src/server/chatledger-publisher.ts
+++ b/src/server/chatledger-publisher.ts
@@ -1,0 +1,48 @@
+/**
+ * ChatLedger Producer
+ *
+ * Publishes CRM-originated commands onto the shared chatLedger Redis stream.
+ * billieChat's Broker consumes chatLedger and routes messages by (agt, typ) to
+ * the appropriate agent inbox — in this case, the reapplicationBlock service.
+ *
+ * Envelope mirrors billieChat's LedgerMessage schema so the Broker can route
+ * without any billieChat changes:
+ *   conv / agt / usr / seq / cls / typ / cause / payload
+ */
+
+import { nanoid } from 'nanoid'
+import { getChatLedgerRedisClient } from './redis-client'
+import {
+  CHATLEDGER_STREAM,
+  CRM_AGENT_ID,
+  EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED,
+} from '@/lib/events/config'
+import type { ReapplicationBlockClearAuthorizedPayload } from '@/lib/events/types'
+
+/**
+ * Publish a reapplication_block.clear_authorized.v1 command to chatLedger.
+ *
+ * The command uses a synthetic ops conversation ID (`ops:block-clear:{request_id}`)
+ * so the Broker can route it without colliding with real customer conversations.
+ *
+ * @param payload - The clear-authorized payload (Task-1 contract).
+ * @returns The nanoid that was used as both the cause field and the returned eventId.
+ */
+export async function publishClearAuthorized(
+  payload: ReapplicationBlockClearAuthorizedPayload,
+): Promise<{ eventId: string }> {
+  const eventId = nanoid()
+  const fields: Record<string, string> = {
+    conv: `ops:block-clear:${payload.request_id}`,
+    agt: CRM_AGENT_ID,
+    usr: payload.canonical_customer_id,
+    seq: '1',
+    cls: 'cmd',
+    typ: EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED,
+    cause: eventId,
+    payload: JSON.stringify(payload),
+  }
+  const redis = getChatLedgerRedisClient()
+  await redis.xadd(CHATLEDGER_STREAM, '*', ...Object.entries(fields).flat())
+  return { eventId }
+}

--- a/src/server/redis-client.ts
+++ b/src/server/redis-client.ts
@@ -112,6 +112,10 @@ export async function closeRedisClient(): Promise<void> {
     await redisClient.quit()
     redisClient = null
   }
+  if (chatLedgerClient) {
+    await chatLedgerClient.quit()
+    chatLedgerClient = null
+  }
 }
 
 /**

--- a/src/server/redis-client.ts
+++ b/src/server/redis-client.ts
@@ -71,6 +71,38 @@ export function getRedisClient(): Redis {
   return redisClient
 }
 
+// =============================================================================
+// ChatLedger Redis Singleton
+// =============================================================================
+
+let chatLedgerClient: Redis | null = null
+
+/**
+ * Get the chatLedger Redis client singleton.
+ *
+ * In production both Redis clients resolve to the same instance (shared Redis).
+ * In development with a split-Redis setup (e.g. billieChat on port 6382 vs
+ * billie-crm on port 6383) set CHATLEDGER_REDIS_URL to point at the chatLedger
+ * instance. Falls back to REDIS_URL when the override is not set.
+ *
+ * @returns Redis client instance for the shared chatLedger stream
+ */
+export function getChatLedgerRedisClient(): Redis {
+  if (!chatLedgerClient) {
+    const url = process.env.CHATLEDGER_REDIS_URL ?? REDIS_URL
+    chatLedgerClient = new Redis(url, {
+      retryStrategy: (times) => Math.min(times * 100, 30000),
+      maxRetriesPerRequest: 3,
+      connectTimeout: 10000,
+      keepAlive: 10000,
+      enableOfflineQueue: false,
+      lazyConnect: true,
+    })
+    chatLedgerClient.on('error', (e) => console.error('[ChatLedger Redis] error:', e.message))
+  }
+  return chatLedgerClient
+}
+
 /**
  * Close the Redis connection.
  * Call this during graceful shutdown.

--- a/tests/int/collections/reapplicationBlockClearRequests.int.spec.ts
+++ b/tests/int/collections/reapplicationBlockClearRequests.int.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { getPayload, type Payload } from 'payload'
+import config from '@payload-config'
+
+let payload: Payload
+beforeAll(async () => {
+  payload = await getPayload({ config })
+})
+
+describe('reapplication-block-clear-requests collection', () => {
+  it('round-trips a request row with status + reasons', async () => {
+    const created = await payload.create({
+      collection: 'reapplication-block-clear-requests',
+      data: {
+        requestId: 'req-int-1',
+        canonicalCustomerId: 'c-int-1',
+        reasons: ['SERVICEABILITY'],
+        justification: 'int test',
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+    expect(created.requestNumber).toMatch(/^RBC-/)
+    const found = await payload.find({
+      collection: 'reapplication-block-clear-requests',
+      where: { requestId: { equals: 'req-int-1' } },
+      overrideAccess: true,
+    })
+    expect(found.docs[0].status).toBe('pending')
+  })
+})

--- a/tests/unit/components/BlockClearDetailDrawer.test.tsx
+++ b/tests/unit/components/BlockClearDetailDrawer.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { BlockClearDetailDrawer } from '@/components/ApprovalsView/BlockClearDetailDrawer'
+import type { BlockClearRequest } from '@/hooks/queries/usePendingBlockClears'
+
+// Mock sonner
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+// Mock useApproveBlockClear
+const mockApproveAsync = vi.fn()
+
+vi.mock('@/hooks/mutations/useApproveBlockClear', () => ({
+  useApproveBlockClear: () => ({
+    approve: vi.fn(),
+    approveAsync: mockApproveAsync,
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    error: null,
+  }),
+}))
+
+// Mock useRejectBlockClear
+const mockRejectAsync = vi.fn()
+
+vi.mock('@/hooks/mutations/useRejectBlockClear', () => ({
+  useRejectBlockClear: () => ({
+    reject: vi.fn(),
+    rejectAsync: mockRejectAsync,
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    error: null,
+  }),
+}))
+
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient()
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+const baseRequest: BlockClearRequest = {
+  id: 'req-1',
+  requestId: 'req-1',
+  requestNumber: 'BC-20241211-001',
+  canonicalCustomerId: 'cust-abc-123',
+  customerName: 'Jane Doe',
+  reasons: ['ID_VERIFICATION', 'INCORRECT_INFO'],
+  justification: 'Customer provided valid documents',
+  status: 'pending',
+  requestedBy: 'user-other-456',
+  requestedByName: 'Other User',
+  createdAt: '2024-12-11T00:00:00.000Z',
+  updatedAt: '2024-12-11T00:00:00.000Z',
+}
+
+const defaultProps = {
+  request: baseRequest,
+  isOpen: true,
+  onClose: vi.fn(),
+  currentUserId: 'user-me-123',
+  currentUserName: 'Me',
+}
+
+describe('BlockClearDetailDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  describe('isOwnRequest — self-approval disabled', () => {
+    it('disables the Approve button and shows "Cannot approve own request" when requestedBy matches currentUserId', () => {
+      const ownRequest: BlockClearRequest = {
+        ...baseRequest,
+        requestedBy: 'user-me-123',
+      }
+
+      renderWithProviders(
+        <BlockClearDetailDrawer
+          {...defaultProps}
+          request={ownRequest}
+          currentUserId="user-me-123"
+        />,
+      )
+
+      const approveBtn = screen.getByTestId('approve-button')
+      expect(approveBtn).toBeDisabled()
+      expect(screen.getByText('Cannot approve own request')).toBeInTheDocument()
+    })
+
+    it('enables the Approve button when requestedBy differs from currentUserId', () => {
+      renderWithProviders(<BlockClearDetailDrawer {...defaultProps} />)
+
+      const approveBtn = screen.getByTestId('approve-button')
+      expect(approveBtn).not.toBeDisabled()
+      expect(screen.queryByText('Cannot approve own request')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Approve action', () => {
+    it('calls approveAsync with requestId, requestNumber, and comment when Approve is confirmed via modal', async () => {
+      mockApproveAsync.mockResolvedValueOnce({
+        id: 'req-1',
+        requestNumber: 'BC-20241211-001',
+        requestId: 'req-1',
+        status: 'approved',
+      })
+
+      renderWithProviders(<BlockClearDetailDrawer {...defaultProps} />)
+
+      // Click Approve button (not own request, so enabled)
+      fireEvent.click(screen.getByTestId('approve-button'))
+
+      // Modal should open
+      expect(screen.getByTestId('approval-action-modal')).toBeInTheDocument()
+
+      // Fill in comment (minimum 10 chars)
+      fireEvent.change(screen.getByTestId('approval-comment-input'), {
+        target: { value: 'Valid reason for approval' },
+      })
+
+      // Confirm
+      fireEvent.click(screen.getByTestId('modal-confirm-button'))
+
+      await waitFor(() => {
+        expect(mockApproveAsync).toHaveBeenCalledWith({
+          requestId: 'req-1',
+          requestNumber: 'BC-20241211-001',
+          comment: 'Valid reason for approval',
+        })
+      })
+    })
+  })
+
+  describe('Reject action', () => {
+    it('calls rejectAsync with requestId, requestNumber, and reason when Reject is confirmed via modal', async () => {
+      mockRejectAsync.mockResolvedValueOnce({
+        id: 'req-1',
+        requestNumber: 'BC-20241211-001',
+        requestId: 'req-1',
+        status: 'rejected',
+      })
+
+      renderWithProviders(<BlockClearDetailDrawer {...defaultProps} />)
+
+      // Click Reject button
+      fireEvent.click(screen.getByTestId('reject-button'))
+
+      // Modal should open
+      expect(screen.getByTestId('approval-action-modal')).toBeInTheDocument()
+
+      // Fill in comment (minimum 10 chars)
+      fireEvent.change(screen.getByTestId('approval-comment-input'), {
+        target: { value: 'Rejected for this reason' },
+      })
+
+      // Confirm
+      fireEvent.click(screen.getByTestId('modal-confirm-button'))
+
+      await waitFor(() => {
+        expect(mockRejectAsync).toHaveBeenCalledWith({
+          requestId: 'req-1',
+          requestNumber: 'BC-20241211-001',
+          reason: 'Rejected for this reason',
+        })
+      })
+    })
+  })
+})

--- a/tests/unit/components/ClearBlockButton.test.tsx
+++ b/tests/unit/components/ClearBlockButton.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import React from 'react'
+import { ClearBlockButton } from '@/components/BlockClear/ClearBlockButton'
+import { CLEARABLE_REASONS } from '@/lib/events/config'
+
+// Mock useAuth — return a canService-eligible user by default
+vi.mock('@payloadcms/ui', () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: 'ops-1', role: 'operations' },
+  })),
+}))
+
+// canService must return true so the button renders
+vi.mock('@/lib/access', () => ({
+  canService: vi.fn(() => true),
+}))
+
+// Stub ClearBlockModal so it doesn't pull in heavy deps
+vi.mock('@/components/BlockClear/ClearBlockModal', () => ({
+  ClearBlockModal: () => <div data-testid="clear-block-modal-stub" />,
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+const CLEARABLE = CLEARABLE_REASONS[0]
+const NON_CLEARABLE = 'ACTIVE_LOAN'
+
+describe('ClearBlockButton', () => {
+  describe('M1 — canonical id gate', () => {
+    it('renders enabled button when reason is clearable and canonicalCustomerId is present', () => {
+      render(
+        <ClearBlockButton
+          block={{ reason: CLEARABLE, canonicalCustomerId: 'cust-123', clearedAt: null }}
+          conversationId="conv-1"
+        />,
+      )
+      expect(screen.getByTestId('clear-block-btn')).toBeInTheDocument()
+      expect(screen.getByTestId('clear-block-btn')).not.toBeDisabled()
+    })
+
+    it('renders disabled button with identity-not-resolved tooltip when reason is clearable but canonicalCustomerId is absent', () => {
+      render(
+        <ClearBlockButton
+          block={{ reason: CLEARABLE, canonicalCustomerId: null, clearedAt: null }}
+          conversationId="conv-1"
+        />,
+      )
+      const btn = screen.getByTestId('clear-block-btn-disabled')
+      expect(btn).toBeDisabled()
+      expect(btn).toHaveAttribute('title', "Customer identity not yet resolved — can't clear here.")
+    })
+
+    it('renders disabled button with "can\'t be cleared here" tooltip when reason is not clearable', () => {
+      render(
+        <ClearBlockButton
+          block={{ reason: NON_CLEARABLE, canonicalCustomerId: 'cust-123', clearedAt: null }}
+          conversationId="conv-1"
+        />,
+      )
+      const btn = screen.getByTestId('clear-block-btn-disabled')
+      expect(btn).toBeDisabled()
+      expect(btn).toHaveAttribute('title', "This block type can't be cleared here")
+    })
+
+    it('does not mount modal when canonicalCustomerId is absent even for clearable reason', () => {
+      render(
+        <ClearBlockButton
+          block={{ reason: CLEARABLE, canonicalCustomerId: null, clearedAt: null }}
+          conversationId="conv-1"
+        />,
+      )
+      expect(screen.queryByTestId('clear-block-modal-stub')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/tests/unit/components/ClearBlockModal.test.tsx
+++ b/tests/unit/components/ClearBlockModal.test.tsx
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { ClearBlockModal } from '@/components/BlockClear/ClearBlockModal'
+import { CLEARABLE_REASONS, REASONS_REQUIRING_APPROVAL } from '@/lib/events/config'
+
+// Mock sonner
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// Mock useRequestBlockClear
+const mockRequestAsync = vi.fn()
+
+vi.mock('@/hooks/mutations/useRequestBlockClear', () => ({
+  useRequestBlockClear: () => ({
+    requestAsync: mockRequestAsync,
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    error: null,
+  }),
+}))
+
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient()
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  canonicalCustomerId: 'cust-abc-123',
+  currentReason: null as string | null,
+}
+
+describe('ClearBlockModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  describe('Rendering', () => {
+    it('renders when isOpen=true', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} />)
+      expect(screen.getByTestId('clear-block-modal')).toBeInTheDocument()
+      expect(screen.getByText('Clear Re-application Block')).toBeInTheDocument()
+    })
+
+    it('does not render when isOpen=false', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} isOpen={false} />)
+      expect(screen.queryByTestId('clear-block-modal')).not.toBeInTheDocument()
+    })
+
+    it('renders all clearable reasons as checkboxes', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} />)
+      for (const reason of CLEARABLE_REASONS) {
+        expect(screen.getByTestId(`reason-checkbox-${reason}`)).toBeInTheDocument()
+      }
+    })
+  })
+
+  describe('Submit guard', () => {
+    it('submit is disabled with no reasons selected and no justification', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} />)
+      expect(screen.getByTestId('submit-button')).toBeDisabled()
+    })
+
+    it('submit is disabled with a reason but short justification (< 10 chars)', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} />)
+
+      fireEvent.click(screen.getByTestId(`reason-checkbox-${CLEARABLE_REASONS[0]}`))
+      fireEvent.change(screen.getByTestId('justification-input'), {
+        target: { value: 'Short' },
+      })
+
+      expect(screen.getByTestId('submit-button')).toBeDisabled()
+    })
+
+    it('submit is disabled with valid justification but no reason selected', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} />)
+
+      fireEvent.change(screen.getByTestId('justification-input'), {
+        target: { value: 'This is a valid justification text' },
+      })
+
+      expect(screen.getByTestId('submit-button')).toBeDisabled()
+    })
+
+    it('submit is enabled with a reason and justification >= 10 chars', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} />)
+
+      fireEvent.click(screen.getByTestId(`reason-checkbox-${CLEARABLE_REASONS[0]}`))
+      fireEvent.change(screen.getByTestId('justification-input'), {
+        target: { value: 'This is a valid justification' },
+      })
+
+      expect(screen.getByTestId('submit-button')).not.toBeDisabled()
+    })
+  })
+
+  describe('Submission', () => {
+    it('calls requestAsync with canonicalCustomerId, reasons, and justification on submit', async () => {
+      mockRequestAsync.mockResolvedValueOnce({ status: 'accepted' })
+      const onClose = vi.fn()
+
+      renderWithProviders(
+        <ClearBlockModal
+          {...defaultProps}
+          onClose={onClose}
+          canonicalCustomerId="cust-test-456"
+          conversationId="conv-xyz"
+          customerName="Jane Doe"
+        />,
+      )
+
+      fireEvent.click(screen.getByTestId(`reason-checkbox-${CLEARABLE_REASONS[0]}`))
+      fireEvent.change(screen.getByTestId('justification-input'), {
+        target: { value: 'Customer situation has improved sufficiently' },
+      })
+      fireEvent.submit(screen.getByTestId('submit-button').closest('form')!)
+
+      await waitFor(() => {
+        expect(mockRequestAsync).toHaveBeenCalledWith({
+          canonicalCustomerId: 'cust-test-456',
+          reasons: [CLEARABLE_REASONS[0]],
+          justification: 'Customer situation has improved sufficiently',
+          conversationId: 'conv-xyz',
+          customerName: 'Jane Doe',
+        })
+      })
+    })
+
+    it('calls onClose after successful submission', async () => {
+      mockRequestAsync.mockResolvedValueOnce({ status: 'accepted' })
+      const onClose = vi.fn()
+
+      renderWithProviders(
+        <ClearBlockModal
+          {...defaultProps}
+          onClose={onClose}
+          canonicalCustomerId="cust-close-test"
+        />,
+      )
+
+      fireEvent.click(screen.getByTestId(`reason-checkbox-${CLEARABLE_REASONS[0]}`))
+      fireEvent.change(screen.getByTestId('justification-input'), {
+        target: { value: 'Sufficient justification text here' },
+      })
+      fireEvent.submit(screen.getByTestId('submit-button').closest('form')!)
+
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('Approval notice', () => {
+    it('does not show approval notice initially', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} />)
+      expect(screen.queryByTestId('approval-notice')).not.toBeInTheDocument()
+    })
+
+    it('shows approval notice when a REASONS_REQUIRING_APPROVAL reason is selected', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} />)
+
+      fireEvent.click(screen.getByTestId(`reason-checkbox-${REASONS_REQUIRING_APPROVAL[0]}`))
+
+      expect(screen.getByTestId('approval-notice')).toBeInTheDocument()
+    })
+
+    it('hides approval notice when approval-required reason is deselected', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} />)
+
+      // Select then deselect
+      fireEvent.click(screen.getByTestId(`reason-checkbox-${REASONS_REQUIRING_APPROVAL[0]}`))
+      expect(screen.getByTestId('approval-notice')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId(`reason-checkbox-${REASONS_REQUIRING_APPROVAL[0]}`))
+      expect(screen.queryByTestId('approval-notice')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Pre-selection', () => {
+    it('pre-selects current reason when it is clearable', () => {
+      const clearableReason = CLEARABLE_REASONS[2] // 'ID_VERIFICATION'
+      renderWithProviders(<ClearBlockModal {...defaultProps} currentReason={clearableReason} />)
+
+      expect(screen.getByTestId(`reason-checkbox-${clearableReason}`)).toBeChecked()
+    })
+
+    it('does not pre-select when current reason is not clearable', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} currentReason="ACTIVE_LOAN" />)
+
+      for (const reason of CLEARABLE_REASONS) {
+        expect(screen.getByTestId(`reason-checkbox-${reason}`)).not.toBeChecked()
+      }
+    })
+
+    it('does not pre-select when currentReason is null', () => {
+      renderWithProviders(<ClearBlockModal {...defaultProps} currentReason={null} />)
+
+      for (const reason of CLEARABLE_REASONS) {
+        expect(screen.getByTestId(`reason-checkbox-${reason}`)).not.toBeChecked()
+      }
+    })
+  })
+})

--- a/tests/unit/components/ClearBlockModal.test.tsx
+++ b/tests/unit/components/ClearBlockModal.test.tsx
@@ -192,7 +192,7 @@ describe('ClearBlockModal', () => {
 
   describe('Pre-selection', () => {
     it('pre-selects current reason when it is clearable', () => {
-      const clearableReason = CLEARABLE_REASONS[2] // 'ID_VERIFICATION'
+      const clearableReason = 'ID_VERIFICATION'
       renderWithProviders(<ClearBlockModal {...defaultProps} currentReason={clearableReason} />)
 
       expect(screen.getByTestId(`reason-checkbox-${clearableReason}`)).toBeChecked()

--- a/tests/unit/components/ServicingViewClearBlock.test.tsx
+++ b/tests/unit/components/ServicingViewClearBlock.test.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import React from 'react'
+import { CLEARABLE_REASONS } from '@/lib/events/config'
+
+// ─── Heavy hook mocks ─────────────────────────────────────────────────────────
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: vi.fn(() => ({ invalidateQueries: vi.fn() })),
+}))
+
+vi.mock('@/hooks/queries/useCustomer', () => ({
+  useCustomer: vi.fn(),
+}))
+
+vi.mock('@/hooks/queries/useFeesCount', () => ({
+  useFeesCount: vi.fn(() => 0),
+}))
+
+vi.mock('@/hooks/queries/usePendingWriteOff', () => ({
+  usePendingWriteOff: vi.fn(() => ({ data: null, isError: false })),
+}))
+
+vi.mock('@/hooks/queries/useTransactions', () => ({
+  transactionsQueryKey: vi.fn(() => ['transactions']),
+}))
+
+vi.mock('@/hooks/queries/useAccruedYield', () => ({
+  accruedYieldQueryKey: vi.fn(() => ['accrued-yield']),
+  accrualHistoryQueryKey: vi.fn(() => ['accrual-history']),
+}))
+
+vi.mock('@/hooks/queries/useECLAllowance', () => ({
+  eclAllowanceQueryKey: vi.fn(() => ['ecl-allowance']),
+}))
+
+vi.mock('@/hooks/useTrackCustomerView', () => ({
+  useTrackCustomerView: vi.fn(),
+}))
+
+// ─── Sub-component stubs ──────────────────────────────────────────────────────
+
+vi.mock('@/components/ServicingView/CustomerHeader', () => ({
+  CustomerHeader: () => <div data-testid="stub-customer-header" />,
+}))
+
+vi.mock('@/components/ServicingView/CustomerHeaderSkeleton', () => ({
+  CustomerHeaderSkeleton: () => <div data-testid="stub-header-skeleton" />,
+}))
+
+vi.mock('@/components/ServicingView/LoanAccountsSkeleton', () => ({
+  LoanAccountsSkeleton: () => <div data-testid="stub-accounts-skeleton" />,
+}))
+
+vi.mock('@/components/ServicingView/TransactionsSkeleton', () => ({
+  TransactionsSkeleton: () => <div data-testid="stub-tx-skeleton" />,
+}))
+
+vi.mock('@/components/ServicingView/WaiveFeeDrawer', () => ({
+  WaiveFeeDrawer: () => null,
+}))
+
+vi.mock('@/components/ServicingView/RecordRepaymentDrawer', () => ({
+  RecordRepaymentDrawer: () => null,
+}))
+
+vi.mock('@/components/ServicingView/BulkWaiveFeeDrawer', () => ({
+  BulkWaiveFeeDrawer: () => null,
+}))
+
+vi.mock('@/components/ServicingView/WriteOffRequestDrawer', () => ({
+  WriteOffRequestDrawer: () => null,
+}))
+
+vi.mock('@/components/ServicingView/DisburseLoanDrawer', () => ({
+  DisburseLoanDrawer: () => null,
+}))
+
+vi.mock('@/components/ServicingView/ApplyFeeDrawer', () => ({
+  ApplyFeeDrawer: () => null,
+}))
+
+vi.mock('@/components/ServicingView/AccountPanel', () => ({
+  AccountPanel: () => <div data-testid="stub-account-panel" />,
+}))
+
+vi.mock('@/components/ServicingView/AccountRail', () => ({
+  AccountRail: () => <div data-testid="stub-account-rail" />,
+}))
+
+vi.mock('@/components/ServicingView/AttentionStrip', () => ({
+  AttentionStrip: () => <div data-testid="stub-attention-strip" />,
+}))
+
+vi.mock('@/components/ServicingView/ContextPane', () => ({
+  ContextPane: () => <div data-testid="stub-context-pane" />,
+}))
+
+vi.mock('@/components/Breadcrumb', () => ({
+  Breadcrumb: () => <div data-testid="stub-breadcrumb" />,
+}))
+
+vi.mock('@/lib/accountTriage', () => ({
+  getAttentionItems: vi.fn(() => []),
+  sortAccountsForRail: vi.fn(() => ({ active: [], closed: [] })),
+}))
+
+// ─── ClearBlockButton spy ─────────────────────────────────────────────────────
+// Expose what it receives as data attributes so we can assert on them.
+
+vi.mock('@/components/BlockClear', () => ({
+  ClearBlockButton: vi.fn(
+    ({
+      block,
+      customerName,
+    }: {
+      block: { canonicalCustomerId?: string | null } | null
+      customerName?: string
+    }) => (
+      <div
+        data-testid="clear-block-btn-stub"
+        data-canonical-id={block?.canonicalCustomerId ?? 'none'}
+        data-customer-name={customerName ?? ''}
+      />
+    ),
+  ),
+}))
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const CLEARABLE = CLEARABLE_REASONS[0]
+const CANONICAL_ID = 'cust-canon-abc-123'
+
+function makeCustomer(blockOverride?: Record<string, unknown> | null) {
+  return {
+    id: 'payload-doc-id-1',
+    customerId: CANONICAL_ID,
+    fullName: 'Alex Testerton',
+    firstName: 'Alex',
+    lastName: 'Testerton',
+    preferredName: null,
+    emailAddress: 'alex@example.com',
+    mobilePhoneNumber: null,
+    dateOfBirth: null,
+    identityVerified: false,
+    staffFlag: false,
+    investorFlag: false,
+    founderFlag: false,
+    vulnerableFlag: false,
+    residentialAddress: null,
+    identityVerification: null,
+    loanAccounts: [],
+    reapplicationBlock: blockOverride !== undefined ? blockOverride : null,
+  }
+}
+
+// ─── Lazy import (after all vi.mock declarations) ─────────────────────────────
+
+async function getServicingView() {
+  const { ServicingView } = await import('@/components/ServicingView/ServicingView')
+  return ServicingView
+}
+
+async function getUseCustomerMock() {
+  const mod = await import('@/hooks/queries/useCustomer')
+  return vi.mocked(mod.useCustomer)
+}
+
+afterEach(() => cleanup())
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ServicingView — ClearBlockButton wiring (BTB-202)', () => {
+  it('renders ClearBlockButton with canonicalCustomerId equal to customer.customerId', async () => {
+    const ServicingView = await getServicingView()
+    const useCustomerMock = await getUseCustomerMock()
+    useCustomerMock.mockReturnValue({
+      data: makeCustomer({ reason: CLEARABLE, clearStatus: null, clearedAt: null }),
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as ReturnType<typeof useCustomerMock>)
+
+    render(<ServicingView customerId={CANONICAL_ID} />)
+
+    const stub = screen.getByTestId('clear-block-btn-stub')
+    expect(stub).toBeInTheDocument()
+    expect(stub).toHaveAttribute('data-canonical-id', CANONICAL_ID)
+  })
+
+  it('passes customerName (fullName) to ClearBlockButton', async () => {
+    const ServicingView = await getServicingView()
+    const useCustomerMock = await getUseCustomerMock()
+    useCustomerMock.mockReturnValue({
+      data: makeCustomer({ reason: CLEARABLE, clearStatus: null, clearedAt: null }),
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as ReturnType<typeof useCustomerMock>)
+
+    render(<ServicingView customerId={CANONICAL_ID} />)
+
+    const stub = screen.getByTestId('clear-block-btn-stub')
+    expect(stub).toHaveAttribute('data-customer-name', 'Alex Testerton')
+  })
+
+  it('renders ClearBlockButton with null block when customer has no reapplicationBlock', async () => {
+    const ServicingView = await getServicingView()
+    const useCustomerMock = await getUseCustomerMock()
+    useCustomerMock.mockReturnValue({
+      data: makeCustomer(null),
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as ReturnType<typeof useCustomerMock>)
+
+    render(<ServicingView customerId={CANONICAL_ID} />)
+
+    // Stub still renders (ClearBlockButton self-gates, not ServicingView)
+    const stub = screen.getByTestId('clear-block-btn-stub')
+    expect(stub).toHaveAttribute('data-canonical-id', 'none')
+  })
+})

--- a/tests/unit/events/blockClear.test.ts
+++ b/tests/unit/events/blockClear.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BlockClearRequestCommandSchema,
+  BlockClearApproveCommandSchema,
+} from '@/lib/events/schemas'
+import {
+  CLEARABLE_REASONS,
+  REASONS_REQUIRING_APPROVAL,
+  EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED,
+} from '@/lib/events/config'
+
+describe('block-clear event contract', () => {
+  it('accepts a valid request command', () => {
+    const ok = BlockClearRequestCommandSchema.safeParse({
+      canonicalCustomerId: 'c123',
+      conversationId: 'conv-1',
+      reasons: ['SERVICEABILITY'],
+      justification: 'manual assessment, ticket OPS-1',
+    })
+    expect(ok.success).toBe(true)
+  })
+
+  it('rejects an empty justification', () => {
+    const bad = BlockClearRequestCommandSchema.safeParse({
+      canonicalCustomerId: 'c123',
+      reasons: ['SERVICEABILITY'],
+      justification: '',
+    })
+    expect(bad.success).toBe(false)
+  })
+
+  it('requires a >=10 char comment to approve', () => {
+    expect(
+      BlockClearApproveCommandSchema.safeParse({
+        requestId: 'r1',
+        requestNumber: 'RBC-1',
+        comment: 'too short',
+      }).success,
+    ).toBe(false)
+  })
+
+  it('exposes the clearable + approval-required vocabularies and the authorize type', () => {
+    expect(CLEARABLE_REASONS).toEqual([
+      'PRIOR_DEFAULT',
+      'PRIOR_SERIOUS_ARREARS',
+      'ID_VERIFICATION',
+      'SERVICEABILITY',
+      'ACCOUNT_CONDUCT',
+    ])
+    expect(REASONS_REQUIRING_APPROVAL).toEqual(['PRIOR_DEFAULT', 'PRIOR_SERIOUS_ARREARS'])
+    expect(EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED).toBe(
+      'reapplication_block.clear_authorized.v1',
+    )
+  })
+})

--- a/tests/unit/hooks/useApproveBlockClear.test.ts
+++ b/tests/unit/hooks/useApproveBlockClear.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useApproveBlockClear } from '@/hooks/mutations/useApproveBlockClear'
+import React from 'react'
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+// Mock error toast utility
+vi.mock('@/lib/utils/error-toast', () => ({
+  showErrorToast: vi.fn(),
+}))
+
+// Create a fresh query client for each test
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function createWrapper() {
+  const queryClient = createTestQueryClient()
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe('useApproveBlockClear', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should expose mutation functions and states', () => {
+    const { result } = renderHook(() => useApproveBlockClear(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.approveAsync).toBeDefined()
+    expect(result.current.isPending).toBe(false)
+    expect(result.current.isSuccess).toBe(false)
+    expect(result.current.isError).toBe(false)
+  })
+
+  it('should POST to /api/commands/reapp-block-clear/approve with correct body', async () => {
+    const commandResponse = {
+      eventId: 'evt-bc-123',
+      requestId: 'req-bc-123',
+      status: 'accepted',
+      message: 'Event accepted',
+    }
+
+    const projectionResponse = {
+      docs: [
+        {
+          id: 'doc-bc-123',
+          requestNumber: 'BC-20241211-ABCD',
+          requestId: 'req-bc-123',
+          status: 'approved',
+        },
+      ],
+    }
+
+    ;(global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(commandResponse),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(projectionResponse),
+      })
+
+    const { result } = renderHook(() => useApproveBlockClear(), {
+      wrapper: createWrapper(),
+    })
+
+    const approvePromise = result.current.approveAsync({
+      requestId: 'req-bc-123',
+      requestNumber: 'BC-20241211-ABCD',
+      comment: 'Approval is justified by customer circumstances',
+    })
+
+    await vi.runAllTimersAsync()
+    await approvePromise
+
+    // Verify command API was called with correct URL
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/commands/reapp-block-clear/approve',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    // Verify request body
+    const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    const body = JSON.parse(fetchCall[1].body)
+    expect(body.requestId).toBe('req-bc-123')
+    expect(body.requestNumber).toBe('BC-20241211-ABCD')
+    expect(body.comment).toBe('Approval is justified by customer circumstances')
+  })
+
+  it('should poll /api/reapplication-block-clear-requests after approve command', async () => {
+    const commandResponse = { eventId: 'evt-poll', requestId: 'req-poll', status: 'accepted' }
+    const projectionResponse = {
+      docs: [
+        { id: 'doc-poll', requestId: 'req-poll', requestNumber: 'BC-POLL', status: 'approved' },
+      ],
+    }
+
+    ;(global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(commandResponse) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(projectionResponse) })
+
+    const { result } = renderHook(() => useApproveBlockClear(), {
+      wrapper: createWrapper(),
+    })
+
+    const approvePromise = result.current.approveAsync({
+      requestId: 'req-poll',
+      requestNumber: 'BC-POLL',
+      comment: 'Valid approval comment here',
+    })
+
+    await vi.runAllTimersAsync()
+    await approvePromise
+
+    // Second fetch should be polling the projection collection
+    const pollCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1]
+    expect(pollCall[0]).toContain('/api/reapplication-block-clear-requests')
+    expect(pollCall[0]).toContain('req-poll')
+    expect(pollCall[0]).toContain('approved')
+  })
+
+  it('should handle command API errors gracefully', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: 'Forbidden' } }),
+    })
+
+    const { result } = renderHook(() => useApproveBlockClear(), {
+      wrapper: createWrapper(),
+    })
+
+    await expect(
+      result.current.approveAsync({
+        requestId: 'req-err',
+        requestNumber: 'BC-ERR',
+        comment: 'This should fail due to API error',
+      }),
+    ).rejects.toThrow('Forbidden')
+  })
+
+  it('should start in non-pending state', () => {
+    const { result } = renderHook(() => useApproveBlockClear(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.isPending).toBe(false)
+  })
+})

--- a/tests/unit/hooks/useRequestBlockClear.test.ts
+++ b/tests/unit/hooks/useRequestBlockClear.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useRequestBlockClear } from '@/hooks/mutations/useRequestBlockClear'
+import React from 'react'
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+// Mock error toast utility
+vi.mock('@/lib/utils/error-toast', () => ({
+  showErrorToast: vi.fn(),
+}))
+
+// Create a fresh query client for each test
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function createWrapper() {
+  const queryClient = createTestQueryClient()
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe('useRequestBlockClear', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should expose mutation functions and states', () => {
+    const { result } = renderHook(() => useRequestBlockClear(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(result.current.requestAsync).toBeDefined()
+    expect(result.current.isPending).toBe(false)
+    expect(result.current.isSuccess).toBe(false)
+    expect(result.current.isError).toBe(false)
+  })
+
+  it('should POST to /api/commands/reapp-block-clear/request with correct body', async () => {
+    const commandResponse = {
+      eventId: 'evt-req-123',
+      requestId: 'req-req-123',
+      status: 'accepted',
+      message: 'Block clear submitted',
+    }
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(commandResponse),
+    })
+
+    const { result } = renderHook(() => useRequestBlockClear(), {
+      wrapper: createWrapper(),
+    })
+
+    const requestPromise = result.current.requestAsync({
+      canonicalCustomerId: 'cust-abc-123',
+      reasons: ['SERVICEABILITY'],
+      justification: 'Customer has improved financial situation',
+    })
+
+    await vi.runAllTimersAsync()
+    await requestPromise
+
+    // Verify command API was called with correct URL
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/commands/reapp-block-clear/request',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    // Verify request body
+    const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    const body = JSON.parse(fetchCall[1].body)
+    expect(body.canonicalCustomerId).toBe('cust-abc-123')
+    expect(body.reasons).toEqual(['SERVICEABILITY'])
+    expect(body.justification).toBe('Customer has improved financial situation')
+  })
+
+  it('should NOT poll after request — single-op returns immediately', async () => {
+    const commandResponse = {
+      eventId: 'evt-no-poll',
+      requestId: 'req-no-poll',
+      status: 'accepted',
+    }
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(commandResponse),
+    })
+
+    const { result } = renderHook(() => useRequestBlockClear(), {
+      wrapper: createWrapper(),
+    })
+
+    const requestPromise = result.current.requestAsync({
+      canonicalCustomerId: 'cust-no-poll',
+      reasons: ['SERVICEABILITY'],
+      justification: 'Single-operator path should not poll',
+    })
+
+    await vi.runAllTimersAsync()
+    await requestPromise
+
+    // Only one fetch call — no polling
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('should include optional fields when provided', async () => {
+    const commandResponse = { eventId: 'evt-opt', requestId: 'req-opt', status: 'accepted' }
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(commandResponse),
+    })
+
+    const { result } = renderHook(() => useRequestBlockClear(), {
+      wrapper: createWrapper(),
+    })
+
+    const requestPromise = result.current.requestAsync({
+      canonicalCustomerId: 'cust-opt',
+      reasons: ['SERVICEABILITY'],
+      justification: 'Valid justification for test',
+      conversationId: 'conv-xyz',
+      customerName: 'Jane Doe',
+    })
+
+    await vi.runAllTimersAsync()
+    await requestPromise
+
+    const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    const body = JSON.parse(fetchCall[1].body)
+    expect(body.conversationId).toBe('conv-xyz')
+    expect(body.customerName).toBe('Jane Doe')
+  })
+
+  it('should handle command API errors gracefully', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ error: { message: 'Unauthorized' } }),
+    })
+
+    const { result } = renderHook(() => useRequestBlockClear(), {
+      wrapper: createWrapper(),
+    })
+
+    await expect(
+      result.current.requestAsync({
+        canonicalCustomerId: 'cust-err',
+        reasons: ['SERVICEABILITY'],
+        justification: 'This should fail at the API level',
+      }),
+    ).rejects.toThrow('Unauthorized')
+  })
+})

--- a/tests/unit/routes/reappBlockClearApprove.test.ts
+++ b/tests/unit/routes/reappBlockClearApprove.test.ts
@@ -153,6 +153,9 @@ describe('POST /api/commands/reapp-block-clear/approve', () => {
 
     expect(res.status).toBe(202)
 
+    // payload.find must be called with depth: 0 to enforce scalar IDs
+    expect(mockFind).toHaveBeenCalledWith(expect.objectContaining({ depth: 0 }))
+
     // publishClearAuthorized must be called with maker as operator_id and checker as approved_by
     expect(vi.mocked(publishClearAuthorized)).toHaveBeenCalledTimes(1)
     const clearArg = vi.mocked(publishClearAuthorized).mock.calls[0][0]
@@ -162,6 +165,10 @@ describe('POST /api/commands/reapp-block-clear/approve', () => {
     expect(clearArg.operator_id).not.toBe(clearArg.approval?.approved_by)
     expect(clearArg.request_id).toBe('req-abc')
     expect(clearArg.canonical_customer_id).toBe('c123')
+    expect(clearArg.reasons).toEqual(['PRIOR_DEFAULT'])
+    expect(clearArg.justification).toBe('credit remediation complete')
+    expect(clearArg.approval?.approved_by_name).toBe('Sup User')
+    expect(clearArg.approval?.approval_request_id).toBe('RBC-001') // doc.requestNumber
 
     // createAndPublishEvent must be called with approved event type
     expect(vi.mocked(createAndPublishEvent)).toHaveBeenCalledTimes(1)

--- a/tests/unit/routes/reappBlockClearApprove.test.ts
+++ b/tests/unit/routes/reappBlockClearApprove.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Unit tests for POST /api/commands/reapp-block-clear/approve
+ *
+ * Mocks:
+ *   - next/server             → NextResponse.json returns { body, status }
+ *   - payload                 → getPayload returns { auth: mockAuth, find: mockFind }
+ *   - @payload-config         → default export stub
+ *   - next/headers            → headers() returns stub with entries()
+ *   - @/server/chatledger-publisher  → spy on publishClearAuthorized
+ *   - @/server/event-publisher       → spy on createAndPublishEvent; real EventPublishError
+ *
+ * CRITICAL: self-approval 403 must assert NEITHER publishClearAuthorized
+ * NOR createAndPublishEvent was called.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// next/server mock
+// ---------------------------------------------------------------------------
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Payload mock — auth and find are hoisted spies so tests can override them
+// ---------------------------------------------------------------------------
+const mockAuth = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    user: {
+      id: 'sup-1',
+      firstName: 'Sup',
+      lastName: 'User',
+      role: 'supervisor',
+      email: 'sup@x',
+    },
+  }),
+)
+
+const mockFind = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    docs: [
+      {
+        requestedBy: 'ops-1',
+        status: 'pending',
+        canonicalCustomerId: 'c123',
+        reasons: ['PRIOR_DEFAULT'],
+        justification: 'credit remediation complete',
+        requestNumber: 'RBC-001',
+        requestedAt: '2026-01-01T00:00:00.000Z',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+  }),
+)
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn().mockResolvedValue({
+    auth: mockAuth,
+    find: mockFind,
+  }),
+}))
+
+vi.mock('@payload-config', () => ({ default: {} }))
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue({ entries: () => [] }),
+}))
+
+// ---------------------------------------------------------------------------
+// chatledger-publisher mock
+// ---------------------------------------------------------------------------
+vi.mock('@/server/chatledger-publisher', () => ({
+  publishClearAuthorized: vi.fn().mockResolvedValue({ eventId: 'evt-chatledger-1' }),
+}))
+
+// ---------------------------------------------------------------------------
+// event-publisher mock
+// ---------------------------------------------------------------------------
+vi.mock('@/server/event-publisher', () => ({
+  createAndPublishEvent: vi.fn().mockResolvedValue({
+    eventId: 'evt-approve-1',
+    requestId: 'req-abc',
+    status: 'accepted',
+    message: 'Block clear approved',
+  }),
+  EventPublishError: class EventPublishError extends Error {
+    public readonly attempts: number
+    constructor(msg: string, opts?: { attempts?: number }) {
+      super(msg)
+      this.name = 'EventPublishError'
+      this.attempts = opts?.attempts ?? 1
+    }
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+import { POST } from '@/app/api/commands/reapp-block-clear/approve/route'
+import { publishClearAuthorized } from '@/server/chatledger-publisher'
+import { createAndPublishEvent } from '@/server/event-publisher'
+
+const makeRequest = (body: unknown) => ({ json: async () => body })
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('POST /api/commands/reapp-block-clear/approve', () => {
+  beforeEach(() => {
+    vi.mocked(publishClearAuthorized).mockClear()
+    vi.mocked(createAndPublishEvent).mockClear()
+    mockAuth.mockClear()
+    mockFind.mockClear()
+    // Reset to defaults
+    mockAuth.mockResolvedValue({
+      user: {
+        id: 'sup-1',
+        firstName: 'Sup',
+        lastName: 'User',
+        role: 'supervisor',
+        email: 'sup@x',
+      },
+    })
+    mockFind.mockResolvedValue({
+      docs: [
+        {
+          requestedBy: 'ops-1',
+          status: 'pending',
+          canonicalCustomerId: 'c123',
+          reasons: ['PRIOR_DEFAULT'],
+          justification: 'credit remediation complete',
+          requestNumber: 'RBC-001',
+          requestedAt: '2026-01-01T00:00:00.000Z',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+  })
+
+  it('(a) happy path: checker≠maker, pending → publishClearAuthorized with operator_id=requestedBy, approval.approved_by=user.id; createAndPublishEvent with approved.v1; 202', async () => {
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(202)
+
+    // publishClearAuthorized must be called with maker as operator_id and checker as approved_by
+    expect(vi.mocked(publishClearAuthorized)).toHaveBeenCalledTimes(1)
+    const clearArg = vi.mocked(publishClearAuthorized).mock.calls[0][0]
+    expect(clearArg.operator_id).toBe('ops-1') // MAKER
+    expect(clearArg.approval?.approved_by).toBe('sup-1') // CHECKER
+    // maker≠checker guarantee
+    expect(clearArg.operator_id).not.toBe(clearArg.approval?.approved_by)
+    expect(clearArg.request_id).toBe('req-abc')
+    expect(clearArg.canonical_customer_id).toBe('c123')
+
+    // createAndPublishEvent must be called with approved event type
+    expect(vi.mocked(createAndPublishEvent)).toHaveBeenCalledTimes(1)
+    const eventArg = vi.mocked(createAndPublishEvent).mock.calls[0][0]
+    expect(eventArg.typ).toBe('block_clear_approval.approved.v1')
+    expect(eventArg.payload.approvedBy).toBe('sup-1')
+    expect(eventArg.payload.requestId).toBe('req-abc')
+    expect(eventArg.requestId).toBe('req-abc')
+  })
+
+  it('(b) SELF_APPROVAL: requestedBy===user.id → 403 SELF_APPROVAL; NEITHER publishClearAuthorized NOR createAndPublishEvent called', async () => {
+    // The checker IS the maker
+    mockFind.mockResolvedValueOnce({
+      docs: [
+        {
+          requestedBy: 'sup-1', // same as checker
+          status: 'pending',
+          canonicalCustomerId: 'c123',
+          reasons: ['PRIOR_DEFAULT'],
+          justification: 'self request',
+          requestNumber: 'RBC-002',
+          requestedAt: '2026-01-01T00:00:00.000Z',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-self',
+        requestNumber: 'RBC-002',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('SELF_APPROVAL')
+
+    // CRITICAL: no publish calls must be made
+    expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(c) non-pending (already approved): status≠pending → 400 INVALID_STATE; no publish', async () => {
+    mockFind.mockResolvedValueOnce({
+      docs: [
+        {
+          requestedBy: 'ops-1',
+          status: 'approved',
+          canonicalCustomerId: 'c123',
+          reasons: ['PRIOR_DEFAULT'],
+          justification: 'already done',
+          requestNumber: 'RBC-003',
+          requestedAt: '2026-01-01T00:00:00.000Z',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-done',
+        requestNumber: 'RBC-003',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('INVALID_STATE')
+    expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(d) not found: empty docs → 404 NOT_FOUND; no publish', async () => {
+    mockFind.mockResolvedValueOnce({ docs: [] })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-missing',
+        requestNumber: 'RBC-999',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(404)
+    expect(res.body.error.code).toBe('NOT_FOUND')
+    expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(e) no approval authority (operations role) → 403 FORBIDDEN; no publish', async () => {
+    mockAuth.mockResolvedValueOnce({
+      user: {
+        id: 'ops-2',
+        firstName: 'Ops',
+        lastName: undefined,
+        role: 'operations', // no approval authority
+        email: 'ops2@x',
+      },
+    })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('FORBIDDEN')
+    expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(f) invalid body (comment too short) → 400 VALIDATION_ERROR; no publish', async () => {
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        comment: 'short', // min 10 chars
+      }) as any,
+    )
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(g) unauthenticated (no user) → 401 UNAUTHENTICATED; no publish', async () => {
+    mockAuth.mockResolvedValueOnce({ user: null })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe('UNAUTHENTICATED')
+    expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/routes/reappBlockClearApprove.test.ts
+++ b/tests/unit/routes/reappBlockClearApprove.test.ts
@@ -315,4 +315,34 @@ describe('POST /api/commands/reapp-block-clear/approve', () => {
     expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
     expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
   })
+
+  it('(h) null requestedBy on stored doc → 500 DATA_INTEGRITY; no publish', async () => {
+    mockFind.mockResolvedValueOnce({
+      docs: [
+        {
+          requestedBy: null, // corrupt row
+          status: 'pending',
+          canonicalCustomerId: 'c123',
+          reasons: ['PRIOR_DEFAULT'],
+          justification: 'credit remediation complete',
+          requestNumber: 'RBC-001',
+          requestedAt: '2026-01-01T00:00:00.000Z',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(500)
+    expect(res.body.error.code).toBe('DATA_INTEGRITY')
+    expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
 })

--- a/tests/unit/routes/reappBlockClearCancel.test.ts
+++ b/tests/unit/routes/reappBlockClearCancel.test.ts
@@ -79,6 +79,10 @@ describe('POST /api/commands/reapp-block-clear/cancel', () => {
     )
 
     expect(res.status).toBe(202)
+
+    // payload.find must be called with depth: 0 to enforce scalar relationship IDs
+    expect(mockFind).toHaveBeenCalledWith(expect.objectContaining({ depth: 0 }))
+
     expect(vi.mocked(createAndPublishEvent)).toHaveBeenCalledTimes(1)
 
     const arg = vi.mocked(createAndPublishEvent).mock.calls[0][0]

--- a/tests/unit/routes/reappBlockClearCancel.test.ts
+++ b/tests/unit/routes/reappBlockClearCancel.test.ts
@@ -83,6 +83,8 @@ describe('POST /api/commands/reapp-block-clear/cancel', () => {
 
     const arg = vi.mocked(createAndPublishEvent).mock.calls[0][0]
     expect(arg.typ).toBe('block_clear_approval.cancelled.v1')
+    expect(arg.payload.cancelledBy).toBe('ops-1')
+    expect(arg.payload.requestId).toBe('req-abc')
   })
 
   it('invalid body (missing requestNumber) → 400', async () => {
@@ -94,6 +96,72 @@ describe('POST /api/commands/reapp-block-clear/cancel', () => {
     )
 
     expect(res.status).toBe(400)
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('different user without approval authority → 403, event NOT published', async () => {
+    // requester is 'other-user', auth user is 'ops-2' with role 'operations' (no approval authority)
+    mockFind.mockResolvedValueOnce({ docs: [{ requestedBy: 'other-user' }] })
+    const { requireAuth } = await import('@/lib/auth')
+    vi.mocked(requireAuth).mockResolvedValueOnce({
+      user: {
+        id: 'ops-2',
+        firstName: 'Other',
+        lastName: undefined,
+        role: 'operations',
+        email: 'other@x',
+      },
+      payload: { find: mockFind },
+    } as any)
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-123',
+      }) as any,
+    )
+
+    expect(res.status).toBe(403)
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it("supervisor (approval authority) cancelling someone else's request → 202, event published", async () => {
+    // requester is 'other-user', auth user is a supervisor
+    mockFind.mockResolvedValueOnce({ docs: [{ requestedBy: 'other-user' }] })
+    const { requireAuth } = await import('@/lib/auth')
+    vi.mocked(requireAuth).mockResolvedValueOnce({
+      user: {
+        id: 'sup-1',
+        firstName: 'Sup',
+        lastName: undefined,
+        role: 'supervisor',
+        email: 'sup@x',
+      },
+      payload: { find: mockFind },
+    } as any)
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-xyz',
+        requestNumber: 'RBC-456',
+      }) as any,
+    )
+
+    expect(res.status).toBe(202)
+    expect(vi.mocked(createAndPublishEvent)).toHaveBeenCalledTimes(1)
+  })
+
+  it('not found (payload.find returns empty docs) → 404, event NOT published', async () => {
+    mockFind.mockResolvedValueOnce({ docs: [] })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-missing',
+        requestNumber: 'RBC-999',
+      }) as any,
+    )
+
+    expect(res.status).toBe(404)
     expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/routes/reappBlockClearCancel.test.ts
+++ b/tests/unit/routes/reappBlockClearCancel.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for POST /api/commands/reapp-block-clear/cancel
+ *
+ * Mocks:
+ *   - next/server        → NextResponse.json returns { body, status }
+ *   - @/lib/auth         → requireAuth returns ops user + payload.find spy
+ *   - @/server/event-publisher       → spy on createAndPublishEvent
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// next/server mock
+// ---------------------------------------------------------------------------
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Auth mock — payload.find is a spy so we can configure per-test
+// vi.hoisted needed so mockFind is available inside the factory
+// ---------------------------------------------------------------------------
+const mockFind = vi.hoisted(() => vi.fn().mockResolvedValue({ docs: [{ requestedBy: 'ops-1' }] }))
+
+vi.mock('@/lib/auth', () => ({
+  requireAuth: vi.fn().mockResolvedValue({
+    user: { id: 'ops-1', firstName: 'Op', lastName: undefined, role: 'operations', email: 'op@x' },
+    payload: { find: mockFind },
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// event-publisher mock
+// ---------------------------------------------------------------------------
+vi.mock('@/server/event-publisher', () => ({
+  createAndPublishEvent: vi.fn().mockResolvedValue({
+    eventId: 'evt-cancel-1',
+    requestId: 'req-cancel-1',
+    status: 'accepted',
+    message: 'Cancelled',
+  }),
+  EventPublishError: class EventPublishError extends Error {
+    public readonly attempts: number
+    constructor(msg: string, opts?: { attempts?: number }) {
+      super(msg)
+      this.name = 'EventPublishError'
+      this.attempts = opts?.attempts ?? 1
+    }
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+import { POST } from '@/app/api/commands/reapp-block-clear/cancel/route'
+import { createAndPublishEvent } from '@/server/event-publisher'
+
+const makeRequest = (body: unknown) => ({ json: async () => body })
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('POST /api/commands/reapp-block-clear/cancel', () => {
+  beforeEach(() => {
+    vi.mocked(createAndPublishEvent).mockClear()
+    mockFind.mockClear()
+  })
+
+  it('happy path (original requester): publishes block_clear_approval.cancelled.v1 and returns 202', async () => {
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-123',
+      }) as any,
+    )
+
+    expect(res.status).toBe(202)
+    expect(vi.mocked(createAndPublishEvent)).toHaveBeenCalledTimes(1)
+
+    const arg = vi.mocked(createAndPublishEvent).mock.calls[0][0]
+    expect(arg.typ).toBe('block_clear_approval.cancelled.v1')
+  })
+
+  it('invalid body (missing requestNumber) → 400', async () => {
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        // missing requestNumber
+      }) as any,
+    )
+
+    expect(res.status).toBe(400)
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/routes/reappBlockClearReject.test.ts
+++ b/tests/unit/routes/reappBlockClearReject.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for POST /api/commands/reapp-block-clear/reject
+ *
+ * Mocks:
+ *   - next/server             → NextResponse.json returns { body, status }
+ *   - payload                 → getPayload returns { auth: mockAuth }
+ *   - @payload-config         → default export stub
+ *   - next/headers            → headers() returns stub with entries()
+ *   - @/server/event-publisher       → spy on createAndPublishEvent; real EventPublishError
+ *
+ * No self-check on reject — any supervisor/admin can reject.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// next/server mock
+// ---------------------------------------------------------------------------
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Payload mock
+// ---------------------------------------------------------------------------
+const mockAuth = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    user: {
+      id: 'sup-1',
+      firstName: 'Sup',
+      lastName: 'User',
+      role: 'supervisor',
+      email: 'sup@x',
+    },
+  }),
+)
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn().mockResolvedValue({
+    auth: mockAuth,
+  }),
+}))
+
+vi.mock('@payload-config', () => ({ default: {} }))
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue({ entries: () => [] }),
+}))
+
+// ---------------------------------------------------------------------------
+// event-publisher mock
+// ---------------------------------------------------------------------------
+vi.mock('@/server/event-publisher', () => ({
+  createAndPublishEvent: vi.fn().mockResolvedValue({
+    eventId: 'evt-reject-1',
+    requestId: 'req-abc',
+    status: 'accepted',
+    message: 'Block clear rejected',
+  }),
+  EventPublishError: class EventPublishError extends Error {
+    public readonly attempts: number
+    constructor(msg: string, opts?: { attempts?: number }) {
+      super(msg)
+      this.name = 'EventPublishError'
+      this.attempts = opts?.attempts ?? 1
+    }
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+import { POST } from '@/app/api/commands/reapp-block-clear/reject/route'
+import { createAndPublishEvent } from '@/server/event-publisher'
+
+const makeRequest = (body: unknown) => ({ json: async () => body })
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('POST /api/commands/reapp-block-clear/reject', () => {
+  beforeEach(() => {
+    vi.mocked(createAndPublishEvent).mockClear()
+    mockAuth.mockClear()
+    mockAuth.mockResolvedValue({
+      user: {
+        id: 'sup-1',
+        firstName: 'Sup',
+        lastName: 'User',
+        role: 'supervisor',
+        email: 'sup@x',
+      },
+    })
+  })
+
+  it('(a) happy path: supervisor rejects → createAndPublishEvent with rejected.v1; rejectedBy=user.id; 202', async () => {
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        reason: 'Insufficient evidence provided for the block clear',
+      }) as any,
+    )
+
+    expect(res.status).toBe(202)
+    expect(vi.mocked(createAndPublishEvent)).toHaveBeenCalledTimes(1)
+
+    const arg = vi.mocked(createAndPublishEvent).mock.calls[0][0]
+    expect(arg.typ).toBe('block_clear_approval.rejected.v1')
+    expect(arg.payload.requestId).toBe('req-abc')
+    expect(arg.payload.requestNumber).toBe('RBC-001')
+    expect(arg.payload.rejectedBy).toBe('sup-1')
+    expect(arg.payload.reason).toBe('Insufficient evidence provided for the block clear')
+    expect(arg.requestId).toBe('req-abc')
+  })
+
+  it('(b) invalid body (reason too short) → 400 VALIDATION_ERROR; event NOT published', async () => {
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        reason: 'Too short', // min 10 chars
+      }) as any,
+    )
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(c) invalid body (missing reason) → 400 VALIDATION_ERROR', async () => {
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        // missing reason
+      }) as any,
+    )
+
+    expect(res.status).toBe(400)
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(d) no approval authority (operations role) → 403 FORBIDDEN; event NOT published', async () => {
+    mockAuth.mockResolvedValueOnce({
+      user: {
+        id: 'ops-2',
+        firstName: 'Ops',
+        lastName: undefined,
+        role: 'operations',
+        email: 'ops2@x',
+      },
+    })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        reason: 'Insufficient evidence provided for the block clear',
+      }) as any,
+    )
+
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('FORBIDDEN')
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(e) unauthenticated (no user) → 401 UNAUTHENTICATED; event NOT published', async () => {
+    mockAuth.mockResolvedValueOnce({ user: null })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        reason: 'Insufficient evidence provided for the block clear',
+      }) as any,
+    )
+
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe('UNAUTHENTICATED')
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(f) no self-check: requester and rejecter can be the same user (unlike approve) → 202', async () => {
+    // On reject, there is NO self-approval check — any supervisor can reject anyone's request
+    // (including their own). This is intentional: blocking own-request rejection would prevent
+    // a supervisor from withdrawing a request they mistakenly submitted.
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'RBC-001',
+        reason: 'Reconsidered and deciding to reject this request',
+      }) as any,
+    )
+
+    expect(res.status).toBe(202)
+    expect(vi.mocked(createAndPublishEvent)).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/routes/reappBlockClearRequest.test.ts
+++ b/tests/unit/routes/reappBlockClearRequest.test.ts
@@ -115,6 +115,26 @@ describe('POST /api/commands/reapp-block-clear/request', () => {
 
     const arg = vi.mocked(createAndPublishEvent).mock.calls[0][0]
     expect(arg.typ).toBe('block_clear_approval.requested.v1')
+    expect(arg.payload.requestedBy).toBe('ops-1')
+    expect(arg.payload.reasons).toEqual(['PRIOR_DEFAULT'])
+    expect(arg.payload.justification).toBe('credit remediation complete')
+  })
+
+  it('(b2) PRIOR_SERIOUS_ARREARS (maker-checker) → createAndPublishEvent called; publishClearAuthorized NOT called; 202', async () => {
+    const res = await POST(
+      makeRequest({
+        canonicalCustomerId: 'c123',
+        reasons: ['PRIOR_SERIOUS_ARREARS'],
+        justification: 'arrears resolved',
+      }) as any,
+    )
+
+    expect(res.status).toBe(202)
+    expect(vi.mocked(createAndPublishEvent)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
+
+    const arg = vi.mocked(createAndPublishEvent).mock.calls[0][0]
+    expect(arg.typ).toBe('block_clear_approval.requested.v1')
   })
 
   it('(c) invalid body (empty reasons array) → 400; no publish calls', async () => {

--- a/tests/unit/routes/reappBlockClearRequest.test.ts
+++ b/tests/unit/routes/reappBlockClearRequest.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for POST /api/commands/reapp-block-clear/request
+ *
+ * Mocks:
+ *   - next/server        → NextResponse.json returns { body, status } for easy assertion
+ *   - @/lib/auth         → requireAuth returns a fixed ops user (no Payload/Redis needed)
+ *   - @/server/chatledger-publisher  → spy on publishClearAuthorized
+ *   - @/server/event-publisher       → spy on createAndPublishEvent; real EventPublishError re-exported
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// next/server mock — must be first so hoisting works
+// ---------------------------------------------------------------------------
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Auth mock — returns a fixed ops user; no Payload/Redis side-effects
+// ---------------------------------------------------------------------------
+vi.mock('@/lib/auth', () => ({
+  requireAuth: vi.fn().mockResolvedValue({
+    user: { id: 'ops-1', firstName: 'Op', lastName: undefined, role: 'operations', email: 'op@x' },
+    payload: {},
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// chatledger-publisher mock
+// ---------------------------------------------------------------------------
+vi.mock('@/server/chatledger-publisher', () => ({
+  publishClearAuthorized: vi.fn().mockResolvedValue({ eventId: 'evt-chatledger-1' }),
+}))
+
+// ---------------------------------------------------------------------------
+// event-publisher mock — keep EventPublishError constructable so catch branches work
+// ---------------------------------------------------------------------------
+vi.mock('@/server/event-publisher', () => ({
+  createAndPublishEvent: vi.fn().mockResolvedValue({
+    eventId: 'evt-internal-1',
+    requestId: 'req-internal-1',
+    status: 'accepted',
+    message: 'OK',
+  }),
+  EventPublishError: class EventPublishError extends Error {
+    public readonly attempts: number
+    constructor(msg: string, opts?: { attempts?: number }) {
+      super(msg)
+      this.name = 'EventPublishError'
+      this.attempts = opts?.attempts ?? 1
+    }
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+import { POST } from '@/app/api/commands/reapp-block-clear/request/route'
+import { publishClearAuthorized } from '@/server/chatledger-publisher'
+import { createAndPublishEvent } from '@/server/event-publisher'
+
+// Helper: build a minimal NextRequest-like object
+const makeRequest = (body: unknown) => ({ json: async () => body })
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('POST /api/commands/reapp-block-clear/request', () => {
+  beforeEach(() => {
+    vi.mocked(publishClearAuthorized).mockClear()
+    vi.mocked(createAndPublishEvent).mockClear()
+  })
+
+  it('(a) SERVICEABILITY (single-op) → publishClearAuthorized called with operator_id=ops-1, reasons, justification, request_id; no approval; createAndPublishEvent NOT called; 202', async () => {
+    const res = await POST(
+      makeRequest({
+        canonicalCustomerId: 'c123',
+        conversationId: 'conv-1',
+        reasons: ['SERVICEABILITY'],
+        justification: 'manual review passed',
+      }) as any,
+    )
+
+    expect(res.status).toBe(202)
+    expect(vi.mocked(publishClearAuthorized)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+
+    const arg = vi.mocked(publishClearAuthorized).mock.calls[0][0]
+    expect(arg.operator_id).toBe('ops-1')
+    expect(arg.reasons).toEqual(['SERVICEABILITY'])
+    expect(arg.justification).toBe('manual review passed')
+    expect(arg.request_id).toBeTruthy()
+    // No approval field on single-op path
+    expect((arg as any).approval).toBeUndefined()
+  })
+
+  it('(b) PRIOR_DEFAULT (maker-checker) → createAndPublishEvent called with typ=block_clear_approval.requested.v1; publishClearAuthorized NOT called; 202', async () => {
+    const res = await POST(
+      makeRequest({
+        canonicalCustomerId: 'c123',
+        reasons: ['PRIOR_DEFAULT'],
+        justification: 'credit remediation complete',
+      }) as any,
+    )
+
+    expect(res.status).toBe(202)
+    expect(vi.mocked(createAndPublishEvent)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
+
+    const arg = vi.mocked(createAndPublishEvent).mock.calls[0][0]
+    expect(arg.typ).toBe('block_clear_approval.requested.v1')
+  })
+
+  it('(c) invalid body (empty reasons array) → 400; no publish calls', async () => {
+    const res = await POST(
+      makeRequest({
+        canonicalCustomerId: 'c123',
+        reasons: [], // fails min(1)
+        justification: 'some justification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(400)
+    expect(vi.mocked(publishClearAuthorized)).not.toHaveBeenCalled()
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(c) invalid body (missing justification) → 400', async () => {
+    const res = await POST(
+      makeRequest({
+        canonicalCustomerId: 'c123',
+        reasons: ['SERVICEABILITY'],
+        // missing justification
+      }) as any,
+    )
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/tests/unit/routes/writeoffApproveSelfApproval.test.ts
+++ b/tests/unit/routes/writeoffApproveSelfApproval.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Unit tests for POST /api/commands/writeoff/approve — self-approval guard
+ *
+ * Mocks:
+ *   - next/server             → NextResponse.json returns { body, status }
+ *   - payload                 → getPayload returns { auth: mockAuth, find: mockFind }
+ *   - @payload-config         → default export stub
+ *   - next/headers            → headers() returns stub with entries()
+ *   - @/server/grpc-client    → getLedgerClient returns mock with writeOff spy
+ *   - @/server/event-publisher → spy on createAndPublishEvent; real EventPublishError
+ *
+ * CRITICAL: self-approval 403 must assert NEITHER the ledger client writeOff
+ * NOR createAndPublishEvent was called.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// next/server mock
+// ---------------------------------------------------------------------------
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Payload mock — auth and find are hoisted spies so tests can override them
+// ---------------------------------------------------------------------------
+const mockAuth = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    user: {
+      id: 'sup-1',
+      firstName: 'Sup',
+      lastName: 'User',
+      role: 'supervisor',
+      email: 'sup@x',
+    },
+  }),
+)
+
+const mockFind = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    docs: [
+      {
+        requestedBy: 'ops-1',
+        status: 'pending',
+        loanAccountId: 'acct-123',
+        reason: 'Customer unable to repay',
+      },
+    ],
+  }),
+)
+
+vi.mock('payload', () => ({
+  getPayload: vi.fn().mockResolvedValue({
+    auth: mockAuth,
+    find: mockFind,
+  }),
+}))
+
+vi.mock('@payload-config', () => ({ default: {} }))
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn().mockResolvedValue({ entries: () => [] }),
+}))
+
+// ---------------------------------------------------------------------------
+// grpc-client mock — mock getLedgerClient to return a mock client
+// ---------------------------------------------------------------------------
+const mockWriteOff = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    eventId: 'ledger-evt-1',
+    transaction: { transactionId: 'txn-123' },
+  }),
+)
+
+vi.mock('@/server/grpc-client', () => ({
+  getLedgerClient: vi.fn(() => ({
+    writeOff: mockWriteOff,
+  })),
+}))
+
+// ---------------------------------------------------------------------------
+// event-publisher mock
+// ---------------------------------------------------------------------------
+vi.mock('@/server/event-publisher', () => ({
+  createAndPublishEvent: vi.fn().mockResolvedValue({
+    eventId: 'evt-approve-1',
+    requestId: 'req-abc',
+    status: 'accepted',
+    message: 'Write-off approved',
+  }),
+  EventPublishError: class EventPublishError extends Error {
+    public readonly attempts: number
+    constructor(msg: string, opts?: { attempts?: number }) {
+      super(msg)
+      this.name = 'EventPublishError'
+      this.attempts = opts?.attempts ?? 1
+    }
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+import { POST } from '@/app/api/commands/writeoff/approve/route'
+import { getLedgerClient } from '@/server/grpc-client'
+import { createAndPublishEvent } from '@/server/event-publisher'
+
+const makeRequest = (body: unknown) => ({ json: async () => body })
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('POST /api/commands/writeoff/approve — self-approval guard', () => {
+  beforeEach(() => {
+    vi.mocked(createAndPublishEvent).mockClear()
+    vi.mocked(getLedgerClient).mockClear()
+    mockWriteOff.mockClear()
+    mockAuth.mockClear()
+    mockFind.mockClear()
+    // Reset to defaults
+    mockAuth.mockResolvedValue({
+      user: {
+        id: 'sup-1',
+        firstName: 'Sup',
+        lastName: 'User',
+        role: 'supervisor',
+        email: 'sup@x',
+      },
+    })
+    mockFind.mockResolvedValue({
+      docs: [
+        {
+          requestedBy: 'ops-1',
+          status: 'pending',
+          loanAccountId: 'acct-123',
+          reason: 'Customer unable to repay',
+        },
+      ],
+    })
+  })
+
+  it('(a) happy path: checker≠maker, pending → ledger writeOff called; createAndPublishEvent called; 202', async () => {
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'WOR-001',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(202)
+
+    // payload.find must be called with depth: 0 to enforce scalar requestedBy id
+    expect(mockFind).toHaveBeenCalledWith(expect.objectContaining({ depth: 0 }))
+
+    // Ledger must be called
+    expect(mockWriteOff).toHaveBeenCalledTimes(1)
+
+    // createAndPublishEvent must be called
+    expect(vi.mocked(createAndPublishEvent)).toHaveBeenCalledTimes(1)
+    const eventArg = vi.mocked(createAndPublishEvent).mock.calls[0][0]
+    expect(eventArg.payload.approvedBy).toBe('sup-1')
+    expect(eventArg.payload.requestId).toBe('req-abc')
+  })
+
+  it('(b) SELF_APPROVAL: requestedBy===user.id → 403 SELF_APPROVAL; NEITHER ledger writeOff NOR createAndPublishEvent called', async () => {
+    // The checker IS the maker — same id as the authenticated user
+    mockFind.mockResolvedValueOnce({
+      docs: [
+        {
+          requestedBy: 'sup-1', // same as authenticated user sup-1
+          status: 'pending',
+          loanAccountId: 'acct-123',
+          reason: 'Customer unable to repay',
+        },
+      ],
+    })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-self',
+        requestNumber: 'WOR-002',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('SELF_APPROVAL')
+    expect(res.body.error.message).toMatch(/cannot approve your own/i)
+
+    // CRITICAL: no ledger or publish calls must be made
+    expect(mockWriteOff).not.toHaveBeenCalled()
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(b2) SELF_APPROVAL with numeric id coercion: requestedBy===user.id as different types → 403 SELF_APPROVAL', async () => {
+    // Verify String() coercion works across type boundaries
+    mockAuth.mockResolvedValueOnce({
+      user: {
+        id: 42, // numeric id
+        firstName: 'Admin',
+        lastName: 'User',
+        role: 'supervisor',
+        email: 'admin@x',
+      },
+    })
+    mockFind.mockResolvedValueOnce({
+      docs: [
+        {
+          requestedBy: 42, // same numeric id
+          status: 'pending',
+          loanAccountId: 'acct-123',
+          reason: 'Customer unable to repay',
+        },
+      ],
+    })
+
+    const res = await POST(
+      makeRequest({
+        requestId: 'req-self-2',
+        requestNumber: 'WOR-003',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('SELF_APPROVAL')
+    expect(mockWriteOff).not.toHaveBeenCalled()
+    expect(vi.mocked(createAndPublishEvent)).not.toHaveBeenCalled()
+  })
+
+  it('(c) find called with depth: 0 (no relationship population, scalar requestedBy)', async () => {
+    await POST(
+      makeRequest({
+        requestId: 'req-abc',
+        requestNumber: 'WOR-001',
+        comment: 'Reviewed and approved after verification',
+      }) as any,
+    )
+
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'write-off-requests',
+        depth: 0,
+      }),
+    )
+  })
+})

--- a/tests/unit/server/chatledgerPublisher.test.ts
+++ b/tests/unit/server/chatledgerPublisher.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const xadd = vi.fn().mockResolvedValue('1-0')
+vi.mock('@/server/redis-client', () => ({
+  getChatLedgerRedisClient: () => ({ xadd }),
+}))
+
+import { publishClearAuthorized } from '@/server/chatledger-publisher'
+
+beforeEach(() => xadd.mockClear())
+
+describe('publishClearAuthorized', () => {
+  it('xadds a chatLedger LedgerMessage with agt=billie-crm and the ops conv', async () => {
+    const res = await publishClearAuthorized({
+      canonical_customer_id: 'c123',
+      reasons: ['SERVICEABILITY'],
+      operator_id: 'ops-1',
+      justification: 'manual assessment',
+      request_id: 'req-1',
+      requested_at: '2026-06-28T00:00:00.000Z',
+    })
+    expect(res.eventId).toBeTruthy()
+    expect(xadd).toHaveBeenCalledTimes(1)
+    const [stream, star, ...flat] = xadd.mock.calls[0]
+    expect(stream).toBe('chatLedger')
+    expect(star).toBe('*')
+    const fields = Object.fromEntries(
+      flat.reduce((acc: string[][], v: string, i: number) => {
+        if (i % 2 === 0) acc.push([v, flat[i + 1]])
+        return acc
+      }, []),
+    )
+    expect(fields.agt).toBe('billie-crm')
+    expect(fields.typ).toBe('reapplication_block.clear_authorized.v1')
+    expect(fields.conv).toBe('ops:block-clear:req-1')
+    expect(fields.usr).toBe('c123')
+    expect(fields.cls).toBe('cmd')
+    expect(JSON.parse(fields.payload).request_id).toBe('req-1')
+  })
+})

--- a/tests/unit/server/chatledgerPublisher.test.ts
+++ b/tests/unit/server/chatledgerPublisher.test.ts
@@ -36,5 +36,7 @@ describe('publishClearAuthorized', () => {
     expect(fields.usr).toBe('c123')
     expect(fields.cls).toBe('cmd')
     expect(JSON.parse(fields.payload).request_id).toBe('req-1')
+    expect(fields.seq).toBe('1')
+    expect(fields.cause).toBeTruthy()
   })
 })

--- a/tests/unit/ui/approvals-view.test.tsx
+++ b/tests/unit/ui/approvals-view.test.tsx
@@ -7,6 +7,30 @@ import { ApprovalsView } from '@/components/ApprovalsView'
 const mockFetch = vi.fn()
 global.fetch = mockFetch
 
+// ApprovalsView also renders <BlockClearList>, which fetches via
+// usePendingBlockClears. These tests cover only the write-off approvals queue,
+// so stub the block-clears hook to "no pending requests" — otherwise it shares
+// the fetch mock above and renders a duplicate table (duplicate text breaks the
+// queries below).
+vi.mock('@/hooks/queries/usePendingBlockClears', () => ({
+  usePendingBlockClears: () => ({
+    data: {
+      docs: [],
+      totalDocs: 0,
+      limit: 20,
+      page: 1,
+      totalPages: 0,
+      hasNextPage: false,
+      hasPrevPage: false,
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isFetching: false,
+  }),
+}))
+
 // Create a fresh QueryClient for each test
 function createTestQueryClient() {
   return new QueryClient({

--- a/tests/unit/ui/block-clear-list.test.tsx
+++ b/tests/unit/ui/block-clear-list.test.tsx
@@ -1,0 +1,83 @@
+import { describe, test, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+/**
+ * Unit tests for BlockClearList row rendering.
+ *
+ * Regression: the row rendered `request.reasons.join(', ')`, which threw
+ * "Cannot read properties of undefined (reading 'join')" whenever a request
+ * arrived without a `reasons` array (the API/projection does not guarantee it,
+ * despite the type declaring it required). BlockClearList must render a fallback
+ * instead of crashing.
+ */
+
+const { hook } = vi.hoisted(() => ({
+  hook: { result: null as unknown },
+}))
+
+vi.mock('@/hooks/queries/usePendingBlockClears', () => ({
+  usePendingBlockClears: () => hook.result,
+}))
+
+// Keep this a focused unit test — stub the detail drawer child.
+vi.mock('@/components/ApprovalsView/BlockClearDetailDrawer', () => ({
+  BlockClearDetailDrawer: () => null,
+}))
+
+import { BlockClearList } from '@/components/ApprovalsView/BlockClearList'
+
+type Doc = Record<string, unknown>
+
+function asLoaded(docs: Doc[]) {
+  hook.result = {
+    data: {
+      docs,
+      totalDocs: docs.length,
+      totalPages: 1,
+      page: 1,
+      hasNextPage: false,
+      hasPrevPage: false,
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    isFetching: false,
+  }
+}
+
+afterEach(() => cleanup())
+
+describe('BlockClearList row rendering', () => {
+  test('does not crash when a request has no reasons', () => {
+    asLoaded([
+      {
+        id: 'r1',
+        requestNumber: 'BCR-1',
+        customerName: 'Jane Doe',
+        requestedByName: 'Op One',
+        createdAt: '2026-06-01T00:00:00Z',
+        reasons: undefined,
+      },
+    ])
+
+    expect(() => render(<BlockClearList />)).not.toThrow()
+    expect(screen.getByTestId('block-clear-row-r1')).toBeInTheDocument()
+  })
+
+  test('joins reasons with a comma when present', () => {
+    asLoaded([
+      {
+        id: 'r2',
+        requestNumber: 'BCR-2',
+        customerName: 'Jane Doe',
+        requestedByName: 'Op One',
+        createdAt: '2026-06-01T00:00:00Z',
+        reasons: ['SCREENING_HIT', 'ADDRESS_MISMATCH'],
+      },
+    ])
+
+    render(<BlockClearList />)
+    expect(screen.getByText('SCREENING_HIT, ADDRESS_MISMATCH')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

The complete billie-crm side of **manual block clear** — the operator-facing half of the feature whose billieChat core is **billieChat PR #110**. An operator can clear a returning-customer re-application eligibility block so the person can re-apply, with **maker-checker approval for default-class reasons** and **single-operator** clearing for windowed declines.

Built in three plans (`docs/superpowers/plans/2026-06-28-manual-block-clear-crm-{backend,routes,ui}.md`), subagent-driven TDD with per-task + two whole-branch (opus) reviews.

## What's here

**B1 — backend contract**
- Event types/Zod schemas/config; the **chatLedger producer** (`publishClearAuthorized` → `reapplication_block.clear_authorized.v1`, `agt=billie-crm`); the `reapplication_block_clear_requests` migration + Payload collection; the Python `block_clear_approval.*` lifecycle handlers; and the `cleared`/`clear_rejected` projection (clears conversations **by canonical**, NULLing the block per spec §14).

**B2 — command routes**
- `/api/commands/reapp-block-clear/{request,approve,reject,cancel}`. `request` tiers by reason: single-operator (windowed declines) emits the clear directly; any default-class reason raises a maker-checker approval request.
- **Server-side maker≠checker** on `approve` (`operator_id`=maker, `approval.approved_by`=checker, guaranteed to differ; `depth: 0` on the lookup makes the comparison real — the whole-branch review confirmed this is load-bearing). billieChat independently fail-closes on the attestation, so it's defense-in-depth.
- **Companion fix:** the same server-side maker≠checker guard (+ `depth: 0`) added to the existing **write-off** approve route, which previously enforced it only in the UI.

**B3 — UI**
- React Query hooks (`use{Request,Approve,Reject,Cancel}BlockClear`, `usePendingBlockClears`) + `pollForBlockClearUpdate`.
- A **"Clear block" action** (button + modal, reasons limited to clearable set, mandatory justification, approval-required notice) on the **customer ServicingView** and the conversation DecisionBanner, role-gated.
- A **block-clear approvals queue** in ApprovalsView (parallel `BlockClear*` components, self-approval-disabled Approve button), additive to the working write-off queue.

## Testing & review

- `pnpm typecheck` **0 errors**; vitest unit (routes/events/hooks/components) **343 pass**; event-processor block-clear + reapplication **58 pass**; B1 collection int test green (Postgres testcontainer).
- Whole-branch (opus) reviews on B1 and on B2+B3 — both **ready to merge**. The reviews caught and fixed: a cross-service phantom-conversation-row bug (B1), a `depth: 0` self-approval-bypass (B2), a typecheck escape in the approve route (B2), and a dead Clear-block button (B3).

## ⚠️ Needs human follow-up before/after merge

- **Visual QA** of the admin UI components (Clear-block modal, the approvals queue tab/drawer) — automated tests cover logic/wiring, not layout. A Playwright e2e mirroring the write-off approvals e2e is recommended.
- **Regenerate the Payload `.json` schema snapshot** for the new migration (hand-authored) before the next `migrate:create`.
- **Follow-up ticket:** `writeoff/cancel` has the same "skip authz when request not found" ordering that was fixed in the block-clear cancel route (left out of scope here).
- Known: the `approve` route's two publishes (chatLedger + CRM stream) aren't atomic — `request_id` is billieChat's idempotency key, and a partial failure leaves the CRM row `pending` (ops-visible); a future outbox/saga is the clean fix.

## Governance

Maker-checker gates the default-class reasons (`PRIOR_DEFAULT`, `PRIOR_SERIOUS_ARREARS`); single-operator handles windowed declines. Confirm with compliance that the approver role set (admin/supervisor) and single-operator scope are correct before enabling in prod. The billieChat side is feature-flagged `ENABLE_MANUAL_BLOCK_CLEAR` (default off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
