### PR TITLE
fix(event-processor): re-export handle_reapplication_block_auto_cleared (main won't start)

### DIFF
--- a/event-processor/src/billie_servicing/handlers/__init__.py
+++ b/event-processor/src/billie_servicing/handlers/__init__.py
@@ -23,6 +23,7 @@ from .reapplication import (
     handle_reapplication_blocked,
     handle_reapplication_block_cleared,
     handle_reapplication_block_clear_rejected,
+    handle_reapplication_block_auto_cleared,
 )
 from .conversation import (
     handle_conversation_started,
@@ -91,6 +92,7 @@ __all__ = [
     "handle_reapplication_blocked",
     "handle_reapplication_block_cleared",
     "handle_reapplication_block_clear_rejected",
+    "handle_reapplication_block_auto_cleared",
     # Identity verification archival (PR #67)
     "handle_identity_report_archived",
     # Conversation handlers

--- a/event-processor/tests/test_handler_exports.py
+++ b/event-processor/tests/test_handler_exports.py
@@ -1,0 +1,42 @@
+"""Guard: every handler main.py imports from `.handlers` must be re-exported.
+
+main.py does ``from .handlers import (...)`` and registers each name, so a
+handler added to a submodule (e.g. handlers/reapplication.py) but not re-exported
+from handlers/__init__.py makes ``import billie_servicing.main`` — the
+event-processor entrypoint — raise ImportError at startup, even though the
+handler's own unit tests (which import the submodule directly) still pass.
+
+This parses main.py's `from .handlers import (...)` block statically and asserts
+each name resolves on the handlers package. It needs no billie SDKs (it does not
+import main.py, which pulls the accounts/customers SDKs via processor.py).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import billie_servicing.handlers as handlers_pkg
+
+_MAIN_PY = Path(handlers_pkg.__file__).parent.parent / "main.py"
+
+
+def _names_imported_from_handlers() -> list[str]:
+    tree = ast.parse(_MAIN_PY.read_text())
+    names: list[str] = []
+    for node in ast.walk(tree):
+        # `from .handlers import (...)` → module="handlers", level=1
+        if isinstance(node, ast.ImportFrom) and node.module == "handlers" and node.level == 1:
+            names.extend(alias.name for alias in node.names)
+    return names
+
+
+def test_main_imports_from_handlers_are_all_reexported():
+    imported = _names_imported_from_handlers()
+    assert imported, "expected main.py to import handlers from `.handlers`"
+    missing = [n for n in imported if not hasattr(handlers_pkg, n)]
+    assert not missing, (
+        "main.py imports these from billie_servicing.handlers but they are not "
+        f"re-exported in handlers/__init__.py (import billie_servicing.main would "
+        f"raise ImportError): {missing}"
+    )


### PR DESCRIPTION
## Broken main

PR #36 added `handle_reapplication_block_auto_cleared` to `handlers/reapplication.py` and registered it in `main.py` (`from .handlers import (...)`), but never re-exported it from `handlers/__init__.py`. So **`import billie_servicing.main` — the event-processor entrypoint — raises `ImportError` on `main` right now**; the processor won't start. It slipped past CI because the handler's unit tests import the submodule directly, not via the package.

## Fix
- Add `handle_reapplication_block_auto_cleared` to the `from .reapplication import (...)` block and `__all__` in `handlers/__init__.py` (two lines).
- Add `test_handler_exports.py`: a guard that statically parses `main.py`'s `from .handlers import (...)` block and asserts every name is re-exported by the package. SDK-free (doesn't import `main.py`), so it runs in the normal suite and catches this whole class of startup break going forward.

Reproduced the ImportError pre-fix; post-fix the import resolves and 52 related tests pass (guard + auto-clear + reapplication + block-clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7Ho4HCdHW9pTjudWYgZfu