### PR TITLE
fix(reapplication): auto-clear ACTIVE_LOAN servicing banner on loan repayment

### DIFF
--- a/event-processor/src/billie_servicing/handlers/reapplication.py
+++ b/event-processor/src/billie_servicing/handlers/reapplication.py
@@ -381,3 +381,64 @@ async def handle_reapplication_block_clear_rejected(
         log.warning("Rejected event without resolvable customer id — no customer mirror")
 
     log.info("Re-application block clear rejected")
+
+
+async def handle_reapplication_block_auto_cleared(
+    pool: asyncpg.Pool, event: dict[str, Any]
+) -> None:
+    """Handle ``reapplication_block.auto_cleared.v1``.
+
+    Emitted by billieChat's reapplicationBlock service when a customer's LAST
+    open loan is repaid, so the ACTIVE_LOAN eligibility condition no longer
+    applies. Unlike the operator-driven ``cleared`` flow, this fires
+    automatically on repayment — for ANY customer closing a loan — so it must be
+    a precise no-op for anyone not currently shown as ACTIVE_LOAN blocked.
+
+    Only the CUSTOMER-level "currently blocked" mirror is touched:
+    * ``residual_block_reason`` is None → the person is no longer blocked at all;
+      NULL ``reapplication_block_reason`` so the servicing banner clears.
+    * a residual reason (e.g. PRIOR_DEFAULT still blocks) → correct the banner to
+      that reason instead of clearing.
+
+    The conversation-level "why was THIS application declined" record is left
+    untouched — that decline was correct at the time and is audit history.
+
+    Guarded ``WHERE reapplication_block_reason = 'ACTIVE_LOAN'`` so it never
+    inserts a phantom row, never stamps customers who were never blocked, and
+    never overrides a higher-precedence reason already shown.
+    """
+    payload = parse_payload(event)
+    customer_id = (
+        safe_str(
+            payload.get("canonical_customer_id") or event.get("usr"),
+            "customer_id",
+        )
+        or None
+    )
+    canonical = await resolve_canonical_customer_id(pool, customer_id)
+    residual = payload.get("residual_block_reason")  # None = fully unblocked
+    cleared_at = coerce_date(payload.get("cleared_at"))
+
+    log = logger.bind(canonical_customer_id=canonical, residual_block_reason=residual)
+    log.info("Processing reapplication_block.auto_cleared.v1")
+
+    if not canonical:
+        log.warning("auto_cleared event without resolvable customer id — no-op")
+        return
+
+    status = await pool.execute(
+        """
+        UPDATE customers
+        SET reapplication_block_reason = $2,
+            reapplication_block_clear_status = 'auto_cleared',
+            reapplication_block_cleared_at = $3,
+            updated_at = $4
+        WHERE customer_id = $1
+          AND reapplication_block_reason = 'ACTIVE_LOAN'
+        """,
+        canonical,
+        residual,
+        cleared_at,
+        datetime.now(UTC),
+    )
+    log.info("Re-application ACTIVE_LOAN block auto-cleared", update_status=status)

--- a/event-processor/src/billie_servicing/main.py
+++ b/event-processor/src/billie_servicing/main.py
@@ -28,6 +28,7 @@ from .handlers import (
     handle_reapplication_blocked,
     handle_reapplication_block_cleared,
     handle_reapplication_block_clear_rejected,
+    handle_reapplication_block_auto_cleared,
     # Conversation handlers
     handle_conversation_started,
     handle_utterance,
@@ -173,6 +174,12 @@ def setup_handlers(processor: EventProcessor) -> None:
     )
     processor.register_handler(
         "reapplication_block.clear_rejected.v1", handle_reapplication_block_clear_rejected
+    )
+    # Automatic clear when a customer's last open loan is repaid (the ACTIVE_LOAN
+    # eligibility condition lapses) — clears the stale servicing "Active loan"
+    # banner without operator action.
+    processor.register_handler(
+        "reapplication_block.auto_cleared.v1", handle_reapplication_block_auto_cleared
     )
 
     # Identity verification report archival (PR #67)

--- a/event-processor/tests/test_reapplication_auto_clear.py
+++ b/event-processor/tests/test_reapplication_auto_clear.py
@@ -1,0 +1,73 @@
+"""reapplication_block.auto_cleared.v1 → customer servicing banner refresh.
+
+Emitted by billieChat when a customer's LAST open loan is repaid (the
+ACTIVE_LOAN eligibility condition lapses). The CRM must refresh ONLY the
+customer-level "currently blocked" mirror, guarded to rows currently shown as
+ACTIVE_LOAN, and must leave the conversation-level decline history untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from billie_servicing.handlers.reapplication import (
+    handle_reapplication_block_auto_cleared,
+)
+
+
+def _event(**payload):
+    payload.setdefault("canonical_customer_id", "8E0BC002")
+    payload.setdefault("cleared_reasons", ["ACTIVE_LOAN"])
+    payload.setdefault("trigger", "account_closed")
+    payload.setdefault("cleared_at", "2026-07-03T00:22:41+00:00")
+    return {
+        "typ": "reapplication_block.auto_cleared.v1",
+        "usr": payload["canonical_customer_id"],
+        "conv": "auto-clear:8E0BC002:acct-1",
+        "seq": 8,
+        "payload": payload,
+    }
+
+
+class TestAutoClear:
+    async def test_nulls_reason_when_fully_unblocked(self, mock_pool):
+        await handle_reapplication_block_auto_cleared(
+            mock_pool, _event(residual_block_reason=None)
+        )
+        upd = mock_pool.last_update("customers")
+        assert upd is not None
+        assert upd["reapplication_block_reason"] is None
+        assert upd["reapplication_block_clear_status"] == "auto_cleared"
+        # Guarded to ACTIVE_LOAN rows only — never overrides a higher reason.
+        sql = mock_pool.calls_against("customers")[-1].sql
+        assert "reapplication_block_reason = 'ACTIVE_LOAN'" in sql
+
+    async def test_sets_residual_reason_when_still_blocked(self, mock_pool):
+        await handle_reapplication_block_auto_cleared(
+            mock_pool, _event(residual_block_reason="PRIOR_DEFAULT")
+        )
+        upd = mock_pool.last_update("customers")
+        assert upd["reapplication_block_reason"] == "PRIOR_DEFAULT"
+        assert upd["reapplication_block_clear_status"] == "auto_cleared"
+
+    async def test_does_not_touch_conversations(self, mock_pool):
+        # The per-application decline reason is audit history and must remain.
+        await handle_reapplication_block_auto_cleared(
+            mock_pool, _event(residual_block_reason=None)
+        )
+        assert not mock_pool.has_call_against("conversations")
+
+    async def test_no_customer_id_is_noop(self, mock_pool):
+        event = _event(residual_block_reason=None)
+        event["payload"]["canonical_customer_id"] = None
+        event["usr"] = None
+        await handle_reapplication_block_auto_cleared(mock_pool, event)
+        assert not mock_pool.has_call_against("customers")
+
+    async def test_string_payload_parsed_defensively(self, mock_pool):
+        import json
+
+        event = _event(residual_block_reason=None)
+        event["payload"] = json.dumps(event["payload"])
+        await handle_reapplication_block_auto_cleared(mock_pool, event)
+        assert mock_pool.last_update("customers") is not None


### PR DESCRIPTION
## Problem

The servicing view kept showing **"Re-application blocked — Active loan (while loan open)"** for a customer whose loan was fully repaid (paid off, $0 outstanding). The CRM only ever **sets** the customer-level block mirror (`handle_reapplication_blocked`) — nothing cleared it on repayment. `handle_account_closed` updates the loan-account row but never touches the `customers.reapplication_block_*` columns, so the banner is stuck forever. And because `ACTIVE_LOAN` is deliberately **not** operator-clearable, the greyed "Clear block" button can't release it either — a dead end.

## Fix

New handler `handle_reapplication_block_auto_cleared` consuming **`reapplication_block.auto_cleared.v1`** (emitted by billieChat's reapplicationBlock service when a customer's last open loan is repaid — see billieChat PR #121). It refreshes **only** the customer-level "currently blocked" mirror:
- `residual_block_reason` is null → NULL `reapplication_block_reason` so the banner clears;
- a residual reason (e.g. `PRIOR_DEFAULT` still blocks) → correct the banner to that reason instead of clearing.

The **conversation-level** decline history is left untouched — that decline was correct at the time and is audit. The `UPDATE` is guarded `WHERE reapplication_block_reason = 'ACTIVE_LOAN'`, so it fires automatically on any loan closure yet is a precise no-op for anyone not currently shown as ACTIVE_LOAN-blocked (never inserts a phantom row, never overrides a higher-precedence reason).

## Tests
5 new (`test_reapplication_auto_clear.py`); existing block-clear/reapplication suites (58) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7Ho4HCdHW9pTjudWYgZfu
