### PR TITLE
feat(marketing): route intake fallback via broker, not direct inbox write

### DIFF
--- a/src/app/api/intake/waitlist/route.ts
+++ b/src/app/api/intake/waitlist/route.ts
@@ -5,24 +5,22 @@
  * site's waitlist form. Callers authenticate via a shared API key + HMAC
  * body signature (see @/lib/intake-auth) rather than a Payload session.
  *
- * gRPC-primary, Redis-fallback: the write goes straight to the platform's
+ * gRPC-primary, chatLedger-fallback: the write goes straight to the platform's
  * MarketingService.UpsertContact over gRPC. If that fails for any reason
  * (network blip, deploy, deadline exceeded), the request is never dropped —
- * it's queued as a `contact.intake.requested.v1` command onto the
- * `inbox:marketing` Redis stream, which the platform's event processor
- * consumes via `_handle_intake_command` / `build_contact_observed`. Both
+ * it's published as a `contact.intake.requested.v1` command onto `chatLedger`,
+ * and billieChat's Broker routes it to the marketingService inbox (which
+ * consumes it via `_handle_intake_command` / `build_contact_observed`). Both
  * paths carry the same idempotency_key, so a client retry (or the queued
  * command being processed later) can never create a duplicate contact.
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { nanoid } from 'nanoid'
 import { WaitlistIntakeSchema, type WaitlistIntake } from '@/lib/schemas/intake'
 import { verifyIntakeAuth } from '@/lib/intake-auth'
 import { upsertContact } from '@/server/marketing-grpc-client'
-import { getRedisClient } from '@/server/redis-client'
-
-const MARKETING_INBOX_STREAM = process.env.MARKETING_INBOX_STREAM ?? 'inbox:marketing'
+import { publishContactIntakeRequested } from '@/server/chatledger-publisher'
+import type { ContactIntakeCommandPayload } from '@/lib/events/types'
 
 /**
  * Build the snake_case command payload for the Redis fallback. Keys
@@ -30,7 +28,10 @@ const MARKETING_INBOX_STREAM = process.env.MARKETING_INBOX_STREAM ?? 'inbox:mark
  * `build_contact_observed` cmd dict — do not rename without updating that
  * consumer in lockstep.
  */
-function intakeToCommandPayload(intake: WaitlistIntake, idempotencyKey: string) {
+function intakeToCommandPayload(
+  intake: WaitlistIntake,
+  idempotencyKey: string,
+): ContactIntakeCommandPayload {
   return {
     idempotency_key: idempotencyKey,
     // Optional fields are normalised to null rather than left undefined:
@@ -108,30 +109,19 @@ export async function POST(request: NextRequest) {
     })
     return NextResponse.json({ status: 'accepted', contactId: result.contactId }, { status: 200 })
   } catch (grpcError) {
-    // Never lose a signup: durable fallback onto the marketing inbox stream.
+    // Never lose a signup: durable fallback publishing the intake command onto
+    // chatLedger, which the Broker routes to the marketingService inbox.
     console.warn(
-      '[Intake] gRPC failed, queueing to Redis fallback:',
+      '[Intake] gRPC failed, publishing to chatLedger fallback:',
       grpcError instanceof Error ? grpcError.message : grpcError,
     )
     try {
-      const redis = getRedisClient()
-      if (redis.status === 'wait') await redis.connect()
-      const fields = {
-        conv: nanoid(),
-        agt: 'billie-crm',
-        usr: 'intake',
-        seq: '1',
-        cls: 'cmd',
-        typ: 'contact.intake.requested.v1',
-        cause: nanoid(),
-        payload: JSON.stringify(intakeToCommandPayload(intake, idempotencyKey)),
-      }
-      await redis.xadd(MARKETING_INBOX_STREAM, '*', ...Object.entries(fields).flat())
+      await publishContactIntakeRequested(intakeToCommandPayload(intake, idempotencyKey))
       return NextResponse.json({ status: 'queued' }, { status: 200 })
-    } catch (redisError) {
+    } catch (publishError) {
       console.error(
         '[Intake] BOTH paths failed — signup at risk:',
-        redisError instanceof Error ? redisError.message : redisError,
+        publishError instanceof Error ? publishError.message : publishError,
       )
       return NextResponse.json(
         { error: { code: 'INTAKE_UNAVAILABLE', message: 'Please retry' } },

--- a/src/lib/events/config.ts
+++ b/src/lib/events/config.ts
@@ -141,6 +141,15 @@ export const EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED =
   'reapplication_block.clear_authorized.v1'
 
 /**
+ * Event type for the public-intake contact command, published to chatLedger
+ * as the durable fallback when the primary gRPC UpsertContact fails. The
+ * Broker routes it to the marketingService inbox (see billieChat routes.json,
+ * `${agent_billie-crm}` → `contact.intake.requested.v1`).
+ */
+export const EVENT_TYPE_CONTACT_INTAKE_REQUESTED =
+  process.env.EVENT_TYPE_CONTACT_INTAKE_REQUESTED ?? 'contact.intake.requested.v1'
+
+/**
  * Single source of truth for the clear vocabulary (mirrors billieChat enums).
  */
 export const CLEARABLE_REASONS = [

--- a/src/lib/events/types.ts
+++ b/src/lib/events/types.ts
@@ -265,3 +265,31 @@ export interface ReapplicationBlockClearAuthorizedPayload {
     comment: string
   }
 }
+
+/**
+ * Snake_case command payload for `contact.intake.requested.v1`, published to
+ * chatLedger as the public-intake fallback and routed by the Broker to the
+ * platform marketingService inbox. Keys mirror marketingService's
+ * `_handle_intake_command` / `build_contact_observed` cmd dict — do not rename
+ * without updating that consumer in lockstep.
+ */
+export interface ContactIntakeCommandPayload {
+  idempotency_key: string
+  first_name: string | null
+  email: string | null
+  mobile: string | null
+  city: string | null
+  postcode: string | null
+  source: string
+  utm: Record<string, unknown>
+  platforms: string[]
+  channel_preference: string | null
+  referred_by_code: string | null
+  waitlist: boolean
+  consent: {
+    granted: boolean
+    method: string
+    channels: string[]
+  }
+  actor: string
+}

--- a/src/server/chatledger-publisher.ts
+++ b/src/server/chatledger-publisher.ts
@@ -17,10 +17,14 @@ import {
   CHATLEDGER_STREAM,
   CRM_AGENT_ID,
   EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED,
+  EVENT_TYPE_CONTACT_INTAKE_REQUESTED,
   PUBLISH_MAX_RETRIES,
   PUBLISH_BACKOFF_MS,
 } from '@/lib/events/config'
-import type { ReapplicationBlockClearAuthorizedPayload } from '@/lib/events/types'
+import type {
+  ReapplicationBlockClearAuthorizedPayload,
+  ContactIntakeCommandPayload,
+} from '@/lib/events/types'
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -75,6 +79,61 @@ export async function publishClearAuthorized(
     }
   }
   throw new EventPublishError('Failed to publish clear_authorized to chatLedger after retries', {
+    attempts: PUBLISH_MAX_RETRIES,
+    cause: lastError,
+  })
+}
+
+/**
+ * Publish a contact.intake.requested.v1 command to chatLedger.
+ *
+ * This is the durable fallback for the public waitlist intake route when the
+ * primary gRPC UpsertContact fails. The Broker routes it to the marketingService
+ * inbox (billieChat routes.json: `${agent_billie-crm}` → `contact.intake.requested.v1`),
+ * so the CRM never has to name the consumer's inbox stream. Carries the same
+ * idempotency_key as the gRPC path, so a later-processed command can't duplicate
+ * a contact the gRPC call already created.
+ *
+ * @param payload - The intake command payload (mirrors the platform cmd dict).
+ * @returns The nanoid used as both the cause field and the returned eventId.
+ */
+export async function publishContactIntakeRequested(
+  payload: ContactIntakeCommandPayload,
+): Promise<{ eventId: string }> {
+  const eventId = nanoid()
+  const fields: Record<string, string> = {
+    conv: `contact-intake:${payload.idempotency_key}`,
+    agt: CRM_AGENT_ID,
+    usr: payload.actor,
+    seq: '1',
+    cls: 'cmd',
+    typ: EVENT_TYPE_CONTACT_INTAKE_REQUESTED,
+    cause: eventId,
+    payload: JSON.stringify(payload),
+  }
+  const redis = getChatLedgerRedisClient()
+
+  // Same lazyConnect + retry posture as publishClearAuthorized above.
+  let lastError: Error | undefined
+  for (let attempt = 0; attempt < PUBLISH_MAX_RETRIES; attempt++) {
+    try {
+      if (redis.status === 'wait') {
+        await redis.connect()
+      }
+      await redis.xadd(CHATLEDGER_STREAM, '*', ...Object.entries(fields).flat())
+      return { eventId }
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error))
+      console.warn(
+        `[ChatLedgerPublisher] Attempt ${attempt + 1}/${PUBLISH_MAX_RETRIES} failed:`,
+        lastError.message,
+      )
+      if (attempt < PUBLISH_MAX_RETRIES - 1) {
+        await sleep(PUBLISH_BACKOFF_MS[attempt] ?? 400)
+      }
+    }
+  }
+  throw new EventPublishError('Failed to publish contact intake to chatLedger after retries', {
     attempts: PUBLISH_MAX_RETRIES,
     cause: lastError,
   })

--- a/tests/unit/api/intake-waitlist.test.ts
+++ b/tests/unit/api/intake-waitlist.test.ts
@@ -3,15 +3,16 @@
  *
  * Covers:
  *   - WaitlistIntakeSchema (zod contract for the public payload)
- *   - POST /api/intake/waitlist — gRPC-primary write with a durable Redis
+ *   - POST /api/intake/waitlist — gRPC-primary write with a durable chatLedger
  *     fallback so a signup is never lost when the platform marketingService
  *     is unavailable.
  *
  * Mocks:
  *   - next/server                         → NextResponse.json returns { body, status }
  *   - @/server/marketing-grpc-client      → upsertContact is mocked (no real gRPC call)
- *   - @/server/redis-client               → getRedisClient returns a fake ioredis-shaped
- *                                            stub (status/connect/xadd)
+ *   - @/server/chatledger-publisher       → publishContactIntakeRequested is mocked; the
+ *                                            fallback publishes the command here and the
+ *                                            Broker (not the CRM) routes it to marketing
  *   - @/lib/intake-auth and @/lib/schemas/intake are the REAL implementations — auth and
  *     validation are exercised end-to-end, not stubbed away.
  */
@@ -41,18 +42,12 @@ vi.mock('@/server/marketing-grpc-client', () => ({
 }))
 
 // ---------------------------------------------------------------------------
-// Redis client mock — ioredis-shaped stub
+// chatLedger publisher mock — the intake fallback publishes the command here,
+// and billieChat's Broker (not the CRM) routes it to the marketingService inbox.
 // ---------------------------------------------------------------------------
-const mockXadd = vi.hoisted(() => vi.fn(async () => '1-1'))
-const mockConnect = vi.hoisted(() => vi.fn(async () => undefined))
-const mockRedis = vi.hoisted(() => ({
-  status: 'ready',
-  connect: mockConnect,
-  xadd: mockXadd,
-}))
-const mockGetRedisClient = vi.hoisted(() => vi.fn(() => mockRedis))
-vi.mock('@/server/redis-client', () => ({
-  getRedisClient: mockGetRedisClient,
+const mockPublishContactIntake = vi.hoisted(() => vi.fn(async () => ({ eventId: 'evt-1' })))
+vi.mock('@/server/chatledger-publisher', () => ({
+  publishContactIntakeRequested: mockPublishContactIntake,
 }))
 
 // ---------------------------------------------------------------------------
@@ -79,15 +74,6 @@ function makeSignedRequest(
     headers,
     body: raw,
   }) as unknown as NextRequest
-}
-
-/** Turn the flat [k, v, k, v, ...] xadd field list back into an object. */
-function xaddFieldsToObject(fields: unknown[]): Record<string, string> {
-  const out: Record<string, string> = {}
-  for (let i = 0; i < fields.length; i += 2) {
-    out[fields[i] as string] = fields[i + 1] as string
-  }
-  return out
 }
 
 // =============================================================================
@@ -154,10 +140,7 @@ describe('POST /api/intake/waitlist', () => {
     process.env.INTAKE_API_KEY = API_KEY
     process.env.INTAKE_HMAC_SECRET = HMAC_SECRET
     mockUpsertContact.mockReset()
-    mockXadd.mockReset().mockResolvedValue('1-1')
-    mockConnect.mockReset().mockResolvedValue(undefined)
-    mockGetRedisClient.mockClear()
-    mockRedis.status = 'ready'
+    mockPublishContactIntake.mockReset().mockResolvedValue({ eventId: 'evt-1' })
   })
 
   const validBody = {
@@ -188,7 +171,7 @@ describe('POST /api/intake/waitlist', () => {
     expect(mockUpsertContact).not.toHaveBeenCalled()
   })
 
-  test('accepts via gRPC and returns 200 with contactId, never touching Redis', async () => {
+  test('accepts via gRPC and returns 200 with contactId, never touching the fallback', async () => {
     mockUpsertContact.mockResolvedValue({
       contactId: 'contact-1',
       eventId: 'event-1',
@@ -203,7 +186,7 @@ describe('POST /api/intake/waitlist', () => {
     expect(res.status).toBe(200)
     expect(res.body.status).toBe('accepted')
     expect(res.body.contactId).toBe('contact-1')
-    expect(mockXadd).not.toHaveBeenCalled()
+    expect(mockPublishContactIntake).not.toHaveBeenCalled()
 
     // idempotency_key defaults to a stable value derived from mobile/email
     const call = mockUpsertContact.mock.calls[0][0]
@@ -212,23 +195,18 @@ describe('POST /api/intake/waitlist', () => {
     expect(call.waitlist).toBe(true)
   })
 
-  test('falls back to Redis and returns 200 queued when gRPC fails', async () => {
+  test('falls back to chatLedger and returns 200 queued when gRPC fails', async () => {
     mockUpsertContact.mockRejectedValue(new Error('UNAVAILABLE'))
     const req = makeSignedRequest(validBody)
     const res = (await POST(req)) as { body: { status: string }; status: number }
     expect(res.status).toBe(200)
     expect(res.body.status).toBe('queued')
-    expect(mockXadd).toHaveBeenCalledTimes(1)
+    expect(mockPublishContactIntake).toHaveBeenCalledTimes(1)
 
-    const [stream, id, ...fields] = mockXadd.mock.calls[0]
-    expect(stream).toBe('inbox:marketing')
-    expect(id).toBe('*')
-    const envelope = xaddFieldsToObject(fields)
-    expect(envelope.cls).toBe('cmd')
-    expect(envelope.typ).toBe('contact.intake.requested.v1')
-    expect(envelope.agt).toBe('billie-crm')
-
-    const payload = JSON.parse(envelope.payload)
+    // The route hands the command payload to the chatLedger publisher; the
+    // envelope + destination stream are the publisher's concern, and the Broker
+    // (not the CRM) routes it to the marketingService inbox.
+    const payload = mockPublishContactIntake.mock.calls[0][0]
     expect(payload).toMatchObject({
       first_name: 'Ash',
       mobile: '0400000001',
@@ -259,17 +237,9 @@ describe('POST /api/intake/waitlist', () => {
     }
   })
 
-  test('connects a lazy Redis client before xadd when status is "wait"', async () => {
+  test('returns 503 when both gRPC and the chatLedger fallback fail — signup genuinely at risk', async () => {
     mockUpsertContact.mockRejectedValue(new Error('UNAVAILABLE'))
-    mockRedis.status = 'wait'
-    const req = makeSignedRequest(validBody)
-    await POST(req)
-    expect(mockConnect).toHaveBeenCalledTimes(1)
-  })
-
-  test('returns 503 when both gRPC and Redis fail — signup genuinely at risk', async () => {
-    mockUpsertContact.mockRejectedValue(new Error('UNAVAILABLE'))
-    mockXadd.mockRejectedValue(new Error('ECONNREFUSED'))
+    mockPublishContactIntake.mockRejectedValue(new Error('ECONNREFUSED'))
     const req = makeSignedRequest(validBody)
     const res = (await POST(req)) as { body: { error: { code: string } }; status: number }
     expect(res.status).toBe(503)

--- a/tests/unit/server/chatledgerPublisher.test.ts
+++ b/tests/unit/server/chatledgerPublisher.test.ts
@@ -7,8 +7,12 @@ vi.mock('@/server/redis-client', () => ({
   getChatLedgerRedisClient: () => mockClient,
 }))
 
-import { publishClearAuthorized } from '@/server/chatledger-publisher'
+import {
+  publishClearAuthorized,
+  publishContactIntakeRequested,
+} from '@/server/chatledger-publisher'
 import { EventPublishError } from '@/server/event-publisher'
+import type { ContactIntakeCommandPayload } from '@/lib/events/types'
 
 beforeEach(() => {
   xadd.mockClear()
@@ -91,6 +95,79 @@ describe('publishClearAuthorized', () => {
         request_id: 'req-4',
         requested_at: '2026-06-28T00:00:00.000Z',
       }),
+    ).rejects.toBeInstanceOf(EventPublishError)
+    expect(xadd).toHaveBeenCalledTimes(3)
+  })
+})
+
+function sampleIntakePayload(
+  overrides: Partial<ContactIntakeCommandPayload> = {},
+): ContactIntakeCommandPayload {
+  return {
+    idempotency_key: 'intake:0400000001',
+    first_name: 'Ash',
+    email: null,
+    mobile: '0400000001',
+    city: null,
+    postcode: null,
+    source: 'meta',
+    utm: {},
+    platforms: [],
+    channel_preference: null,
+    referred_by_code: null,
+    waitlist: true,
+    consent: { granted: true, method: 'waitlist_form', channels: ['sms'] },
+    actor: 'intake',
+    ...overrides,
+  }
+}
+
+describe('publishContactIntakeRequested', () => {
+  it('xadds a chatLedger command with agt=billie-crm, cmd typ, and the intake conv', async () => {
+    const res = await publishContactIntakeRequested(sampleIntakePayload())
+    expect(res.eventId).toBeTruthy()
+    expect(xadd).toHaveBeenCalledTimes(1)
+    const [stream, star, ...flat] = xadd.mock.calls[0]
+    expect(stream).toBe('chatLedger')
+    expect(star).toBe('*')
+    const fields = Object.fromEntries(
+      flat.reduce((acc: string[][], v: string, i: number) => {
+        if (i % 2 === 0) acc.push([v, flat[i + 1]])
+        return acc
+      }, []),
+    )
+    expect(fields.agt).toBe('billie-crm')
+    expect(fields.typ).toBe('contact.intake.requested.v1')
+    expect(fields.conv).toBe('contact-intake:intake:0400000001')
+    expect(fields.usr).toBe('intake')
+    expect(fields.cls).toBe('cmd')
+    expect(fields.seq).toBe('1')
+    expect(fields.cause).toBeTruthy()
+    expect(JSON.parse(fields.payload).idempotency_key).toBe('intake:0400000001')
+  })
+
+  it('connects first when the lazy client has not connected yet', async () => {
+    mockClient.status = 'wait'
+    await publishContactIntakeRequested(sampleIntakePayload({ idempotency_key: 'intake:k2' }))
+    expect(connect).toHaveBeenCalled()
+    expect(xadd).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a transient xadd failure and succeeds', async () => {
+    xadd
+      .mockRejectedValueOnce(
+        new Error("Stream isn't writeable and enableOfflineQueue options is false"),
+      )
+      .mockResolvedValueOnce('1-1')
+    const res = await publishContactIntakeRequested(sampleIntakePayload({ idempotency_key: 'intake:k3' }))
+    expect(res.eventId).toBeTruthy()
+    expect(xadd).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws EventPublishError after exhausting retries', async () => {
+    xadd.mockRejectedValue(new Error('down'))
+    await expect(
+      publishContactIntakeRequested(sampleIntakePayload({ idempotency_key: 'intake:k4' })),
     ).rejects.toBeInstanceOf(EventPublishError)
     expect(xadd).toHaveBeenCalledTimes(3)
   })


### PR DESCRIPTION
## What

The public waitlist intake's durable fallback (when the primary gRPC `UpsertContact` fails) no longer writes the `contact.intake.requested.v1` command straight to the platform's `inbox:marketing` stream. It now publishes to `chatLedger` via a new `publishContactIntakeRequested()`, and billieChat's Broker routes it to marketingService.

## Why

Writing direct-to-inbox meant the CRM hard-coded the consumer's inbox name **and** hand-built the platform's `_handle_intake_command` envelope — coupling that belongs in the broker's routing table, not the producer. Publishing to `chatLedger` and letting the broker route centralises routing and keeps the CRM ignorant of the consumer.

- **gRPC primary path: unchanged** — a synchronous command that needs a `contactId` back can't be fire-and-forget, so it correctly stays a direct call.
- **marketingService consumer: no changes** — it already dispatches the `typ` off `inbox:marketing`, regardless of how the message arrives.
- **`MARKETING_INBOX_STREAM` is now obsolete** in the CRM and can be dropped from env config. No new env var is needed (`CHATLEDGER_STREAM`/`CHATLEDGER_REDIS_URL` already exist for the reapplication flow).

## Paired change

billieChat PR #123 adds the `contact.intake.requested.v1 → marketingService` route. **That route should deploy before/with this** so the fallback command always resolves.

## Tests

- `tests/unit/api/intake-waitlist.test.ts` — **12 passed** (fallback now asserts the publisher call, not an inbox `xadd`).
- `tests/unit/server/chatledgerPublisher.test.ts` — **8 passed** (added coverage for `publishContactIntakeRequested`: envelope, lazy-connect, retry, exhaustion).
- `pnpm typecheck` + eslint on changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)