### PR TITLE
feat(marketing): Phase-2 B6 UI — grid Assign-to-batch + feedback queue view

### DIFF
--- a/src/components/MarketingView/FeedbackQueueView.tsx
+++ b/src/components/MarketingView/FeedbackQueueView.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import React, { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useFeedbackQueue } from '@/hooks/queries/useFeedbackQueue'
+import { useSetFeedbackStatus } from '@/hooks/mutations/useMarketingCommands'
+import type { Feedback } from '@/payload-types'
+import { formatDateShort } from '@/lib/formatters'
+import styles from './styles.module.css'
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All statuses' },
+  { value: 'new', label: 'New' },
+  { value: 'acknowledged', label: 'Acknowledged' },
+  { value: 'resolved', label: 'Resolved' },
+]
+
+/**
+ * FeedbackQueueView — the marketing feedback triage queue at
+ * `/admin/marketing/feedback`. Lists the `feedback` projection (filterable by
+ * status) and advances items via the SetFeedbackStatus command. Reuses the
+ * marketing view styles; fixed-layout action cells keep the row shape stable.
+ */
+export const FeedbackQueueView: React.FC = () => {
+  const [status, setStatus] = useState('')
+  const [page, setPage] = useState(1)
+
+  const filters = useMemo(() => ({ status: status || undefined, page }), [status, page])
+  const { data, isLoading, isError } = useFeedbackQueue(filters)
+  const setStatusMutation = useSetFeedbackStatus()
+  const docs = data?.docs ?? []
+
+  const advance = (feedbackId: string | null | undefined, to: 'acknowledged' | 'resolved') => {
+    if (!feedbackId) return
+    setStatusMutation.mutate({ feedbackId, status: to })
+  }
+
+  const statusBadge = (s: Feedback['status']) => <span className={styles.badge}>{s ?? 'new'}</span>
+
+  return (
+    <div className={styles.container}>
+      <Link href="/admin/marketing" className={styles.backLink}>
+        ← Back to Marketing
+      </Link>
+
+      <div className={styles.header}>
+        <h1 className={styles.headerTitle}>Feedback queue</h1>
+      </div>
+
+      <div className={styles.filters}>
+        <div className={styles.filterGroup}>
+          <label className={styles.filterLabel} htmlFor="feedback-status-filter">
+            Status
+          </label>
+          <select
+            id="feedback-status-filter"
+            className={styles.filterSelect}
+            value={status}
+            onChange={(e) => {
+              setStatus(e.target.value)
+              setPage(1)
+            }}
+          >
+            {STATUS_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className={styles.tableWrapper}>
+        {isError ? (
+          <div className={styles.emptyState}>Failed to load feedback. Please retry.</div>
+        ) : (
+          <>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>Contact</th>
+                  <th>Type</th>
+                  <th>Feedback</th>
+                  <th>Status</th>
+                  <th>Received</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading && docs.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className={styles.emptyCell}>
+                      Loading feedback…
+                    </td>
+                  </tr>
+                ) : docs.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className={styles.emptyCell}>
+                      No feedback matches the current filter.
+                    </td>
+                  </tr>
+                ) : (
+                  docs.map((fb) => (
+                    <tr key={fb.id} className={styles.row}>
+                      <td>
+                        {fb.contactIdString ? (
+                          <Link
+                            href={`/admin/marketing/contacts/${fb.contactIdString}`}
+                            className={styles.nameLink}
+                          >
+                            {fb.contactIdString}
+                          </Link>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
+                      <td>{fb.feedbackType ?? '—'}</td>
+                      <td>{fb.body ?? '—'}</td>
+                      <td>{statusBadge(fb.status)}</td>
+                      <td>{fb.receivedAt ? formatDateShort(fb.receivedAt) : '—'}</td>
+                      <td>
+                        <button
+                          type="button"
+                          className={styles.pageButton}
+                          onClick={() => advance(fb.feedbackId, 'acknowledged')}
+                          disabled={setStatusMutation.isPending || fb.status !== 'new'}
+                        >
+                          Acknowledge
+                        </button>{' '}
+                        <button
+                          type="button"
+                          className={styles.pageButton}
+                          onClick={() => advance(fb.feedbackId, 'resolved')}
+                          disabled={setStatusMutation.isPending || fb.status === 'resolved'}
+                        >
+                          Resolve
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+
+            <div className={styles.pagination}>
+              <button
+                type="button"
+                className={styles.pageButton}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={!data || !data.hasPrevPage}
+              >
+                ← Previous
+              </button>
+              <span className={styles.pageStatus}>
+                Page {data?.page ?? page} of {data?.totalPages ?? 1} · {data?.totalDocs ?? 0} items
+              </span>
+              <button
+                type="button"
+                className={styles.pageButton}
+                onClick={() => setPage((p) => p + 1)}
+                disabled={!data || !data.hasNextPage}
+              >
+                Next →
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default FeedbackQueueView

--- a/src/components/MarketingView/MarketingView.tsx
+++ b/src/components/MarketingView/MarketingView.tsx
@@ -12,6 +12,7 @@ import { formatDateShort } from '@/lib/formatters'
 import { getMarketingConsentGranted } from '@/lib/marketing'
 import { ContactDetail } from './ContactDetail'
 import { FeedbackQueueView } from './FeedbackQueueView'
+import { NewContactModal } from './NewContactModal'
 import styles from './styles.module.css'
 
 export interface MarketingViewProps {
@@ -89,6 +90,7 @@ const MarketingContactsGrid: React.FC = () => {
   const [page, setPage] = useState(1)
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [assignTarget, setAssignTarget] = useState('')
+  const [showNewContact, setShowNewContact] = useState(false)
 
   const filters = useMemo<MarketingContactsFilters>(
     () => ({
@@ -156,6 +158,9 @@ const MarketingContactsGrid: React.FC = () => {
     <div className={styles.container}>
       <div className={styles.header}>
         <h1 className={styles.headerTitle}>Marketing</h1>
+        <button type="button" className={styles.pageButton} onClick={() => setShowNewContact(true)}>
+          + New contact
+        </button>
         <Link href="/admin/marketing/feedback" className={styles.backLink}>
           Feedback queue →
         </Link>
@@ -388,6 +393,13 @@ const MarketingContactsGrid: React.FC = () => {
           </>
         )}
       </div>
+
+      {showNewContact && (
+        <NewContactModal
+          onClose={() => setShowNewContact(false)}
+          onSuccess={() => setShowNewContact(false)}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/MarketingView/MarketingView.tsx
+++ b/src/components/MarketingView/MarketingView.tsx
@@ -5,14 +5,18 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useMarketingContacts } from '@/hooks/queries/useMarketingContacts'
 import type { MarketingContactsFilters } from '@/hooks/queries/useMarketingContacts'
+import { useBatches } from '@/hooks/queries/useBatches'
+import { useAssignBatch } from '@/hooks/mutations/useMarketingCommands'
 import type { Contact } from '@/payload-types'
 import { formatDateShort } from '@/lib/formatters'
 import { getMarketingConsentGranted } from '@/lib/marketing'
 import { ContactDetail } from './ContactDetail'
+import { FeedbackQueueView } from './FeedbackQueueView'
 import styles from './styles.module.css'
 
 export interface MarketingViewProps {
   contactId: string
+  feedback?: boolean
 }
 
 const STAGE_OPTIONS: Array<{ value: Contact['derivedStage'] & string; label: string }> = [
@@ -65,7 +69,10 @@ function ConsentBadge({ consent }: { consent: Contact['consent'] }) {
  * timeline at `/admin/marketing/contacts/<contactId>` when a contactId is
  * supplied by the WithTemplate wrapper.
  */
-export const MarketingView: React.FC<MarketingViewProps> = ({ contactId }) => {
+export const MarketingView: React.FC<MarketingViewProps> = ({ contactId, feedback }) => {
+  if (feedback) {
+    return <FeedbackQueueView />
+  }
   if (contactId) {
     return <ContactDetail contactId={contactId} />
   }
@@ -78,7 +85,10 @@ const MarketingContactsGrid: React.FC = () => {
   const [stage, setStage] = useState('')
   const [source, setSource] = useState('')
   const [city, setCity] = useState('')
+  const [batch, setBatch] = useState('')
   const [page, setPage] = useState(1)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [assignTarget, setAssignTarget] = useState('')
 
   const filters = useMemo<MarketingContactsFilters>(
     () => ({
@@ -86,32 +96,58 @@ const MarketingContactsGrid: React.FC = () => {
       stage: stage || undefined,
       source: source || undefined,
       city: city || undefined,
+      batch: batch || undefined,
       page,
     }),
-    [q, stage, source, city, page],
+    [q, stage, source, city, batch, page],
   )
 
   const { data, isLoading, isError } = useMarketingContacts(filters)
+  const { data: batchesData } = useBatches()
+  const assign = useAssignBatch()
   const docs = data?.docs ?? []
+  const batchOptions = batchesData?.docs ?? []
+  const batchNameFor = (id?: string | null) =>
+    id ? (batchOptions.find((b) => b.batchId === id)?.name ?? id) : '—'
 
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setQ(e.target.value)
-    setPage(1)
-  }
+  const onFilter =
+    (setter: (v: string) => void) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+      setter(e.target.value)
+      setPage(1)
+    }
 
-  const handleStageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setStage(e.target.value)
-    setPage(1)
-  }
+  const toggleOne = (contactId: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(contactId)) next.delete(contactId)
+      else next.add(contactId)
+      return next
+    })
 
-  const handleSourceChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setSource(e.target.value)
-    setPage(1)
-  }
+  const pageContactIds = docs.map((d) => d.contactId).filter((v): v is string => !!v)
+  const allOnPageSelected =
+    pageContactIds.length > 0 && pageContactIds.every((id) => selected.has(id))
+  const toggleAllOnPage = () =>
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (allOnPageSelected) pageContactIds.forEach((id) => next.delete(id))
+      else pageContactIds.forEach((id) => next.add(id))
+      return next
+    })
 
-  const handleCityChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setCity(e.target.value)
-    setPage(1)
+  const canAssign = selected.size > 0 && !!assignTarget && !assign.isPending
+  const handleAssign = () => {
+    if (!canAssign) return
+    assign.mutate(
+      { batchId: assignTarget, contactIds: Array.from(selected) },
+      {
+        onSuccess: () => {
+          setSelected(new Set())
+          setAssignTarget('')
+        },
+      },
+    )
   }
 
   const contactHref = (contact: Contact) => `/admin/marketing/contacts/${contact.contactId}`
@@ -120,6 +156,9 @@ const MarketingContactsGrid: React.FC = () => {
     <div className={styles.container}>
       <div className={styles.header}>
         <h1 className={styles.headerTitle}>Marketing</h1>
+        <Link href="/admin/marketing/feedback" className={styles.backLink}>
+          Feedback queue →
+        </Link>
       </div>
 
       <div className={styles.filters}>
@@ -128,7 +167,7 @@ const MarketingContactsGrid: React.FC = () => {
           className={styles.searchInput}
           placeholder="Search name, email, mobile"
           value={q}
-          onChange={handleSearchChange}
+          onChange={onFilter(setQ)}
           aria-label="Search contacts"
         />
 
@@ -140,7 +179,7 @@ const MarketingContactsGrid: React.FC = () => {
             id="marketing-stage-filter"
             className={styles.filterSelect}
             value={stage}
-            onChange={handleStageChange}
+            onChange={onFilter(setStage)}
           >
             <option value="">All stages</option>
             {STAGE_OPTIONS.map((opt) => (
@@ -159,7 +198,7 @@ const MarketingContactsGrid: React.FC = () => {
             id="marketing-source-filter"
             className={styles.filterSelect}
             value={source}
-            onChange={handleSourceChange}
+            onChange={onFilter(setSource)}
           >
             <option value="">All sources</option>
             {SOURCE_OPTIONS.map((opt) => (
@@ -178,7 +217,7 @@ const MarketingContactsGrid: React.FC = () => {
             id="marketing-city-filter"
             className={styles.filterSelect}
             value={city}
-            onChange={handleCityChange}
+            onChange={onFilter(setCity)}
           >
             <option value="">All cities</option>
             {CITY_OPTIONS.map((c) => (
@@ -188,6 +227,58 @@ const MarketingContactsGrid: React.FC = () => {
             ))}
           </select>
         </div>
+
+        <div className={styles.filterGroup}>
+          <label className={styles.filterLabel} htmlFor="marketing-batch-filter">
+            Batch
+          </label>
+          <select
+            id="marketing-batch-filter"
+            className={styles.filterSelect}
+            value={batch}
+            onChange={onFilter(setBatch)}
+          >
+            <option value="">All batches</option>
+            {batchOptions.map((b) => (
+              <option key={b.batchId} value={b.batchId}>
+                {b.name ?? b.batchId}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Assign-to-batch bar — always present (fixed layout); controls disable
+          until a selection + target batch exist. */}
+      <div className={styles.filters}>
+        <span className={styles.pageStatus}>{selected.size} selected</span>
+        <div className={styles.filterGroup}>
+          <label className={styles.filterLabel} htmlFor="marketing-assign-batch">
+            Assign to batch
+          </label>
+          <select
+            id="marketing-assign-batch"
+            className={styles.filterSelect}
+            value={assignTarget}
+            onChange={(e) => setAssignTarget(e.target.value)}
+            disabled={selected.size === 0}
+          >
+            <option value="">Choose a batch…</option>
+            {batchOptions.map((b) => (
+              <option key={b.batchId} value={b.batchId}>
+                {b.name ?? b.batchId}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          type="button"
+          className={styles.pageButton}
+          onClick={handleAssign}
+          disabled={!canAssign}
+        >
+          {assign.isPending ? 'Assigning…' : 'Assign'}
+        </button>
       </div>
 
       <div className={styles.tableWrapper}>
@@ -198,10 +289,19 @@ const MarketingContactsGrid: React.FC = () => {
             <table className={styles.table}>
               <thead>
                 <tr>
+                  <th>
+                    <input
+                      type="checkbox"
+                      checked={allOnPageSelected}
+                      onChange={toggleAllOnPage}
+                      aria-label="Select all on page"
+                    />
+                  </th>
                   <th>Name</th>
                   <th>Mobile</th>
                   <th>Stage</th>
                   <th>Source</th>
+                  <th>Batch</th>
                   <th>Consent</th>
                   <th>Updated</th>
                 </tr>
@@ -209,13 +309,13 @@ const MarketingContactsGrid: React.FC = () => {
               <tbody>
                 {isLoading && docs.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className={styles.emptyCell}>
+                    <td colSpan={8} className={styles.emptyCell}>
                       Loading contacts…
                     </td>
                   </tr>
                 ) : docs.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className={styles.emptyCell}>
+                    <td colSpan={8} className={styles.emptyCell}>
                       No contacts match the current filters.
                     </td>
                   </tr>
@@ -226,6 +326,14 @@ const MarketingContactsGrid: React.FC = () => {
                       className={styles.row}
                       onClick={() => router.push(contactHref(contact))}
                     >
+                      <td onClick={(e) => e.stopPropagation()}>
+                        <input
+                          type="checkbox"
+                          checked={contact.contactId ? selected.has(contact.contactId) : false}
+                          onChange={() => contact.contactId && toggleOne(contact.contactId)}
+                          aria-label={`Select ${contact.firstName ?? contact.contactId}`}
+                        />
+                      </td>
                       <td>
                         <Link
                           href={contactHref(contact)}
@@ -244,6 +352,7 @@ const MarketingContactsGrid: React.FC = () => {
                         )}
                       </td>
                       <td>{contact.source ? sourceLabel(contact.source) : '—'}</td>
+                      <td>{batchNameFor(contact.batchId)}</td>
                       <td>
                         <ConsentBadge consent={contact.consent} />
                       </td>
@@ -264,7 +373,8 @@ const MarketingContactsGrid: React.FC = () => {
                 ← Previous
               </button>
               <span className={styles.pageStatus}>
-                Page {data?.page ?? page} of {data?.totalPages ?? 1} · {data?.totalDocs ?? 0} contacts
+                Page {data?.page ?? page} of {data?.totalPages ?? 1} · {data?.totalDocs ?? 0}{' '}
+                contacts
               </span>
               <button
                 type="button"

--- a/src/components/MarketingView/MarketingViewWithTemplate.tsx
+++ b/src/components/MarketingView/MarketingViewWithTemplate.tsx
@@ -26,8 +26,9 @@ export async function MarketingViewWithTemplate({
   }
   const resolvedParams = await params
   const segments = resolvedParams?.segments as string[] | undefined
-  // /marketing → grid; /marketing/contacts/<id> → detail
+  // /marketing → grid; /marketing/contacts/<id> → detail; /marketing/feedback → queue
   const contactId = segments?.[1] === 'contacts' ? (segments?.[2] ?? '') : ''
+  const feedback = segments?.[1] === 'feedback'
 
   return (
     <DefaultTemplate
@@ -40,7 +41,7 @@ export async function MarketingViewWithTemplate({
       user={initPageResult.req.user}
       visibleEntities={initPageResult.visibleEntities}
     >
-      <MarketingView contactId={contactId} />
+      <MarketingView contactId={contactId} feedback={feedback} />
     </DefaultTemplate>
   )
 }

--- a/src/components/MarketingView/NewContactModal.tsx
+++ b/src/components/MarketingView/NewContactModal.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useCreateContact, type CreateContactVars } from '@/hooks/mutations/useMarketingCommands'
+import styles from './styles.module.css'
+
+interface NewContactModalProps {
+  onClose: () => void
+  onSuccess: () => void
+}
+
+const SOURCE_OPTIONS = [
+  { value: 'meta', label: 'Meta' },
+  { value: 'google', label: 'Google' },
+  { value: 'campus', label: 'Campus' },
+  { value: 'referral', label: 'Referral' },
+  { value: 'social_dm', label: 'Social DM' },
+  { value: 'ai_search', label: 'AI search' },
+  { value: 'organic', label: 'Organic' },
+  { value: 'other', label: 'Other' },
+]
+
+/**
+ * Staff-initiated contact creation. Posts to MarketingService.UpsertContact via
+ * /api/marketing/contacts (waitlist:false) — the contact is created in the
+ * marketing system of record and projects back into the grid. Mobile or email
+ * is required (the natural key); everything else is optional.
+ */
+export const NewContactModal: React.FC<NewContactModalProps> = ({ onClose, onSuccess }) => {
+  const [firstName, setFirstName] = useState('')
+  const [email, setEmail] = useState('')
+  const [mobile, setMobile] = useState('')
+  const [source, setSource] = useState('other')
+  const [channelPreference, setChannelPreference] = useState('')
+  const [city, setCity] = useState('')
+  const [postcode, setPostcode] = useState('')
+
+  const create = useCreateContact()
+  const canSubmit = (!!mobile.trim() || !!email.trim()) && !create.isPending
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+
+    const vars: CreateContactVars = { source }
+    if (firstName.trim()) vars.first_name = firstName.trim()
+    if (email.trim()) vars.email = email.trim()
+    if (mobile.trim()) vars.mobile = mobile.trim()
+    if (city.trim()) vars.city = city.trim()
+    if (postcode.trim()) vars.postcode = postcode.trim()
+    if (channelPreference === 'whatsapp' || channelPreference === 'sms') {
+      vars.channel_preference = channelPreference
+    }
+
+    create.mutate(vars, { onSuccess: () => onSuccess() })
+  }
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h2 className={styles.modalTitle}>New contact</h2>
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className={styles.modalBody}>
+            {create.isError && (
+              <div className={styles.errorMessage}>
+                {create.error instanceof Error ? create.error.message : 'Failed to create contact'}
+              </div>
+            )}
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="new-contact-first-name">
+                First name
+              </label>
+              <input
+                id="new-contact-first-name"
+                type="text"
+                className={styles.formInput}
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+              />
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="new-contact-mobile">
+                Mobile
+              </label>
+              <input
+                id="new-contact-mobile"
+                type="tel"
+                className={styles.formInput}
+                value={mobile}
+                onChange={(e) => setMobile(e.target.value)}
+                placeholder="+61…"
+              />
+              <p className={styles.formHint}>Mobile or email is required.</p>
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="new-contact-email">
+                Email
+              </label>
+              <input
+                id="new-contact-email"
+                type="email"
+                className={styles.formInput}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="new-contact-source">
+                Source
+              </label>
+              <select
+                id="new-contact-source"
+                className={styles.formSelect}
+                value={source}
+                onChange={(e) => setSource(e.target.value)}
+              >
+                {SOURCE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="new-contact-channel">
+                Channel preference
+              </label>
+              <select
+                id="new-contact-channel"
+                className={styles.formSelect}
+                value={channelPreference}
+                onChange={(e) => setChannelPreference(e.target.value)}
+              >
+                <option value="">—</option>
+                <option value="sms">SMS</option>
+                <option value="whatsapp">WhatsApp</option>
+              </select>
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="new-contact-city">
+                City
+              </label>
+              <input
+                id="new-contact-city"
+                type="text"
+                className={styles.formInput}
+                value={city}
+                onChange={(e) => setCity(e.target.value)}
+              />
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="new-contact-postcode">
+                Postcode
+              </label>
+              <input
+                id="new-contact-postcode"
+                type="text"
+                className={styles.formInput}
+                value={postcode}
+                onChange={(e) => setPostcode(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className={styles.modalFooter}>
+            <button type="button" className={styles.btnCancel} onClick={onClose}>
+              Cancel
+            </button>
+            <button type="submit" className={styles.btnSubmit} disabled={!canSubmit}>
+              {create.isPending ? 'Creating…' : 'Create contact'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default NewContactModal

--- a/src/components/MarketingView/styles.module.css
+++ b/src/components/MarketingView/styles.module.css
@@ -415,3 +415,140 @@
   font-size: 12px;
   white-space: nowrap;
 }
+
+/* --- New-contact modal (mirrors the LoanAccountServicing modal styles) --- */
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: var(--theme-bg, white);
+  border-radius: 12px;
+  width: 100%;
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--theme-elevation-100);
+}
+
+.modalTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--theme-elevation-500);
+  line-height: 1;
+}
+
+.closeBtn:hover {
+  color: var(--theme-elevation-800);
+}
+
+.modalBody {
+  padding: 1.5rem;
+}
+
+.formGroup {
+  margin-bottom: 1rem;
+}
+
+.formLabel {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 0.375rem;
+  color: var(--theme-elevation-700);
+}
+
+.formInput,
+.formSelect {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.formInput:focus,
+.formSelect:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.formHint {
+  font-size: 0.75rem;
+  color: var(--theme-elevation-500);
+  margin-top: 0.25rem;
+}
+
+.modalFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--theme-elevation-100);
+}
+
+.btnCancel {
+  padding: 0.625rem 1.25rem;
+  background: var(--theme-elevation-100);
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btnCancel:hover {
+  background: var(--theme-elevation-200);
+}
+
+.btnSubmit {
+  padding: 0.625rem 1.25rem;
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btnSubmit:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+.btnSubmit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.errorMessage {
+  background: #fee2e2;
+  color: #991b1b;
+  padding: 0.75rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+}

--- a/src/hooks/mutations/useMarketingCommands.ts
+++ b/src/hooks/mutations/useMarketingCommands.ts
@@ -99,3 +99,26 @@ export function useSetFeedbackStatus() {
     onError: (e: Error) => toast.error('Failed to update status', { description: e.message }),
   })
 }
+
+export interface CreateContactVars {
+  first_name?: string
+  email?: string
+  mobile?: string
+  city?: string
+  postcode?: string
+  channel_preference?: 'whatsapp' | 'sms'
+  source: string
+}
+
+export function useCreateContact() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: CreateContactVars) =>
+      postCommand<{ contactId: string; eventId: string }>('/api/marketing/contacts', vars),
+    onSuccess: () => {
+      toast.success('Contact created')
+      qc.invalidateQueries({ queryKey: ['marketing-contacts'] })
+    },
+    onError: (e: Error) => toast.error('Failed to create contact', { description: e.message }),
+  })
+}

--- a/tests/unit/hooks/useMarketingCommands.test.tsx
+++ b/tests/unit/hooks/useMarketingCommands.test.tsx
@@ -16,6 +16,7 @@ import {
   useAssignBatch,
   useTriggerInvitations,
   useSetFeedbackStatus,
+  useCreateContact,
 } from '@/hooks/mutations/useMarketingCommands'
 
 function createWrapper() {
@@ -85,5 +86,25 @@ describe('useMarketingCommands', () => {
     const [url, init] = mockFetch().mock.calls[0]
     expect(url).toBe('/api/marketing/feedback/f-1/status')
     expect(JSON.parse(init.body)).toEqual({ status: 'acknowledged' })
+  })
+
+  test('useCreateContact POSTs the contact body to /api/marketing/contacts', async () => {
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useCreateContact(), { wrapper })
+    await act(async () => {
+      await result.current.mutateAsync({
+        mobile: '+61403320117',
+        first_name: 'Test',
+        source: 'other',
+      })
+    })
+    const [url, init] = mockFetch().mock.calls[0]
+    expect(url).toBe('/api/marketing/contacts')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({
+      mobile: '+61403320117',
+      first_name: 'Test',
+      source: 'other',
+    })
   })
 })


### PR DESCRIPTION
Completes the **B6 admin UI** (the remaining visual pieces on top of the merged data layer, PR #44).

## Marketing grid
- New **`[Batch]` filter** + **Batch column** (via `useBatches` + the `batch` contacts filter).
- Multi-select **Assign to batch**: row checkboxes + select-all, and an always-present assign bar (fixed-layout rule) that assigns the selection to a chosen batch via `useAssignBatch`.

## Feedback queue
- New **`FeedbackQueueView`** at `/admin/marketing/feedback` — status filter + **Acknowledge / Resolve** actions (`useFeedbackQueue` + `useSetFeedbackStatus`). Embedded as a sub-route of the existing marketing view (no new payload.config / nav / importMap wiring), with a "Feedback queue" link from the grid.

Reuses the marketing view styles throughout; `typecheck` + eslint + Prettier clean.

## ⚠️ Visual QA
There's no component-render harness for MarketingView, so **this wants a human visual pass** — the fixed-layout assign bar, the checkbox column, and the queue table/actions. The data layer + mutations underneath are all unit-tested (PR #44). Recommend pulling the branch and clicking through `/admin/marketing` (select rows → assign) and `/admin/marketing/feedback` (acknowledge/resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)