### PR TITLE
feat(marketing): Phase-2 Part B backend — feedback intake, staff command routes, dashboard feed (B2–B4)

### DIFF
--- a/proto/marketing_service.proto
+++ b/proto/marketing_service.proto
@@ -9,6 +9,10 @@ service MarketingService {
   rpc LogInteraction(LogInteractionRequest) returns (CommandResponse);
   rpc EraseContact(EraseContactRequest) returns (CommandResponse);
   rpc SubmitFeedback(SubmitFeedbackRequest) returns (SubmitFeedbackResponse);
+  rpc CreateBatch(CreateBatchRequest) returns (CreateBatchResponse);
+  rpc AssignBatch(AssignBatchRequest) returns (AssignBatchResponse);
+  rpc TriggerBatchInvitations(TriggerBatchInvitationsRequest) returns (TriggerBatchInvitationsResponse);
+  rpc SetFeedbackStatus(SetFeedbackStatusRequest) returns (SetFeedbackStatusResponse);
 }
 
 message ConsentCapture {
@@ -105,4 +109,58 @@ message SubmitFeedbackResponse {
   string feedback_id = 1;
   string event_id = 2;
   bool idempotent_replay = 3;
+}
+
+message CreateBatchRequest {
+  string idempotency_key = 1;
+  string name = 2;
+  string criteria_json = 3;         // JSON object as string (segment snapshot)
+  string actor = 4;
+}
+
+message CreateBatchResponse {
+  string batch_id = 1;
+  string event_id = 2;
+  bool idempotent_replay = 3;
+}
+
+message AssignBatchRequest {
+  string idempotency_key = 1;
+  string batch_id = 2;
+  repeated string contact_ids = 3;  // from a filtered CRM segment
+  string actor = 4;
+}
+
+message AssignBatchResponse {
+  string batch_id = 1;
+  int32 assigned_count = 2;
+  string event_id = 3;              // last emitted contact.batch.assigned.v1
+  bool idempotent_replay = 4;
+}
+
+message TriggerBatchInvitationsRequest {
+  string idempotency_key = 1;
+  string batch_id = 2;
+  string actor = 3;
+}
+
+message TriggerBatchInvitationsResponse {
+  string batch_id = 1;
+  int32 invited_count = 2;          // consented members a dispatch was emitted for
+  int32 skipped_unconsented = 3;    // members skipped for lack of marketing consent
+  bool idempotent_replay = 4;
+}
+
+message SetFeedbackStatusRequest {
+  string idempotency_key = 1;
+  string feedback_id = 2;
+  string status = 3;                // new | acknowledged | resolved
+  string actor = 4;
+}
+
+message SetFeedbackStatusResponse {
+  string feedback_id = 1;
+  string event_id = 2;
+  string status = 3;
+  bool idempotent_replay = 4;
 }

--- a/proto/marketing_service.proto
+++ b/proto/marketing_service.proto
@@ -8,6 +8,7 @@ service MarketingService {
   rpc SetConsent(SetConsentRequest) returns (CommandResponse);
   rpc LogInteraction(LogInteractionRequest) returns (CommandResponse);
   rpc EraseContact(EraseContactRequest) returns (CommandResponse);
+  rpc SubmitFeedback(SubmitFeedbackRequest) returns (SubmitFeedbackResponse);
 }
 
 message ConsentCapture {
@@ -85,6 +86,23 @@ message EraseContactRequest {
 
 message CommandResponse {
   string contact_id = 1;
+  string event_id = 2;
+  bool idempotent_replay = 3;
+}
+
+message SubmitFeedbackRequest {
+  string idempotency_key = 1;
+  string contact_id = 2;
+  string customer_id = 3;           // optional canonical link if already a customer
+  string type = 4;                  // bug | praise | feature | complaint | ...
+  string severity = 5;              // optional
+  string text = 6;
+  string product_area = 7;          // optional
+  string actor = 8;
+}
+
+message SubmitFeedbackResponse {
+  string feedback_id = 1;
   string event_id = 2;
   bool idempotent_replay = 3;
 }

--- a/src/app/api/intake/feedback/route.ts
+++ b/src/app/api/intake/feedback/route.ts
@@ -1,0 +1,121 @@
+/**
+ * API Route: POST /api/intake/feedback
+ *
+ * Public, unauthenticated-by-session intake endpoint for the marketing site's
+ * feedback form. Callers authenticate via a shared API key + HMAC body
+ * signature (see @/lib/intake-auth), the same posture as the waitlist intake.
+ *
+ * gRPC-primary, chatLedger-fallback: the write goes straight to the platform's
+ * MarketingService.SubmitFeedback over gRPC. If that fails for any reason, the
+ * feedback is never dropped — it's published as a `feedback.submit.requested.v1`
+ * command onto `chatLedger`, and billieChat's Broker routes it to the
+ * marketingService inbox. Both paths carry the same idempotency_key, so a
+ * client retry (or the queued command being processed later) can't duplicate
+ * feedback.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createHash } from 'crypto'
+import { FeedbackIntakeSchema, type FeedbackIntake } from '@/lib/schemas/intake'
+import { verifyIntakeAuth } from '@/lib/intake-auth'
+import { submitFeedback } from '@/server/marketing-grpc-client'
+import { publishFeedbackSubmitted } from '@/server/chatledger-publisher'
+import type { FeedbackSubmitCommandPayload } from '@/lib/events/types'
+
+/**
+ * Build the snake_case command payload for the chatLedger fallback. Keys mirror
+ * the platform's SubmitFeedback request; optional fields are normalised to null
+ * (JSON.stringify drops undefined-valued keys, silently stripping them).
+ */
+function feedbackToCommandPayload(
+  intake: FeedbackIntake,
+  idempotencyKey: string,
+): FeedbackSubmitCommandPayload {
+  return {
+    idempotency_key: idempotencyKey,
+    contact_id: intake.contact_id,
+    customer_id: intake.customer_id ?? null,
+    type: intake.type,
+    severity: intake.severity ?? null,
+    text: intake.text,
+    product_area: intake.product_area ?? null,
+    actor: 'intake',
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const rawBody = await request.text()
+
+  if (!verifyIntakeAuth(request, rawBody)) {
+    return NextResponse.json(
+      { error: { code: 'UNAUTHENTICATED', message: 'Invalid intake credentials' } },
+      { status: 401 },
+    )
+  }
+
+  let json: unknown
+  try {
+    json = JSON.parse(rawBody)
+  } catch {
+    return NextResponse.json(
+      { error: { code: 'VALIDATION_ERROR', message: 'Body must be JSON' } },
+      { status: 400 },
+    )
+  }
+
+  const parsed = FeedbackIntakeSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid feedback payload',
+          details: parsed.error.flatten().fieldErrors,
+        },
+      },
+      { status: 400 },
+    )
+  }
+
+  const intake = parsed.data
+  // Stable idempotency key: client-supplied, else derived from the contact and a
+  // hash of the text so a double-submit of the same feedback is deduped, while
+  // genuinely different feedback from the same contact is not.
+  const idempotencyKey =
+    intake.idempotency_key ??
+    `feedback:${intake.contact_id}:${createHash('sha256').update(intake.text).digest('hex').slice(0, 16)}`
+
+  try {
+    const result = await submitFeedback({
+      idempotencyKey,
+      contactId: intake.contact_id,
+      customerId: intake.customer_id,
+      type: intake.type,
+      severity: intake.severity,
+      text: intake.text,
+      productArea: intake.product_area,
+      actor: 'intake',
+    })
+    return NextResponse.json({ status: 'accepted', feedbackId: result.feedbackId }, { status: 200 })
+  } catch (grpcError) {
+    // Never lose feedback: durable fallback publishing the command onto
+    // chatLedger, which the Broker routes to the marketingService inbox.
+    console.warn(
+      '[FeedbackIntake] gRPC failed, publishing to chatLedger fallback:',
+      grpcError instanceof Error ? grpcError.message : grpcError,
+    )
+    try {
+      await publishFeedbackSubmitted(feedbackToCommandPayload(intake, idempotencyKey))
+      return NextResponse.json({ status: 'queued' }, { status: 200 })
+    } catch (publishError) {
+      console.error(
+        '[FeedbackIntake] BOTH paths failed — feedback at risk:',
+        publishError instanceof Error ? publishError.message : publishError,
+      )
+      return NextResponse.json(
+        { error: { code: 'INTAKE_UNAVAILABLE', message: 'Please retry' } },
+        { status: 503 },
+      )
+    }
+  }
+}

--- a/src/app/api/marketing/batches/[batchId]/assign/route.ts
+++ b/src/app/api/marketing/batches/[batchId]/assign/route.ts
@@ -1,0 +1,65 @@
+/**
+ * API Route: POST /api/marketing/batches/[batchId]/assign
+ *
+ * Assign a filtered CRM segment (a list of contact_ids) to a batch via
+ * MarketingService.AssignBatch. Gated on `canMarketing`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { canMarketing } from '@/lib/access'
+import { AssignBatchSchema } from '@/lib/schemas/marketing'
+import { assignBatch } from '@/server/marketing-grpc-client'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ batchId: string }> },
+) {
+  const auth = await requireAuth(canMarketing)
+  if ('error' in auth) return auth.error
+  const { user } = auth
+  const { batchId } = await params
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: { code: 'VALIDATION_ERROR', message: 'Body must be valid JSON' } },
+      { status: 400 },
+    )
+  }
+
+  const parsed = AssignBatchSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid assign payload',
+          details: parsed.error.flatten().fieldErrors,
+        },
+      },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const result = await assignBatch({
+      idempotencyKey: `assign:${batchId}:${Date.now()}`,
+      batchId,
+      contactIds: parsed.data.contact_ids,
+      actor: String(user.id),
+    })
+    return NextResponse.json(
+      { batchId, assignedCount: result.assignedCount, eventId: result.eventId },
+      { status: 202 },
+    )
+  } catch (e) {
+    console.error('[Marketing Assign Batch] gRPC error:', e)
+    return NextResponse.json(
+      { error: { code: 'COMMAND_FAILED', message: 'Assigning the batch failed. Please retry.' } },
+      { status: 503 },
+    )
+  }
+}

--- a/src/app/api/marketing/batches/[batchId]/invite/route.ts
+++ b/src/app/api/marketing/batches/[batchId]/invite/route.ts
@@ -1,0 +1,52 @@
+/**
+ * API Route: POST /api/marketing/batches/[batchId]/invite
+ *
+ * Trigger invitations for a batch via MarketingService.TriggerBatchInvitations
+ * — the platform emits a notification-dispatch command per consented member and
+ * skips members without marketing consent. Gated on `canMarketing`.
+ *
+ * The idempotency key is stable per batch (`invite:{batchId}`) so a double-click
+ * can't fan out a second wave of invites.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { canMarketing } from '@/lib/access'
+import { triggerBatchInvitations } from '@/server/marketing-grpc-client'
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ batchId: string }> },
+) {
+  const auth = await requireAuth(canMarketing)
+  if ('error' in auth) return auth.error
+  const { user } = auth
+  const { batchId } = await params
+
+  try {
+    const result = await triggerBatchInvitations({
+      idempotencyKey: `invite:${batchId}`,
+      batchId,
+      actor: String(user.id),
+    })
+    return NextResponse.json(
+      {
+        batchId,
+        invitedCount: result.invitedCount,
+        skippedUnconsented: result.skippedUnconsented,
+      },
+      { status: 202 },
+    )
+  } catch (e) {
+    console.error('[Marketing Trigger Invitations] gRPC error:', e)
+    return NextResponse.json(
+      {
+        error: {
+          code: 'COMMAND_FAILED',
+          message: 'Triggering batch invitations failed. Please retry.',
+        },
+      },
+      { status: 503 },
+    )
+  }
+}

--- a/src/app/api/marketing/batches/route.ts
+++ b/src/app/api/marketing/batches/route.ts
@@ -1,0 +1,81 @@
+/**
+ * API Route: /api/marketing/batches
+ *
+ * GET  — list batches from the read-only `batches` projection. Gated on
+ *        `canReadMarketing`.
+ * POST — create a marketing batch via MarketingService.CreateBatch. The
+ *        `criteria` object is the segment snapshot the batch was built from.
+ *        Gated on `canMarketing`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { canMarketing, canReadMarketing } from '@/lib/access'
+import { CreateBatchSchema } from '@/lib/schemas/marketing'
+import { createBatch } from '@/server/marketing-grpc-client'
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(canReadMarketing)
+  if ('error' in auth) return auth.error
+  const { payload, user } = auth
+
+  const sp = request.nextUrl.searchParams
+  const result = await payload.find({
+    collection: 'batches',
+    page: Number(sp.get('page') ?? 1),
+    limit: 50,
+    sort: '-batchCreatedAt',
+    overrideAccess: false,
+    user,
+  })
+
+  return NextResponse.json(result)
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(canMarketing)
+  if ('error' in auth) return auth.error
+  const { user } = auth
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: { code: 'VALIDATION_ERROR', message: 'Body must be valid JSON' } },
+      { status: 400 },
+    )
+  }
+
+  const parsed = CreateBatchSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid batch payload',
+          details: parsed.error.flatten().fieldErrors,
+        },
+      },
+      { status: 400 },
+    )
+  }
+
+  const data = parsed.data
+
+  try {
+    const result = await createBatch({
+      idempotencyKey: `batch:${Date.now()}`,
+      name: data.name,
+      criteriaJson: JSON.stringify(data.criteria ?? {}),
+      actor: String(user.id),
+    })
+    return NextResponse.json({ batchId: result.batchId, eventId: result.eventId }, { status: 202 })
+  } catch (e) {
+    console.error('[Marketing Create Batch] gRPC error:', e)
+    return NextResponse.json(
+      { error: { code: 'COMMAND_FAILED', message: 'Creating the batch failed. Please retry.' } },
+      { status: 503 },
+    )
+  }
+}

--- a/src/app/api/marketing/dashboard-feed/route.ts
+++ b/src/app/api/marketing/dashboard-feed/route.ts
@@ -1,0 +1,105 @@
+/**
+ * API Route: GET /api/marketing/dashboard-feed
+ *
+ * Read-only aggregate counts for the marketing Looker Studio dashboard —
+ * contacts by stage + source, referral rate, and the acquisition funnel.
+ *
+ * Authenticated by a static service API key (`x-api-key` header ===
+ * MARKETING_DASHBOARD_API_KEY), NOT a staff session — it's consumed by an
+ * external BI tool. Fail-closed: a missing/blank env key rejects every request.
+ *
+ * Aggregates come straight from the `contacts` projection via the pg pool
+ * (scalar GROUP BY counts — the Local API has no groupBy). Erased contacts
+ * (DSR tombstones) are excluded from every metric.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+
+/** Canonical funnel order (mirrors Contacts.derivedStage options). */
+const FUNNEL_ORDER = [
+  'lead',
+  'waitlist',
+  'invited',
+  'applicant',
+  'customer',
+  'former_customer',
+] as const
+
+interface CountRow {
+  k: unknown
+  c: unknown
+}
+
+function toCountMap(rows: CountRow[]): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const r of rows) {
+    const key = r.k == null ? 'unknown' : String(r.k)
+    out[key] = Number(r.c) || 0
+  }
+  return out
+}
+
+export async function GET(request: NextRequest) {
+  const expected = process.env.MARKETING_DASHBOARD_API_KEY
+  const provided = request.headers.get('x-api-key')
+  if (!expected || !provided || provided !== expected) {
+    return NextResponse.json(
+      { error: { code: 'UNAUTHENTICATED', message: 'Invalid service credentials' } },
+      { status: 401 },
+    )
+  }
+
+  try {
+    const payload = await getPayload({ config: configPromise })
+    const pool = (
+      payload.db as { pool?: { query: (text: string) => Promise<{ rows: CountRow[] }> } }
+    ).pool
+    if (!pool) {
+      return NextResponse.json(
+        { error: { code: 'INTERNAL_ERROR', message: 'Aggregation unavailable.' } },
+        { status: 500 },
+      )
+    }
+
+    const [stageRes, sourceRes, referralRes] = await Promise.all([
+      pool.query(
+        `SELECT derived_stage AS k, COUNT(*)::bigint AS c
+           FROM contacts WHERE erased IS NOT TRUE GROUP BY derived_stage`,
+      ),
+      pool.query(
+        `SELECT source AS k, COUNT(*)::bigint AS c
+           FROM contacts WHERE erased IS NOT TRUE GROUP BY source`,
+      ),
+      pool.query(
+        `SELECT COUNT(*)::bigint AS k, COUNT(referred_by_contact_id)::bigint AS c
+           FROM contacts WHERE erased IS NOT TRUE`,
+      ),
+    ])
+
+    const byStage = toCountMap(stageRes.rows)
+    const bySource = toCountMap(sourceRes.rows)
+    const total = Number(referralRes.rows[0]?.k ?? 0)
+    const referred = Number(referralRes.rows[0]?.c ?? 0)
+
+    return NextResponse.json({
+      generatedAt: new Date().toISOString(),
+      totalContacts: total,
+      byStage,
+      bySource,
+      referral: {
+        total,
+        referred,
+        rate: total > 0 ? referred / total : 0,
+      },
+      funnel: FUNNEL_ORDER.map((stage) => ({ stage, count: byStage[stage] ?? 0 })),
+    })
+  } catch (error) {
+    console.error('[Marketing Dashboard Feed] Error:', error)
+    return NextResponse.json(
+      { error: { code: 'INTERNAL_ERROR', message: 'Failed to load dashboard feed.' } },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/marketing/dashboard-feed/route.ts
+++ b/src/app/api/marketing/dashboard-feed/route.ts
@@ -16,6 +16,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getPayload } from 'payload'
 import configPromise from '@payload-config'
+import { safeEqual } from '@/lib/intake-auth'
 
 /** Canonical funnel order (mirrors Contacts.derivedStage options). */
 const FUNNEL_ORDER = [
@@ -43,8 +44,9 @@ function toCountMap(rows: CountRow[]): Record<string, number> {
 
 export async function GET(request: NextRequest) {
   const expected = process.env.MARKETING_DASHBOARD_API_KEY
-  const provided = request.headers.get('x-api-key')
-  if (!expected || !provided || provided !== expected) {
+  const provided = request.headers.get('x-api-key') ?? ''
+  // Constant-time comparison to avoid leaking the key via timing side channels.
+  if (!expected || !safeEqual(provided, expected)) {
     return NextResponse.json(
       { error: { code: 'UNAUTHENTICATED', message: 'Invalid service credentials' } },
       { status: 401 },

--- a/src/app/api/marketing/feedback/[feedbackId]/status/route.ts
+++ b/src/app/api/marketing/feedback/[feedbackId]/status/route.ts
@@ -1,0 +1,73 @@
+/**
+ * API Route: POST /api/marketing/feedback/[feedbackId]/status
+ *
+ * Advance a feedback item's queue status (new → acknowledged → resolved) via
+ * MarketingService.SetFeedbackStatus. Gated on `canMarketing`. The idempotency
+ * key is stable per (feedback, status) so re-setting the same status is a no-op.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { canMarketing } from '@/lib/access'
+import { SetFeedbackStatusSchema } from '@/lib/schemas/marketing'
+import { setFeedbackStatus } from '@/server/marketing-grpc-client'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ feedbackId: string }> },
+) {
+  const auth = await requireAuth(canMarketing)
+  if ('error' in auth) return auth.error
+  const { user } = auth
+  const { feedbackId } = await params
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: { code: 'VALIDATION_ERROR', message: 'Body must be valid JSON' } },
+      { status: 400 },
+    )
+  }
+
+  const parsed = SetFeedbackStatusSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid status payload',
+          details: parsed.error.flatten().fieldErrors,
+        },
+      },
+      { status: 400 },
+    )
+  }
+
+  const { status } = parsed.data
+
+  try {
+    const result = await setFeedbackStatus({
+      idempotencyKey: `feedback-status:${feedbackId}:${status}`,
+      feedbackId,
+      status,
+      actor: String(user.id),
+    })
+    return NextResponse.json(
+      { feedbackId, status: result.status, eventId: result.eventId },
+      { status: 202 },
+    )
+  } catch (e) {
+    console.error('[Marketing Set Feedback Status] gRPC error:', e)
+    return NextResponse.json(
+      {
+        error: {
+          code: 'COMMAND_FAILED',
+          message: 'Updating feedback status failed. Please retry.',
+        },
+      },
+      { status: 503 },
+    )
+  }
+}

--- a/src/app/api/marketing/feedback/route.ts
+++ b/src/app/api/marketing/feedback/route.ts
@@ -1,0 +1,33 @@
+/**
+ * API Route: GET /api/marketing/feedback
+ *
+ * Lists the feedback queue from the read-only `feedback` projection, filterable
+ * by `status` and `product_area`. Gated on `canReadMarketing`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { canReadMarketing } from '@/lib/access'
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(canReadMarketing)
+  if ('error' in auth) return auth.error
+  const { payload, user } = auth
+
+  const sp = request.nextUrl.searchParams
+  const where: Record<string, unknown> = {}
+  if (sp.get('status')) where.status = { equals: sp.get('status') }
+  if (sp.get('product_area')) where.productArea = { equals: sp.get('product_area') }
+
+  const result = await payload.find({
+    collection: 'feedback',
+    where: where as never,
+    page: Number(sp.get('page') ?? 1),
+    limit: 50,
+    sort: '-receivedAt',
+    overrideAccess: false,
+    user,
+  })
+
+  return NextResponse.json(result)
+}

--- a/src/lib/events/config.ts
+++ b/src/lib/events/config.ts
@@ -150,6 +150,19 @@ export const EVENT_TYPE_CONTACT_INTAKE_REQUESTED =
   process.env.EVENT_TYPE_CONTACT_INTAKE_REQUESTED ?? 'contact.intake.requested.v1'
 
 /**
+ * Event type for the public feedback-intake command, published to chatLedger as
+ * the durable fallback when the primary gRPC SubmitFeedback fails. The Broker
+ * routes it to the marketingService inbox (billieChat routes.json,
+ * `${agent_billie-crm}` → `feedback.submit.requested.v1`).
+ *
+ * NOTE: requires a matching `feedback.submit.requested.v1` handler in the
+ * platform marketingService inbox consumer (companion to `_handle_intake_command`)
+ * for the fallback to be effective — see the B2 dependency flag.
+ */
+export const EVENT_TYPE_FEEDBACK_SUBMIT_REQUESTED =
+  process.env.EVENT_TYPE_FEEDBACK_SUBMIT_REQUESTED ?? 'feedback.submit.requested.v1'
+
+/**
  * Single source of truth for the clear vocabulary (mirrors billieChat enums).
  */
 export const CLEARABLE_REASONS = [

--- a/src/lib/events/types.ts
+++ b/src/lib/events/types.ts
@@ -293,3 +293,19 @@ export interface ContactIntakeCommandPayload {
   }
   actor: string
 }
+
+/**
+ * snake_case command payload for `feedback.submit.requested.v1`, published to
+ * chatLedger as the feedback-intake fallback and routed by the Broker to the
+ * marketingService inbox. Keys mirror the `SubmitFeedback` gRPC request.
+ */
+export interface FeedbackSubmitCommandPayload {
+  idempotency_key: string
+  contact_id: string
+  customer_id: string | null
+  type: string
+  severity: string | null
+  text: string
+  product_area: string | null
+  actor: string
+}

--- a/src/lib/intake-auth.ts
+++ b/src/lib/intake-auth.ts
@@ -17,7 +17,7 @@ import type { NextRequest } from 'next/server'
  * lengths differ, rather than passing mismatched buffers to
  * `timingSafeEqual`, which throws a RangeError in that case.
  */
-function safeEqual(provided: string, expected: string): boolean {
+export function safeEqual(provided: string, expected: string): boolean {
   const providedBuf = Buffer.from(provided)
   const expectedBuf = Buffer.from(expected)
   return providedBuf.length === expectedBuf.length && timingSafeEqual(providedBuf, expectedBuf)

--- a/src/lib/schemas/intake.ts
+++ b/src/lib/schemas/intake.ts
@@ -30,3 +30,21 @@ export const WaitlistIntakeSchema = z
   .refine((d) => !!d.mobile || !!d.email, { message: 'mobile or email is required' })
 
 export type WaitlistIntake = z.infer<typeof WaitlistIntakeSchema>
+
+/**
+ * Public contract for the feedback intake route (POST /api/intake/feedback).
+ * snake_case to match the marketingService `SubmitFeedback` command fields.
+ * `contact_id` is required — the public feedback form carries it (e.g. from a
+ * feedback-prompt link); anonymous feedback is out of scope for phase 2.
+ */
+export const FeedbackIntakeSchema = z.object({
+  idempotency_key: z.string().max(128).optional(),
+  contact_id: z.string().min(1).max(128),
+  customer_id: z.string().max(128).optional(),
+  type: z.string().min(1).max(50), // bug | praise | feature | complaint | ...
+  severity: z.string().max(50).optional(),
+  text: z.string().min(1).max(5000),
+  product_area: z.string().max(100).optional(),
+})
+
+export type FeedbackIntake = z.infer<typeof FeedbackIntakeSchema>

--- a/src/lib/schemas/marketing.ts
+++ b/src/lib/schemas/marketing.ts
@@ -68,3 +68,26 @@ export const LogInteractionSchema = z.object({
 })
 
 export type LogInteraction = z.infer<typeof LogInteractionSchema>
+
+/**
+ * Phase-2 (Stream A) staff command contracts — batches + feedback triage.
+ */
+
+export const CreateBatchSchema = z.object({
+  name: z.string().min(1).max(200),
+  criteria: z.record(z.string(), z.unknown()).optional(),
+})
+
+export type CreateBatch = z.infer<typeof CreateBatchSchema>
+
+export const AssignBatchSchema = z.object({
+  contact_ids: z.array(z.string().min(1)).min(1).max(10000),
+})
+
+export type AssignBatch = z.infer<typeof AssignBatchSchema>
+
+export const SetFeedbackStatusSchema = z.object({
+  status: z.enum(['new', 'acknowledged', 'resolved']),
+})
+
+export type SetFeedbackStatus = z.infer<typeof SetFeedbackStatusSchema>

--- a/src/server/chatledger-publisher.ts
+++ b/src/server/chatledger-publisher.ts
@@ -18,12 +18,14 @@ import {
   CRM_AGENT_ID,
   EVENT_TYPE_REAPPLICATION_BLOCK_CLEAR_AUTHORIZED,
   EVENT_TYPE_CONTACT_INTAKE_REQUESTED,
+  EVENT_TYPE_FEEDBACK_SUBMIT_REQUESTED,
   PUBLISH_MAX_RETRIES,
   PUBLISH_BACKOFF_MS,
 } from '@/lib/events/config'
 import type {
   ReapplicationBlockClearAuthorizedPayload,
   ContactIntakeCommandPayload,
+  FeedbackSubmitCommandPayload,
 } from '@/lib/events/types'
 
 function sleep(ms: number): Promise<void> {
@@ -134,6 +136,60 @@ export async function publishContactIntakeRequested(
     }
   }
   throw new EventPublishError('Failed to publish contact intake to chatLedger after retries', {
+    attempts: PUBLISH_MAX_RETRIES,
+    cause: lastError,
+  })
+}
+
+/**
+ * Publish a feedback.submit.requested.v1 command to chatLedger.
+ *
+ * Durable fallback for the public feedback intake route when the primary gRPC
+ * SubmitFeedback fails. The Broker routes it to the marketingService inbox
+ * (billieChat routes.json: `${agent_billie-crm}` → `feedback.submit.requested.v1`).
+ * Carries the same idempotency_key as the gRPC path, so a later-processed
+ * command can't duplicate feedback the gRPC call already recorded.
+ *
+ * @param payload - The feedback command payload (mirrors the SubmitFeedback request).
+ * @returns The nanoid used as both the cause field and the returned eventId.
+ */
+export async function publishFeedbackSubmitted(
+  payload: FeedbackSubmitCommandPayload,
+): Promise<{ eventId: string }> {
+  const eventId = nanoid()
+  const fields: Record<string, string> = {
+    conv: `feedback-intake:${payload.idempotency_key}`,
+    agt: CRM_AGENT_ID,
+    usr: payload.actor,
+    seq: '1',
+    cls: 'cmd',
+    typ: EVENT_TYPE_FEEDBACK_SUBMIT_REQUESTED,
+    cause: eventId,
+    payload: JSON.stringify(payload),
+  }
+  const redis = getChatLedgerRedisClient()
+
+  // Same lazyConnect + retry posture as the other chatLedger publishers above.
+  let lastError: Error | undefined
+  for (let attempt = 0; attempt < PUBLISH_MAX_RETRIES; attempt++) {
+    try {
+      if (redis.status === 'wait') {
+        await redis.connect()
+      }
+      await redis.xadd(CHATLEDGER_STREAM, '*', ...Object.entries(fields).flat())
+      return { eventId }
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error))
+      console.warn(
+        `[ChatLedgerPublisher] Attempt ${attempt + 1}/${PUBLISH_MAX_RETRIES} failed:`,
+        lastError.message,
+      )
+      if (attempt < PUBLISH_MAX_RETRIES - 1) {
+        await sleep(PUBLISH_BACKOFF_MS[attempt] ?? 400)
+      }
+    }
+  }
+  throw new EventPublishError('Failed to publish feedback intake to chatLedger after retries', {
     attempts: PUBLISH_MAX_RETRIES,
     cause: lastError,
   })

--- a/src/server/marketing-grpc-client.ts
+++ b/src/server/marketing-grpc-client.ts
@@ -123,6 +123,23 @@ export interface CommandResult {
   idempotentReplay: boolean
 }
 
+export interface SubmitFeedbackInput {
+  idempotencyKey: string
+  contactId: string
+  customerId?: string
+  type: string
+  severity?: string
+  text: string
+  productArea?: string
+  actor?: string
+}
+
+export interface SubmitFeedbackResult {
+  feedbackId: string
+  eventId: string
+  idempotentReplay: boolean
+}
+
 // =============================================================================
 // Client Class
 // =============================================================================
@@ -184,6 +201,12 @@ export class MarketingClient {
   async eraseContact(request: EraseContactInput): Promise<CommandResult> {
     return this.promisify<EraseContactInput, CommandResult>(this.client.eraseContact)(request)
   }
+
+  async submitFeedback(request: SubmitFeedbackInput): Promise<SubmitFeedbackResult> {
+    return this.promisify<SubmitFeedbackInput, SubmitFeedbackResult>(this.client.submitFeedback)(
+      request,
+    )
+  }
 }
 
 // =============================================================================
@@ -221,4 +244,8 @@ export async function logInteraction(request: LogInteractionInput): Promise<Comm
 
 export async function eraseContact(request: EraseContactInput): Promise<CommandResult> {
   return getMarketingClient().eraseContact(request)
+}
+
+export async function submitFeedback(request: SubmitFeedbackInput): Promise<SubmitFeedbackResult> {
+  return getMarketingClient().submitFeedback(request)
 }

--- a/src/server/marketing-grpc-client.ts
+++ b/src/server/marketing-grpc-client.ts
@@ -140,6 +140,60 @@ export interface SubmitFeedbackResult {
   idempotentReplay: boolean
 }
 
+export interface CreateBatchInput {
+  idempotencyKey: string
+  name: string
+  criteriaJson?: string
+  actor?: string
+}
+
+export interface CreateBatchResult {
+  batchId: string
+  eventId: string
+  idempotentReplay: boolean
+}
+
+export interface AssignBatchInput {
+  idempotencyKey: string
+  batchId: string
+  contactIds: string[]
+  actor?: string
+}
+
+export interface AssignBatchResult {
+  batchId: string
+  assignedCount: number
+  eventId: string
+  idempotentReplay: boolean
+}
+
+export interface TriggerBatchInvitationsInput {
+  idempotencyKey: string
+  batchId: string
+  actor?: string
+}
+
+export interface TriggerBatchInvitationsResult {
+  batchId: string
+  invitedCount: number
+  skippedUnconsented: number
+  idempotentReplay: boolean
+}
+
+export interface SetFeedbackStatusInput {
+  idempotencyKey: string
+  feedbackId: string
+  status: string
+  actor?: string
+}
+
+export interface SetFeedbackStatusResult {
+  feedbackId: string
+  eventId: string
+  status: string
+  idempotentReplay: boolean
+}
+
 // =============================================================================
 // Client Class
 // =============================================================================
@@ -207,6 +261,28 @@ export class MarketingClient {
       request,
     )
   }
+
+  async createBatch(request: CreateBatchInput): Promise<CreateBatchResult> {
+    return this.promisify<CreateBatchInput, CreateBatchResult>(this.client.createBatch)(request)
+  }
+
+  async assignBatch(request: AssignBatchInput): Promise<AssignBatchResult> {
+    return this.promisify<AssignBatchInput, AssignBatchResult>(this.client.assignBatch)(request)
+  }
+
+  async triggerBatchInvitations(
+    request: TriggerBatchInvitationsInput,
+  ): Promise<TriggerBatchInvitationsResult> {
+    return this.promisify<TriggerBatchInvitationsInput, TriggerBatchInvitationsResult>(
+      this.client.triggerBatchInvitations,
+    )(request)
+  }
+
+  async setFeedbackStatus(request: SetFeedbackStatusInput): Promise<SetFeedbackStatusResult> {
+    return this.promisify<SetFeedbackStatusInput, SetFeedbackStatusResult>(
+      this.client.setFeedbackStatus,
+    )(request)
+  }
 }
 
 // =============================================================================
@@ -248,4 +324,24 @@ export async function eraseContact(request: EraseContactInput): Promise<CommandR
 
 export async function submitFeedback(request: SubmitFeedbackInput): Promise<SubmitFeedbackResult> {
   return getMarketingClient().submitFeedback(request)
+}
+
+export async function createBatch(request: CreateBatchInput): Promise<CreateBatchResult> {
+  return getMarketingClient().createBatch(request)
+}
+
+export async function assignBatch(request: AssignBatchInput): Promise<AssignBatchResult> {
+  return getMarketingClient().assignBatch(request)
+}
+
+export async function triggerBatchInvitations(
+  request: TriggerBatchInvitationsInput,
+): Promise<TriggerBatchInvitationsResult> {
+  return getMarketingClient().triggerBatchInvitations(request)
+}
+
+export async function setFeedbackStatus(
+  request: SetFeedbackStatusInput,
+): Promise<SetFeedbackStatusResult> {
+  return getMarketingClient().setFeedbackStatus(request)
 }

--- a/tests/unit/api/intake-feedback.test.ts
+++ b/tests/unit/api/intake-feedback.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for B2: public feedback intake (POST /api/intake/feedback).
+ *
+ * gRPC-primary (SubmitFeedback) with a durable chatLedger fallback — the same
+ * intake-via-broker posture as the waitlist route.
+ *
+ * Mocks:
+ *   - next/server                     → NextResponse.json returns { body, status }
+ *   - @/server/marketing-grpc-client  → submitFeedback is mocked (no real gRPC)
+ *   - @/server/chatledger-publisher   → publishFeedbackSubmitted is mocked; the
+ *                                        fallback publishes the command here and
+ *                                        the Broker routes it to marketingService
+ *   - @/lib/intake-auth and @/lib/schemas/intake are the REAL implementations.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { createHmac } from 'crypto'
+import type { NextRequest } from 'next/server'
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+const mockSubmitFeedback = vi.hoisted(() => vi.fn())
+vi.mock('@/server/marketing-grpc-client', () => ({
+  submitFeedback: mockSubmitFeedback,
+}))
+
+const mockPublishFeedback = vi.hoisted(() => vi.fn(async () => ({ eventId: 'evt-1' })))
+vi.mock('@/server/chatledger-publisher', () => ({
+  publishFeedbackSubmitted: mockPublishFeedback,
+}))
+
+import { POST } from '@/app/api/intake/feedback/route'
+
+const API_KEY = 'test-key'
+const HMAC_SECRET = 'test-secret'
+
+function makeSignedRequest(
+  bodyObj: unknown,
+  opts?: { signature?: string; skipAuthHeaders?: boolean },
+): NextRequest {
+  const raw = JSON.stringify(bodyObj)
+  const headers: Record<string, string> = {}
+  if (!opts?.skipAuthHeaders) {
+    headers['x-api-key'] = API_KEY
+    headers['x-signature'] =
+      opts?.signature ?? createHmac('sha256', HMAC_SECRET).update(raw).digest('hex')
+  }
+  return new Request('http://x/api/intake/feedback', {
+    method: 'POST',
+    headers,
+    body: raw,
+  }) as unknown as NextRequest
+}
+
+describe('POST /api/intake/feedback', () => {
+  beforeEach(() => {
+    process.env.INTAKE_API_KEY = API_KEY
+    process.env.INTAKE_HMAC_SECRET = HMAC_SECRET
+    mockSubmitFeedback.mockReset()
+    mockPublishFeedback.mockReset().mockResolvedValue({ eventId: 'evt-1' })
+  })
+
+  const validBody = {
+    contact_id: 'c-1',
+    type: 'bug',
+    text: 'the app crashed on submit',
+  }
+
+  test('401s when the signature is invalid', async () => {
+    const res = (await POST(makeSignedRequest(validBody, { signature: 'deadbeef' }))) as {
+      status: number
+    }
+    expect(res.status).toBe(401)
+    expect(mockSubmitFeedback).not.toHaveBeenCalled()
+  })
+
+  test('400s when contact_id or text is missing', async () => {
+    const res = (await POST(makeSignedRequest({ type: 'bug' }))) as {
+      body: { error: { code: string } }
+      status: number
+    }
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(mockSubmitFeedback).not.toHaveBeenCalled()
+  })
+
+  test('accepts via gRPC and returns 200 with feedbackId, never touching the fallback', async () => {
+    mockSubmitFeedback.mockResolvedValue({
+      feedbackId: 'fb-1',
+      eventId: 'ev-1',
+      idempotentReplay: false,
+    })
+    const res = (await POST(makeSignedRequest(validBody))) as {
+      body: { status: string; feedbackId?: string }
+      status: number
+    }
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('accepted')
+    expect(res.body.feedbackId).toBe('fb-1')
+    expect(mockPublishFeedback).not.toHaveBeenCalled()
+
+    const call = mockSubmitFeedback.mock.calls[0][0]
+    expect(call.contactId).toBe('c-1')
+    expect(call.type).toBe('bug')
+    expect(call.actor).toBe('intake')
+    // derived idempotency key: feedback:<contact>:<hash>
+    expect(call.idempotencyKey).toMatch(/^feedback:c-1:[0-9a-f]{16}$/)
+  })
+
+  test('falls back to chatLedger and returns 200 queued when gRPC fails', async () => {
+    mockSubmitFeedback.mockRejectedValue(new Error('UNAVAILABLE'))
+    const res = (await POST(makeSignedRequest(validBody))) as {
+      body: { status: string }
+      status: number
+    }
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('queued')
+    expect(mockPublishFeedback).toHaveBeenCalledTimes(1)
+
+    const payload = mockPublishFeedback.mock.calls[0][0]
+    expect(payload).toMatchObject({
+      contact_id: 'c-1',
+      type: 'bug',
+      text: 'the app crashed on submit',
+      actor: 'intake',
+    })
+    // optional fields normalised to null (not dropped by JSON.stringify)
+    for (const key of [
+      'idempotency_key',
+      'contact_id',
+      'customer_id',
+      'type',
+      'severity',
+      'text',
+      'product_area',
+      'actor',
+    ]) {
+      expect(payload).toHaveProperty(key)
+    }
+    expect(payload.customer_id).toBeNull()
+    expect(payload.severity).toBeNull()
+  })
+
+  test('returns 503 when both gRPC and the chatLedger fallback fail', async () => {
+    mockSubmitFeedback.mockRejectedValue(new Error('UNAVAILABLE'))
+    mockPublishFeedback.mockRejectedValue(new Error('ECONNREFUSED'))
+    const res = (await POST(makeSignedRequest(validBody))) as {
+      body: { error: { code: string } }
+      status: number
+    }
+    expect(res.status).toBe(503)
+    expect(res.body.error.code).toBe('INTAKE_UNAVAILABLE')
+  })
+
+  test('respects a caller-supplied idempotency_key', async () => {
+    mockSubmitFeedback.mockResolvedValue({
+      feedbackId: 'fb-2',
+      eventId: 'ev-2',
+      idempotentReplay: true,
+    })
+    await POST(makeSignedRequest({ ...validBody, idempotency_key: 'client-key' }))
+    expect(mockSubmitFeedback.mock.calls[0][0].idempotencyKey).toBe('client-key')
+  })
+})

--- a/tests/unit/api/marketing-dashboard-feed.test.ts
+++ b/tests/unit/api/marketing-dashboard-feed.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for B4: GET /api/marketing/dashboard-feed.
+ *
+ * Service-API-key auth (fail-closed) + raw-SQL aggregation over the `contacts`
+ * projection. `payload`/pool are mocked; the three GROUP BY queries are stubbed
+ * in order (stage, source, referral).
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+const mockQuery = vi.hoisted(() => vi.fn())
+vi.mock('payload', () => ({
+  getPayload: vi.fn(async () => ({ db: { pool: { query: mockQuery } } })),
+}))
+vi.mock('@payload-config', () => ({ default: {} }))
+
+import { GET } from '@/app/api/marketing/dashboard-feed/route'
+
+const KEY = 'svc-dashboard-key'
+
+function req(apiKey?: string): NextRequest {
+  const headers: Record<string, string> = {}
+  if (apiKey !== undefined) headers['x-api-key'] = apiKey
+  return new Request('http://x/api/marketing/dashboard-feed', { headers }) as unknown as NextRequest
+}
+
+beforeEach(() => {
+  process.env.MARKETING_DASHBOARD_API_KEY = KEY
+  mockQuery.mockReset()
+})
+
+describe('GET /api/marketing/dashboard-feed — auth', () => {
+  test('401 when the x-api-key header is missing', async () => {
+    const res = (await GET(req())) as { status: number }
+    expect(res.status).toBe(401)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  test('401 when the x-api-key is wrong', async () => {
+    const res = (await GET(req('nope'))) as { status: number }
+    expect(res.status).toBe(401)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+
+  test('fail-closed: 401 even with a header when the env key is unset', async () => {
+    delete process.env.MARKETING_DASHBOARD_API_KEY
+    const res = (await GET(req(KEY))) as { status: number }
+    expect(res.status).toBe(401)
+    expect(mockQuery).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/marketing/dashboard-feed — aggregation', () => {
+  test('200 with stage/source/referral/funnel aggregates', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          { k: 'waitlist', c: '10' },
+          { k: 'customer', c: '3' },
+          { k: null, c: '1' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { k: 'meta', c: '8' },
+          { k: 'referral', c: '5' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ k: '14', c: '5' }] })
+
+    const res = (await GET(req(KEY))) as {
+      body: {
+        totalContacts: number
+        byStage: Record<string, number>
+        bySource: Record<string, number>
+        referral: { total: number; referred: number; rate: number }
+        funnel: Array<{ stage: string; count: number }>
+      }
+      status: number
+    }
+
+    expect(res.status).toBe(200)
+    expect(res.body.totalContacts).toBe(14)
+    expect(res.body.byStage).toEqual({ waitlist: 10, customer: 3, unknown: 1 })
+    expect(res.body.bySource).toEqual({ meta: 8, referral: 5 })
+    expect(res.body.referral).toEqual({ total: 14, referred: 5, rate: 5 / 14 })
+    // funnel is in canonical order and fills zeros for absent stages
+    expect(res.body.funnel).toEqual([
+      { stage: 'lead', count: 0 },
+      { stage: 'waitlist', count: 10 },
+      { stage: 'invited', count: 0 },
+      { stage: 'applicant', count: 0 },
+      { stage: 'customer', count: 3 },
+      { stage: 'former_customer', count: 0 },
+    ])
+  })
+
+  test('rate is 0 when there are no contacts (no divide-by-zero)', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ k: '0', c: '0' }] })
+
+    const res = (await GET(req(KEY))) as {
+      body: { referral: { rate: number } }
+      status: number
+    }
+    expect(res.status).toBe(200)
+    expect(res.body.referral.rate).toBe(0)
+  })
+})

--- a/tests/unit/routes/marketingBatchFeedback.test.ts
+++ b/tests/unit/routes/marketingBatchFeedback.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for B3 marketing staff command routes:
+ *   POST /api/marketing/batches                       (CreateBatch)
+ *   POST /api/marketing/batches/[batchId]/assign      (AssignBatch)
+ *   POST /api/marketing/batches/[batchId]/invite      (TriggerBatchInvitations)
+ *   POST /api/marketing/feedback/[feedbackId]/status  (SetFeedbackStatus)
+ *
+ * next/server, @/lib/auth (requireAuth) and @/server/marketing-grpc-client are
+ * mocked; the zod schemas are the REAL implementations.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+const authHolder = vi.hoisted(() => ({
+  current: { user: { id: 'staff-1' } } as Record<string, unknown>,
+}))
+vi.mock('@/lib/auth', () => ({
+  requireAuth: vi.fn(async () => authHolder.current),
+}))
+
+const grpc = vi.hoisted(() => ({
+  createBatch: vi.fn(),
+  assignBatch: vi.fn(),
+  triggerBatchInvitations: vi.fn(),
+  setFeedbackStatus: vi.fn(),
+}))
+vi.mock('@/server/marketing-grpc-client', () => grpc)
+
+import { POST as createBatchPost } from '@/app/api/marketing/batches/route'
+import { POST as assignPost } from '@/app/api/marketing/batches/[batchId]/assign/route'
+import { POST as invitePost } from '@/app/api/marketing/batches/[batchId]/invite/route'
+import { POST as feedbackStatusPost } from '@/app/api/marketing/feedback/[feedbackId]/status/route'
+
+function req(body?: unknown): NextRequest {
+  return new Request('http://x/api/marketing', {
+    method: 'POST',
+    body: body === undefined ? undefined : JSON.stringify(body),
+  }) as unknown as NextRequest
+}
+const p = <T extends Record<string, string>>(v: T) => ({ params: Promise.resolve(v) })
+
+beforeEach(() => {
+  authHolder.current = { user: { id: 'staff-1' } }
+  grpc.createBatch.mockReset().mockResolvedValue({ batchId: 'b-1', eventId: 'e-1' })
+  grpc.assignBatch
+    .mockReset()
+    .mockResolvedValue({ batchId: 'b-1', assignedCount: 3, eventId: 'e-2' })
+  grpc.triggerBatchInvitations
+    .mockReset()
+    .mockResolvedValue({ batchId: 'b-1', invitedCount: 5, skippedUnconsented: 2 })
+  grpc.setFeedbackStatus
+    .mockReset()
+    .mockResolvedValue({ feedbackId: 'f-1', status: 'acknowledged', eventId: 'e-3' })
+})
+
+describe('POST /api/marketing/batches (CreateBatch)', () => {
+  test('202 + serialises criteria to criteria_json, actor = staff id', async () => {
+    const res = (await createBatchPost(
+      req({ name: 'Campus 1', criteria: { source: 'campus' } }),
+    )) as {
+      body: { batchId: string }
+      status: number
+    }
+    expect(res.status).toBe(202)
+    expect(res.body.batchId).toBe('b-1')
+    const arg = grpc.createBatch.mock.calls[0][0]
+    expect(arg.name).toBe('Campus 1')
+    expect(JSON.parse(arg.criteriaJson)).toEqual({ source: 'campus' })
+    expect(arg.actor).toBe('staff-1')
+  })
+
+  test('400 on empty name', async () => {
+    const res = (await createBatchPost(req({ name: '' }))) as { status: number }
+    expect(res.status).toBe(400)
+    expect(grpc.createBatch).not.toHaveBeenCalled()
+  })
+
+  test('503 when the gRPC command fails', async () => {
+    grpc.createBatch.mockRejectedValue(new Error('down'))
+    const res = (await createBatchPost(req({ name: 'X' }))) as {
+      body: { error: { code: string } }
+      status: number
+    }
+    expect(res.status).toBe(503)
+    expect(res.body.error.code).toBe('COMMAND_FAILED')
+  })
+
+  test('returns the auth error when requireAuth denies', async () => {
+    authHolder.current = { error: { body: { error: { code: 'FORBIDDEN' } }, status: 403 } }
+    const res = (await createBatchPost(req({ name: 'X' }))) as { status: number }
+    expect(res.status).toBe(403)
+    expect(grpc.createBatch).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/marketing/batches/[batchId]/assign (AssignBatch)', () => {
+  test('202 + passes contactIds + batchId from the path', async () => {
+    const res = (await assignPost(
+      req({ contact_ids: ['c-1', 'c-2', 'c-3'] }),
+      p({ batchId: 'b-1' }),
+    )) as {
+      body: { assignedCount: number }
+      status: number
+    }
+    expect(res.status).toBe(202)
+    expect(res.body.assignedCount).toBe(3)
+    const arg = grpc.assignBatch.mock.calls[0][0]
+    expect(arg.batchId).toBe('b-1')
+    expect(arg.contactIds).toEqual(['c-1', 'c-2', 'c-3'])
+  })
+
+  test('400 on an empty contact_ids list', async () => {
+    const res = (await assignPost(req({ contact_ids: [] }), p({ batchId: 'b-1' }))) as {
+      status: number
+    }
+    expect(res.status).toBe(400)
+    expect(grpc.assignBatch).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/marketing/batches/[batchId]/invite (TriggerBatchInvitations)', () => {
+  test('202 + stable idempotency key invite:{batchId}, surfaces counts', async () => {
+    const res = (await invitePost(req(), p({ batchId: 'b-1' }))) as {
+      body: { invitedCount: number; skippedUnconsented: number }
+      status: number
+    }
+    expect(res.status).toBe(202)
+    expect(res.body.invitedCount).toBe(5)
+    expect(res.body.skippedUnconsented).toBe(2)
+    expect(grpc.triggerBatchInvitations.mock.calls[0][0].idempotencyKey).toBe('invite:b-1')
+  })
+})
+
+describe('POST /api/marketing/feedback/[feedbackId]/status (SetFeedbackStatus)', () => {
+  test('202 + stable key feedback-status:{id}:{status}', async () => {
+    const res = (await feedbackStatusPost(
+      req({ status: 'acknowledged' }),
+      p({ feedbackId: 'f-1' }),
+    )) as { body: { status: string }; status: number }
+    expect(res.status).toBe(202)
+    expect(res.body.status).toBe('acknowledged')
+    const arg = grpc.setFeedbackStatus.mock.calls[0][0]
+    expect(arg.idempotencyKey).toBe('feedback-status:f-1:acknowledged')
+    expect(arg.status).toBe('acknowledged')
+  })
+
+  test('400 on an invalid status', async () => {
+    const res = (await feedbackStatusPost(req({ status: 'bogus' }), p({ feedbackId: 'f-1' }))) as {
+      status: number
+    }
+    expect(res.status).toBe(400)
+    expect(grpc.setFeedbackStatus).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/server/chatledgerPublisher.test.ts
+++ b/tests/unit/server/chatledgerPublisher.test.ts
@@ -10,9 +10,13 @@ vi.mock('@/server/redis-client', () => ({
 import {
   publishClearAuthorized,
   publishContactIntakeRequested,
+  publishFeedbackSubmitted,
 } from '@/server/chatledger-publisher'
 import { EventPublishError } from '@/server/event-publisher'
-import type { ContactIntakeCommandPayload } from '@/lib/events/types'
+import type {
+  ContactIntakeCommandPayload,
+  FeedbackSubmitCommandPayload,
+} from '@/lib/events/types'
 
 beforeEach(() => {
   xadd.mockClear()
@@ -168,6 +172,64 @@ describe('publishContactIntakeRequested', () => {
     xadd.mockRejectedValue(new Error('down'))
     await expect(
       publishContactIntakeRequested(sampleIntakePayload({ idempotency_key: 'intake:k4' })),
+    ).rejects.toBeInstanceOf(EventPublishError)
+    expect(xadd).toHaveBeenCalledTimes(3)
+  })
+})
+
+function sampleFeedbackPayload(
+  overrides: Partial<FeedbackSubmitCommandPayload> = {},
+): FeedbackSubmitCommandPayload {
+  return {
+    idempotency_key: 'feedback:c-1:abcdef0123456789',
+    contact_id: 'c-1',
+    customer_id: null,
+    type: 'bug',
+    severity: null,
+    text: 'app crashed',
+    product_area: null,
+    actor: 'intake',
+    ...overrides,
+  }
+}
+
+describe('publishFeedbackSubmitted', () => {
+  it('xadds a chatLedger command with agt=billie-crm, cmd typ, and the feedback conv', async () => {
+    const res = await publishFeedbackSubmitted(sampleFeedbackPayload())
+    expect(res.eventId).toBeTruthy()
+    expect(xadd).toHaveBeenCalledTimes(1)
+    const [stream, star, ...flat] = xadd.mock.calls[0]
+    expect(stream).toBe('chatLedger')
+    expect(star).toBe('*')
+    const fields = Object.fromEntries(
+      flat.reduce((acc: string[][], v: string, i: number) => {
+        if (i % 2 === 0) acc.push([v, flat[i + 1]])
+        return acc
+      }, []),
+    )
+    expect(fields.agt).toBe('billie-crm')
+    expect(fields.typ).toBe('feedback.submit.requested.v1')
+    expect(fields.conv).toBe('feedback-intake:feedback:c-1:abcdef0123456789')
+    expect(fields.usr).toBe('intake')
+    expect(fields.cls).toBe('cmd')
+    expect(JSON.parse(fields.payload).contact_id).toBe('c-1')
+  })
+
+  it('retries a transient xadd failure and succeeds', async () => {
+    xadd
+      .mockRejectedValueOnce(
+        new Error("Stream isn't writeable and enableOfflineQueue options is false"),
+      )
+      .mockResolvedValueOnce('1-1')
+    const res = await publishFeedbackSubmitted(sampleFeedbackPayload({ idempotency_key: 'k3' }))
+    expect(res.eventId).toBeTruthy()
+    expect(xadd).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws EventPublishError after exhausting retries', async () => {
+    xadd.mockRejectedValue(new Error('down'))
+    await expect(
+      publishFeedbackSubmitted(sampleFeedbackPayload({ idempotency_key: 'k4' })),
     ).rejects.toBeInstanceOf(EventPublishError)
     expect(xadd).toHaveBeenCalledTimes(3)
   })


### PR DESCRIPTION
Part B (billie-crm) backend cluster of the marketing Phase-2 sends stream — tasks **B2, B3, B4** of `docs/superpowers/plans/2026-07-03-marketing-crm-phase2-sends.md`. Builds on B5 (projection layer, PR #42, merged).

## B2 — public feedback intake
`POST /api/intake/feedback`: HMAC-authed, gRPC-primary (`SubmitFeedback`) with a chatLedger fallback (`feedback.submit.requested.v1`) — the same intake-via-broker posture as the waitlist route.

## B3 — staff command routes
- `POST /api/marketing/batches` (+ GET) — `CreateBatch`
- `POST /api/marketing/batches/[batchId]/assign` — `AssignBatch`
- `POST /api/marketing/batches/[batchId]/invite` — `TriggerBatchInvitations` (stable `invite:{batchId}` key)
- `GET /api/marketing/feedback` + `POST …/feedback/[feedbackId]/status` — `SetFeedbackStatus`

Adds `SubmitFeedback`/`CreateBatch`/`AssignBatch`/`TriggerBatchInvitations`/`SetFeedbackStatus` to the CRM marketing proto + client (matched field-for-field to the platform contract) and their zod schemas.

## B4 — dashboard feed
`GET /api/marketing/dashboard-feed`: read-only aggregate counts (by stage/source, referral rate, funnel) via raw-SQL GROUP BY, service-API-key auth (fail-closed), for Looker Studio.

## ⚠️ Cross-service dependency (platform-services)
marketingService's inbox consumer handles `contact.intake.requested.v1` but **not** `feedback.submit.requested.v1` — the B2 fallback command is silently ignored until a companion inbox handler is added there (the A8 route exists; the consumer handler does not). The gRPC primary path is unaffected.

## Tests
- B2 intake 6/6, B3 routes 9/9, B4 feed 5/5, chatledger publisher 11/11, real-proto load guard 4/4.
- `pnpm typecheck` + eslint + Prettier clean throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)