### PR TITLE
feat(marketing): Phase-2 B6 — admin UI data layer + contact-detail panels

### DIFF
--- a/src/app/api/marketing/contacts/[contactId]/referrals/route.ts
+++ b/src/app/api/marketing/contacts/[contactId]/referrals/route.ts
@@ -1,0 +1,68 @@
+/**
+ * API Route: GET /api/marketing/contacts/[contactId]/referrals
+ *
+ * Resolves both directions of a contact's referral graph for the contact-detail
+ * Referrals panel: who referred THIS contact (`referrer`, from the contact's
+ * `referredByContactId`), and the contacts THIS one referred (`referred`, plus a
+ * total `referredCount`). Read-only; gated on `canReadMarketing`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { canReadMarketing } from '@/lib/access'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ contactId: string }> },
+) {
+  const auth = await requireAuth(canReadMarketing)
+  if ('error' in auth) return auth.error
+  const { payload, user } = auth
+  const { contactId } = await params
+
+  const selfRes = await payload.find({
+    collection: 'contacts',
+    where: { contactId: { equals: contactId } },
+    limit: 1,
+    depth: 0,
+    overrideAccess: false,
+    user,
+  })
+  const self = selfRes.docs[0]
+
+  let referrer: { contactId: string; firstName: string | null } | null = null
+  if (self?.referredByContactId) {
+    const refRes = await payload.find({
+      collection: 'contacts',
+      where: { contactId: { equals: self.referredByContactId } },
+      limit: 1,
+      depth: 0,
+      overrideAccess: false,
+      user,
+    })
+    const r = refRes.docs[0]
+    if (r) referrer = { contactId: r.contactId, firstName: r.firstName ?? null }
+  }
+
+  const referredRes = await payload.find({
+    collection: 'contacts',
+    where: { referredByContactId: { equals: contactId } },
+    limit: 100,
+    depth: 0,
+    sort: '-observedAt',
+    overrideAccess: false,
+    user,
+  })
+
+  const referred = referredRes.docs.map((d) => ({
+    contactId: d.contactId,
+    firstName: d.firstName ?? null,
+    derivedStage: d.derivedStage ?? null,
+  }))
+
+  return NextResponse.json({
+    referrer,
+    referred,
+    referredCount: referredRes.totalDocs,
+  })
+}

--- a/src/app/api/marketing/contacts/route.ts
+++ b/src/app/api/marketing/contacts/route.ts
@@ -28,6 +28,7 @@ export async function GET(request: NextRequest) {
   if (sp.get('stage')) where.derivedStage = { equals: sp.get('stage') }
   if (sp.get('source')) where.source = { equals: sp.get('source') }
   if (sp.get('city')) where.city = { like: sp.get('city') }
+  if (sp.get('batch')) where.batchId = { equals: sp.get('batch') }
   if (sp.get('q')) {
     where.or = [
       { firstName: { like: sp.get('q') } },

--- a/src/app/api/marketing/feedback/route.ts
+++ b/src/app/api/marketing/feedback/route.ts
@@ -18,6 +18,7 @@ export async function GET(request: NextRequest) {
   const where: Record<string, unknown> = {}
   if (sp.get('status')) where.status = { equals: sp.get('status') }
   if (sp.get('product_area')) where.productArea = { equals: sp.get('product_area') }
+  if (sp.get('contact_id')) where.contactIdString = { equals: sp.get('contact_id') }
 
   const result = await payload.find({
     collection: 'feedback',

--- a/src/components/MarketingView/ContactDetail.tsx
+++ b/src/components/MarketingView/ContactDetail.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { useMarketingContact, marketingContactQueryKey } from '@/hooks/queries/useMarketingContact'
+import { useContactReferrals } from '@/hooks/queries/useContactReferrals'
+import { useFeedbackQueue } from '@/hooks/queries/useFeedbackQueue'
 import type { ContactAuditLog, Interaction } from '@/payload-types'
 import { formatDateMedium } from '@/lib/formatters'
 import { getMarketingConsentGranted } from '@/lib/marketing'
@@ -115,6 +117,8 @@ const InteractionCard: React.FC<{ interaction: Interaction }> = ({ interaction }
  */
 export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
   const { data, isLoading, isError } = useMarketingContact(contactId)
+  const { data: referrals } = useContactReferrals(contactId)
+  const { data: feedback } = useFeedbackQueue({ contact_id: contactId })
   const queryClient = useQueryClient()
   const [noteText, setNoteText] = useState('')
 
@@ -176,13 +180,17 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
         </div>
         <div className={styles.detailHeaderBadges}>
           <span className={styles.badge}>
-            {contact.derivedStage ? (STAGE_LABELS[contact.derivedStage] ?? contact.derivedStage) : '—'}
+            {contact.derivedStage
+              ? (STAGE_LABELS[contact.derivedStage] ?? contact.derivedStage)
+              : '—'}
           </span>
           {consentGranted === true && (
             <span className={`${styles.badge} ${styles.badgeConsentGranted}`}>Consent granted</span>
           )}
           {consentGranted === false && (
-            <span className={`${styles.badge} ${styles.badgeConsentDeclined}`}>Consent declined</span>
+            <span className={`${styles.badge} ${styles.badgeConsentDeclined}`}>
+              Consent declined
+            </span>
           )}
           {consentGranted === null && <span className={styles.placeholder}>Consent —</span>}
           {contact.customerId ? (
@@ -244,15 +252,47 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
             )}
           </Panel>
 
-          <Panel title="Referral">
+          <Panel title="Referrals">
             <div className={styles.panelRow}>
               <span className={styles.panelRowLabel}>Referral code</span>
               <span className={styles.panelRowValue}>{contact.referralCode ?? '—'}</span>
             </div>
             <div className={styles.panelRow}>
               <span className={styles.panelRowLabel}>Referred by</span>
-              <span className={styles.panelRowValue}>{contact.referredByContactId ?? '—'}</span>
+              <span className={styles.panelRowValue}>
+                {referrals?.referrer
+                  ? (referrals.referrer.firstName ?? referrals.referrer.contactId)
+                  : '—'}
+              </span>
             </div>
+            <div className={styles.panelRow}>
+              <span className={styles.panelRowLabel}>Referred</span>
+              <span className={styles.panelRowValue}>{referrals?.referredCount ?? 0}</span>
+            </div>
+            {(referrals?.referred ?? []).map((r) => (
+              <div key={r.contactId} className={styles.panelRow}>
+                <span className={styles.panelRowPrimary}>↳ {r.firstName ?? r.contactId}</span>
+                <span className={styles.panelRowMeta}>
+                  {r.derivedStage ? (STAGE_LABELS[r.derivedStage] ?? r.derivedStage) : '—'}
+                </span>
+              </div>
+            ))}
+          </Panel>
+
+          <Panel title={`Feedback${feedback?.totalDocs ? ` (${feedback.totalDocs})` : ''}`}>
+            {!feedback || feedback.docs.length === 0 ? (
+              <div className={styles.panelEmpty}>—</div>
+            ) : (
+              feedback.docs.map((f) => (
+                <div key={f.id} className={styles.panelRow}>
+                  <span className={styles.panelRowPrimary}>
+                    {f.feedbackType ? `${f.feedbackType}: ` : ''}
+                    {f.body ?? '—'}
+                  </span>
+                  <span className={styles.panelRowMeta}>{f.status ?? '—'}</span>
+                </div>
+              ))
+            )}
           </Panel>
 
           <Panel title="Loan status">

--- a/src/hooks/mutations/useMarketingCommands.ts
+++ b/src/hooks/mutations/useMarketingCommands.ts
@@ -1,0 +1,101 @@
+'use client'
+
+/**
+ * Phase-2 (Stream A) marketing command mutation hooks — batches + feedback
+ * triage. Thin `useMutation` wrappers over the B3 command routes, following the
+ * Phase-1 marketing pattern (sonner toast + query invalidation). Each command
+ * returns 202 (command → projection); the UI re-reads via the invalidated
+ * list/detail queries.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+async function postCommand<T = unknown>(url: string, body?: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.error?.message ?? `Command failed: ${res.status}`)
+  }
+  return res.json()
+}
+
+export interface CreateBatchVars {
+  name: string
+  criteria?: Record<string, unknown>
+}
+
+export function useCreateBatch() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: CreateBatchVars) => postCommand('/api/marketing/batches', vars),
+    onSuccess: () => {
+      toast.success('Batch created')
+      qc.invalidateQueries({ queryKey: ['marketing-batches'] })
+    },
+    onError: (e: Error) => toast.error('Failed to create batch', { description: e.message }),
+  })
+}
+
+export interface AssignBatchVars {
+  batchId: string
+  contactIds: string[]
+}
+
+export function useAssignBatch() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: AssignBatchVars) =>
+      postCommand<{ assignedCount: number }>(
+        `/api/marketing/batches/${encodeURIComponent(vars.batchId)}/assign`,
+        { contact_ids: vars.contactIds },
+      ),
+    onSuccess: (res) => {
+      toast.success(`Assigned ${res.assignedCount} contact(s) to the batch`)
+      qc.invalidateQueries({ queryKey: ['marketing-batches'] })
+      qc.invalidateQueries({ queryKey: ['marketing-contacts'] })
+    },
+    onError: (e: Error) => toast.error('Failed to assign contacts', { description: e.message }),
+  })
+}
+
+export function useTriggerInvitations() {
+  return useMutation({
+    mutationFn: (batchId: string) =>
+      postCommand<{ invitedCount: number; skippedUnconsented: number }>(
+        `/api/marketing/batches/${encodeURIComponent(batchId)}/invite`,
+      ),
+    onSuccess: (res) => {
+      toast.success(
+        `Invited ${res.invitedCount} member(s)` +
+          (res.skippedUnconsented ? `, skipped ${res.skippedUnconsented} unconsented` : ''),
+      )
+    },
+    onError: (e: Error) => toast.error('Failed to trigger invitations', { description: e.message }),
+  })
+}
+
+export interface SetFeedbackStatusVars {
+  feedbackId: string
+  status: 'new' | 'acknowledged' | 'resolved'
+}
+
+export function useSetFeedbackStatus() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: SetFeedbackStatusVars) =>
+      postCommand(`/api/marketing/feedback/${encodeURIComponent(vars.feedbackId)}/status`, {
+        status: vars.status,
+      }),
+    onSuccess: () => {
+      toast.success('Feedback status updated')
+      qc.invalidateQueries({ queryKey: ['marketing-feedback'] })
+    },
+    onError: (e: Error) => toast.error('Failed to update status', { description: e.message }),
+  })
+}

--- a/src/hooks/queries/useBatches.ts
+++ b/src/hooks/queries/useBatches.ts
@@ -1,0 +1,53 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import type { Batch } from '@/payload-types'
+
+export interface BatchesFilters {
+  page?: number
+}
+
+export interface BatchesResponse {
+  docs: Batch[]
+  totalDocs: number
+  totalPages: number
+  page: number
+  hasNextPage: boolean
+  hasPrevPage: boolean
+  limit: number
+}
+
+function buildQueryString(filters: BatchesFilters): string {
+  const params = new URLSearchParams()
+  if (filters.page) params.set('page', String(filters.page))
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+async function fetchBatches(filters: BatchesFilters): Promise<BatchesResponse> {
+  const res = await fetch(`/api/marketing/batches${buildQueryString(filters)}`, {
+    credentials: 'include',
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.error?.message ?? `Batches fetch failed: ${res.status}`)
+  }
+  return res.json()
+}
+
+/**
+ * Query key for the marketing batches list. Exported so the create/assign
+ * mutations can invalidate the batch picker.
+ */
+export const batchesQueryKey = (filters: BatchesFilters) =>
+  ['marketing-batches', 'list', filters] as const
+
+/** React Query hook for the marketing batches list (B6 batch picker). */
+export function useBatches(filters: BatchesFilters = {}) {
+  return useQuery({
+    queryKey: batchesQueryKey(filters),
+    queryFn: () => fetchBatches(filters),
+    placeholderData: (prev) => prev,
+    refetchInterval: 30_000,
+  })
+}

--- a/src/hooks/queries/useContactReferrals.ts
+++ b/src/hooks/queries/useContactReferrals.ts
@@ -1,0 +1,33 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+
+export interface ContactReferrals {
+  referrer: { contactId: string; firstName: string | null } | null
+  referred: Array<{ contactId: string; firstName: string | null; derivedStage: string | null }>
+  referredCount: number
+}
+
+async function fetchContactReferrals(contactId: string): Promise<ContactReferrals> {
+  const res = await fetch(`/api/marketing/contacts/${encodeURIComponent(contactId)}/referrals`, {
+    credentials: 'include',
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.error?.message ?? `Referrals fetch failed: ${res.status}`)
+  }
+  return res.json()
+}
+
+/** Query key for a contact's referral graph. */
+export const contactReferralsQueryKey = (contactId: string) =>
+  ['marketing-contacts', 'referrals', contactId] as const
+
+/** React Query hook for the contact-detail Referrals panel (B6). */
+export function useContactReferrals(contactId: string) {
+  return useQuery({
+    queryKey: contactReferralsQueryKey(contactId),
+    queryFn: () => fetchContactReferrals(contactId),
+    enabled: !!contactId,
+  })
+}

--- a/src/hooks/queries/useFeedbackQueue.ts
+++ b/src/hooks/queries/useFeedbackQueue.ts
@@ -1,0 +1,57 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import type { Feedback } from '@/payload-types'
+
+export interface FeedbackQueueFilters {
+  status?: string
+  product_area?: string
+  page?: number
+}
+
+export interface FeedbackQueueResponse {
+  docs: Feedback[]
+  totalDocs: number
+  totalPages: number
+  page: number
+  hasNextPage: boolean
+  hasPrevPage: boolean
+  limit: number
+}
+
+function buildQueryString(filters: FeedbackQueueFilters): string {
+  const params = new URLSearchParams()
+  if (filters.status) params.set('status', filters.status)
+  if (filters.product_area) params.set('product_area', filters.product_area)
+  if (filters.page) params.set('page', String(filters.page))
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+async function fetchFeedbackQueue(filters: FeedbackQueueFilters): Promise<FeedbackQueueResponse> {
+  const res = await fetch(`/api/marketing/feedback${buildQueryString(filters)}`, {
+    credentials: 'include',
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.error?.message ?? `Feedback fetch failed: ${res.status}`)
+  }
+  return res.json()
+}
+
+/**
+ * Query key for the marketing feedback queue. Exported so the status mutation
+ * can invalidate the queue.
+ */
+export const feedbackQueueQueryKey = (filters: FeedbackQueueFilters) =>
+  ['marketing-feedback', 'list', filters] as const
+
+/** React Query hook for the marketing feedback queue (B6). */
+export function useFeedbackQueue(filters: FeedbackQueueFilters = {}) {
+  return useQuery({
+    queryKey: feedbackQueueQueryKey(filters),
+    queryFn: () => fetchFeedbackQueue(filters),
+    placeholderData: (prev) => prev,
+    refetchInterval: 30_000,
+  })
+}

--- a/src/hooks/queries/useFeedbackQueue.ts
+++ b/src/hooks/queries/useFeedbackQueue.ts
@@ -6,6 +6,7 @@ import type { Feedback } from '@/payload-types'
 export interface FeedbackQueueFilters {
   status?: string
   product_area?: string
+  contact_id?: string
   page?: number
 }
 
@@ -23,6 +24,7 @@ function buildQueryString(filters: FeedbackQueueFilters): string {
   const params = new URLSearchParams()
   if (filters.status) params.set('status', filters.status)
   if (filters.product_area) params.set('product_area', filters.product_area)
+  if (filters.contact_id) params.set('contact_id', filters.contact_id)
   if (filters.page) params.set('page', String(filters.page))
   const qs = params.toString()
   return qs ? `?${qs}` : ''

--- a/src/hooks/queries/useMarketingContacts.ts
+++ b/src/hooks/queries/useMarketingContacts.ts
@@ -8,6 +8,7 @@ export interface MarketingContactsFilters {
   stage?: string
   source?: string
   city?: string
+  batch?: string
   page?: number
 }
 
@@ -27,6 +28,7 @@ function buildQueryString(filters: MarketingContactsFilters): string {
   if (filters.stage) params.set('stage', filters.stage)
   if (filters.source) params.set('source', filters.source)
   if (filters.city) params.set('city', filters.city)
+  if (filters.batch) params.set('batch', filters.batch)
   if (filters.page) params.set('page', String(filters.page))
   const qs = params.toString()
   return qs ? `?${qs}` : ''

--- a/tests/unit/hooks/useMarketingBatchesFeedback.test.ts
+++ b/tests/unit/hooks/useMarketingBatchesFeedback.test.ts
@@ -16,4 +16,14 @@ describe('B6 marketing query hooks', () => {
       { status: 'new' },
     ])
   })
+
+  test('useContactReferrals exports hook + query key factory', async () => {
+    const mod = await import('@/hooks/queries/useContactReferrals')
+    expect(typeof mod.useContactReferrals).toBe('function')
+    expect(mod.contactReferralsQueryKey('c-1')).toEqual([
+      'marketing-contacts',
+      'referrals',
+      'c-1',
+    ])
+  })
 })

--- a/tests/unit/hooks/useMarketingBatchesFeedback.test.ts
+++ b/tests/unit/hooks/useMarketingBatchesFeedback.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from 'vitest'
+
+describe('B6 marketing query hooks', () => {
+  test('useBatches exports hook + query key factory', async () => {
+    const mod = await import('@/hooks/queries/useBatches')
+    expect(typeof mod.useBatches).toBe('function')
+    expect(mod.batchesQueryKey({ page: 2 })).toEqual(['marketing-batches', 'list', { page: 2 }])
+  })
+
+  test('useFeedbackQueue exports hook + query key factory', async () => {
+    const mod = await import('@/hooks/queries/useFeedbackQueue')
+    expect(typeof mod.useFeedbackQueue).toBe('function')
+    expect(mod.feedbackQueueQueryKey({ status: 'new' })).toEqual([
+      'marketing-feedback',
+      'list',
+      { status: 'new' },
+    ])
+  })
+})

--- a/tests/unit/hooks/useMarketingCommands.test.tsx
+++ b/tests/unit/hooks/useMarketingCommands.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Functional tests for the B6 marketing command mutation hooks — assert the
+ * POST URL + body each hook sends. fetch + sonner are mocked.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+import {
+  useCreateBatch,
+  useAssignBatch,
+  useTriggerInvitations,
+  useSetFeedbackStatus,
+} from '@/hooks/mutations/useMarketingCommands'
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return {
+    wrapper: function Wrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(QueryClientProvider, { client: queryClient }, children)
+    },
+  }
+}
+
+function mockFetch(): ReturnType<typeof vi.fn> {
+  return global.fetch as ReturnType<typeof vi.fn>
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ assignedCount: 3, invitedCount: 5, skippedUnconsented: 1 }),
+  })) as unknown as typeof fetch
+})
+
+describe('useMarketingCommands', () => {
+  test('useCreateBatch POSTs name + criteria to /api/marketing/batches', async () => {
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useCreateBatch(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'Campus 1', criteria: { source: 'campus' } })
+    })
+    const [url, init] = mockFetch().mock.calls[0]
+    expect(url).toBe('/api/marketing/batches')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ name: 'Campus 1', criteria: { source: 'campus' } })
+  })
+
+  test('useAssignBatch POSTs contact_ids to the batch assign route', async () => {
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAssignBatch(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ batchId: 'b-1', contactIds: ['c-1', 'c-2'] })
+    })
+    const [url, init] = mockFetch().mock.calls[0]
+    expect(url).toBe('/api/marketing/batches/b-1/assign')
+    expect(JSON.parse(init.body)).toEqual({ contact_ids: ['c-1', 'c-2'] })
+  })
+
+  test('useTriggerInvitations POSTs (no body) to the invite route', async () => {
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useTriggerInvitations(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync('b-1')
+    })
+    const [url, init] = mockFetch().mock.calls[0]
+    expect(url).toBe('/api/marketing/batches/b-1/invite')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBeUndefined()
+  })
+
+  test('useSetFeedbackStatus POSTs status to the feedback status route', async () => {
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useSetFeedbackStatus(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({ feedbackId: 'f-1', status: 'acknowledged' })
+    })
+    const [url, init] = mockFetch().mock.calls[0]
+    expect(url).toBe('/api/marketing/feedback/f-1/status')
+    expect(JSON.parse(init.body)).toEqual({ status: 'acknowledged' })
+  })
+})

--- a/tests/unit/routes/marketingReferrals.test.ts
+++ b/tests/unit/routes/marketingReferrals.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for B6 backend gap: GET /api/marketing/contacts/[contactId]/referrals.
+ * requireAuth + payload.find mocked; asserts both directions of the referral graph.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+const mockFind = vi.hoisted(() => vi.fn())
+const authHolder = vi.hoisted(() => ({
+  current: { user: { id: 'staff-1' }, payload: { find: undefined as unknown } } as Record<
+    string,
+    unknown
+  >,
+}))
+vi.mock('@/lib/auth', () => ({
+  requireAuth: vi.fn(async () => authHolder.current),
+}))
+
+import { GET } from '@/app/api/marketing/contacts/[contactId]/referrals/route'
+
+const p = (contactId: string) => ({ params: Promise.resolve({ contactId }) })
+const req = () => new Request('http://x') as unknown as NextRequest
+
+beforeEach(() => {
+  mockFind.mockReset()
+  authHolder.current = { user: { id: 'staff-1' }, payload: { find: mockFind } }
+})
+
+describe('GET /api/marketing/contacts/[contactId]/referrals', () => {
+  test('resolves referrer + referred list + count', async () => {
+    mockFind
+      // self lookup — has a referrer
+      .mockResolvedValueOnce({ docs: [{ contactId: 'c-1', referredByContactId: 'c-ref' }] })
+      // referrer lookup
+      .mockResolvedValueOnce({ docs: [{ contactId: 'c-ref', firstName: 'Sam' }] })
+      // referred-by-me list
+      .mockResolvedValueOnce({
+        docs: [
+          { contactId: 'c-2', firstName: 'Jo', derivedStage: 'waitlist' },
+          { contactId: 'c-3', firstName: null, derivedStage: null },
+        ],
+        totalDocs: 2,
+      })
+
+    const res = (await GET(req(), p('c-1'))) as {
+      body: {
+        referrer: { contactId: string; firstName: string | null } | null
+        referred: unknown[]
+        referredCount: number
+      }
+      status: number
+    }
+    expect(res.status).toBe(200)
+    expect(res.body.referrer).toEqual({ contactId: 'c-ref', firstName: 'Sam' })
+    expect(res.body.referredCount).toBe(2)
+    expect(res.body.referred).toEqual([
+      { contactId: 'c-2', firstName: 'Jo', derivedStage: 'waitlist' },
+      { contactId: 'c-3', firstName: null, derivedStage: null },
+    ])
+  })
+
+  test('referrer is null when the contact has no referredByContactId', async () => {
+    mockFind
+      .mockResolvedValueOnce({ docs: [{ contactId: 'c-1' }] }) // self, no referrer
+      .mockResolvedValueOnce({ docs: [], totalDocs: 0 }) // referred-by-me (empty)
+
+    const res = (await GET(req(), p('c-1'))) as {
+      body: { referrer: unknown; referredCount: number }
+      status: number
+    }
+    expect(res.status).toBe(200)
+    expect(res.body.referrer).toBeNull()
+    expect(res.body.referredCount).toBe(0)
+    // only two finds — the referrer lookup is skipped
+    expect(mockFind).toHaveBeenCalledTimes(2)
+  })
+
+  test('passes the auth error through when requireAuth denies', async () => {
+    authHolder.current = { error: { body: { error: { code: 'FORBIDDEN' } }, status: 403 } }
+    const res = (await GET(req(), p('c-1'))) as { status: number }
+    expect(res.status).toBe(403)
+    expect(mockFind).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Part B (billie-crm) task **B6** of the marketing Phase-2 sends stream — the admin UI. This PR lands the fully-tested **data layer + the contact-detail panels**; the two remaining pieces are pure-visual and tracked below.

## In this PR
**Query hooks** — `useBatches`, `useFeedbackQueue` (with `contact_id` filter), `useContactReferrals`.
**Mutation hooks** — `useCreateBatch`, `useAssignBatch`, `useTriggerInvitations`, `useSetFeedbackStatus` (sonner toasts + query invalidation).
**Backend gaps filled** — `contact_id` filter on `GET /api/marketing/feedback`; new `GET /api/marketing/contacts/[contactId]/referrals` (resolves both directions of the referral graph); `batch` filter on `GET /api/marketing/contacts`.
**Contact-detail panels** — `ContactDetail` gains a resolved **Referrals** panel (referred-by name, referred count + list) and a **Feedback** panel (contact's feedback + status), reusing the fixed-layout `Panel` structure.

## Tests
- B6 query-hook exports 3/3, referrals route 3/3, mutation hooks (functional URL/body) 4/4.
- `pnpm typecheck` + eslint + Prettier clean throughout.

## Remaining B6 (follow-up — pure UI, needs human visual QA)
- Marketing **grid**: the `[Batch ▾]` filter control + multi-select **Assign to batch** action (data layer ready: `useBatches` + `useAssignBatch` + the `batch` contacts filter).
- **Feedback queue view** (a registered admin view over `useFeedbackQueue` + `useSetFeedbackStatus`).

These are best built with the app runnable so the fixed-layout rule + UX can be eyeballed. `ContactDetail`'s new panels also want a visual pass (no component-render harness exists for MarketingView; the underlying hooks are unit-tested).

## Still open for owners (unchanged)
- ⚠️ Platform: `marketingService` needs a `feedback.submit.requested.v1` inbox handler (B2 fallback).
- B1 ClickSend webhook — blocked on the signature scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)