### PR TITLE
fix(event-processor): add CI test job and repair stale dedup test

### DIFF
--- a/.github/workflows/event-processor-tests.yml
+++ b/.github/workflows/event-processor-tests.yml
@@ -1,0 +1,66 @@
+name: event-processor tests
+
+# Runs the Python event-processor test suite on PRs and pushes that touch it.
+# These are pure unit tests (handlers run against an in-memory MockPool — see
+# event-processor/tests/conftest.py), so no Postgres/Redis services are needed.
+
+on:
+  pull_request:
+    paths:
+      - 'event-processor/**'
+      - '.github/workflows/event-processor-tests.yml'
+
+# Cancel superseded runs on the same ref (e.g. a force-push to a PR branch).
+concurrency:
+  group: event-processor-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: pytest (python 3.11)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: event-processor
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: event-processor/requirements-dev.txt
+
+      # requirements.txt pulls the private Billie Event SDKs from
+      # github.com/BillieLoans/billie-event-sdks and expands ${GITHUB_TOKEN}
+      # in the git+https URLs. The workflow's automatic GITHUB_TOKEN is scoped
+      # to THIS repo and cannot clone that one, so a separate token is required
+      # (a PAT or GitHub App token with read access to the SDK repo, stored as
+      # the repo/org secret SDK_GITHUB_TOKEN — see event-processor/README).
+      - name: Check SDK token is configured
+        env:
+          SDK_GITHUB_TOKEN: ${{ secrets.SDK_GITHUB_TOKEN }}
+        run: |
+          if [ -z "$SDK_GITHUB_TOKEN" ]; then
+            echo "::error::secrets.SDK_GITHUB_TOKEN is not set. Add a token with read"
+            echo "::error::access to BillieLoans/billie-event-sdks (repo or org secret)."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        env:
+          # requirements.txt expands ${GITHUB_TOKEN}; feed it from our SDK secret.
+          GITHUB_TOKEN: ${{ secrets.SDK_GITHUB_TOKEN }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        env:
+          # Matches the Dockerfile (ENV PYTHONPATH=/app/src) — the billie_servicing
+          # package lives under src/ and is not pip-installed in this job.
+          PYTHONPATH: src
+        run: pytest

--- a/event-processor/README.md
+++ b/event-processor/README.md
@@ -121,6 +121,25 @@ poetry run mypy src
 poetry run ruff check src
 ```
 
+The suite is pure unit tests — handlers run against an in-memory `MockPool`
+(`tests/conftest.py`) that records SQL calls, so no Postgres or Redis is needed.
+
+### Continuous integration
+
+`.github/workflows/event-processor-tests.yml` runs `pytest` on every PR that touches
+`event-processor/**`.
+
+Because the automatic GitHub Actions `GITHUB_TOKEN` is scoped to this repo and cannot
+clone the separate `billie-event-sdks` repo, the job reads the SDK token from a repo
+(or org) secret named **`SDK_GITHUB_TOKEN`**. Create it once:
+
+```bash
+gh secret set SDK_GITHUB_TOKEN --repo BillieLoans/billie-crm   # paste a PAT / App token
+```
+
+The token needs read access to `BillieLoans/billie-event-sdks`. A fine-grained PAT
+(Contents: Read on that repo) or a GitHub App installation token both work.
+
 ## Architecture
 
 ```

--- a/event-processor/tests/test_payload_size.py
+++ b/event-processor/tests/test_payload_size.py
@@ -23,7 +23,8 @@ def processor():
     """Create a processor with mocked Redis and DB."""
     proc = EventProcessor()
     proc.redis = MagicMock()
-    proc.redis.set = AsyncMock(return_value=True)  # Atomic dedup: key was set (not a duplicate)
+    proc.redis.exists = AsyncMock(return_value=0)  # Dedup CHECK: 0 = not seen before
+    proc.redis.set = AsyncMock(return_value=True)  # Dedup mark, written after handler succeeds
     proc.redis.xack = AsyncMock()
     proc.redis.xadd = AsyncMock()  # DLQ write
     proc.db = MagicMock()
@@ -112,5 +113,8 @@ class TestPayloadSizeLimit:
 
         await processor._process_message(message, settings.inbox_stream)
 
-        # Dedup check (redis.set with nx=True) should NOT have been called
+        # Dedup check (redis.exists) should NOT have been called — the size
+        # check rejects the message before we spend a Redis round-trip. The
+        # after-success mark (redis.set) is likewise never reached.
+        processor.redis.exists.assert_not_called()
         processor.redis.set.assert_not_called()


### PR DESCRIPTION
## What & why

The event-processor's Python suite never ran in CI (this repo had **no GitHub Actions at all** — the Cursor bot was the only check). That's why the missing-export bug in #36 slipped through. This PR adds the missing safety net.

### 1. New CI job — `.github/workflows/event-processor-tests.yml`
- Runs `pytest` on every **PR** that touches `event-processor/**` (or the workflow file).
- PR-only trigger, path-filtered, `cancel-in-progress` on — to conserve Actions minutes.
- No service containers: the suite is pure unit tests against an in-memory `MockPool` (`tests/conftest.py`).

### 2. Fixed two tests that were already red on `main`
Wiring up CI surfaced a pre-existing break. On **2026-06-09**, commit `4f70654` redesigned dedup from an atomic `redis.set(nx=True)` to a check-then-set-after-success flow (`await redis.exists(key)` up front). `test_payload_size.py`'s fixture (from 2026-03-29) was never updated — it stubbed `redis.set` but not `redis.exists`, so `await self.redis.exists(...)` hit a bare `MagicMock` → `TypeError`, and the handler was never reached. Invisible for ~a month because the suite never ran in CI.

Fix: stub `redis.exists` and tighten `test_oversized_payload_skips_dedup_check` to assert on the real dedup primitive. **Full suite now green — 254 passed** (verified on a clean Python 3.11 venv running the exact CI recipe).

### 3. README — documented the CI job and the required secret.

## ⚠️ Action required before CI goes green
The job installs the private Billie Event SDKs, which the automatic Actions `GITHUB_TOKEN` **cannot** clone (it's scoped to this repo). Add a repo/org secret **`SDK_GITHUB_TOKEN`** with read access to `BillieLoans/billie-event-sdks`:

```bash
gh secret set SDK_GITHUB_TOKEN --repo BillieLoans/billie-crm   # PAT / App token
```

Until it exists, the job fails fast at a clear "Check SDK token is configured" step (so **this PR's own check will be red**). The next event-processor PR after the secret is added exercises it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NKea9WT8LoA12qUeureUb
