### PR TITLE
fix(proxy): exempt intake + webhook routes from CSRF origin check

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -73,7 +73,12 @@ function verifyCsrfOrigin(request: NextRequest): NextResponse | null {
   if (!appUrl) {
     // Fail closed: block mutations if we can't verify the origin
     return NextResponse.json(
-      { error: { code: 'CSRF_REJECTED', message: 'Server misconfigured — cannot verify request origin.' } },
+      {
+        error: {
+          code: 'CSRF_REJECTED',
+          message: 'Server misconfigured — cannot verify request origin.',
+        },
+      },
       { status: 403 },
     )
   }
@@ -85,7 +90,12 @@ function verifyCsrfOrigin(request: NextRequest): NextResponse | null {
   // Origin on cross-origin requests. Missing both headers on a mutation is suspicious.
   if (!origin && !referer) {
     return NextResponse.json(
-      { error: { code: 'CSRF_REJECTED', message: 'Missing Origin and Referer headers on mutation request.' } },
+      {
+        error: {
+          code: 'CSRF_REJECTED',
+          message: 'Missing Origin and Referer headers on mutation request.',
+        },
+      },
       { status: 403 },
     )
   }
@@ -120,6 +130,19 @@ function verifyCsrfOrigin(request: NextRequest): NextResponse | null {
   return null
 }
 
+/**
+ * Public endpoints authenticated by their own secret rather than a session
+ * cookie — the marketing-site intake forms (API key + HMAC) and inbound
+ * webhooks (shared secret). They are called cross-origin / server-to-server
+ * (e.g. ClickSend), so the browser CSRF origin check does not apply and would
+ * wrongly reject them (no Origin/Referer to match). Auth is enforced in-route.
+ */
+const CSRF_EXEMPT_PREFIXES = ['/api/intake/', '/api/webhooks/']
+
+function isCsrfExemptPath(pathname: string): boolean {
+  return CSRF_EXEMPT_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+}
+
 function setSecurityHeaders(response: NextResponse): NextResponse {
   response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload')
   response.headers.set('X-Frame-Options', 'DENY')
@@ -134,7 +157,8 @@ function setSecurityHeaders(response: NextResponse): NextResponse {
 }
 
 const hasPayloadSecret =
-  !!process.env.PAYLOAD_SECRET && process.env.PAYLOAD_SECRET !== 'build-placeholder-not-for-production'
+  !!process.env.PAYLOAD_SECRET &&
+  process.env.PAYLOAD_SECRET !== 'build-placeholder-not-for-production'
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -153,8 +177,11 @@ export async function proxy(request: NextRequest) {
   }
 
   // --- CSRF origin validation ---
-  // Block cross-origin mutation requests (POST/PUT/PATCH/DELETE)
-  if (pathname !== '/api/health') {
+  // Block cross-origin mutation requests (POST/PUT/PATCH/DELETE), except the
+  // secret-authenticated public API surface (intake forms + inbound webhooks),
+  // which is cross-origin/server-to-server by design and carries no session
+  // cookie — see isCsrfExemptPath.
+  if (pathname !== '/api/health' && !isCsrfExemptPath(pathname)) {
     const csrfBlocked = verifyCsrfOrigin(request)
     if (csrfBlocked) return csrfBlocked
   }

--- a/tests/unit/security/csrf-origin.test.ts
+++ b/tests/unit/security/csrf-origin.test.ts
@@ -1,17 +1,22 @@
 import { describe, test, expect } from 'vitest'
 
 /**
- * Tests for the CSRF origin validation logic in src/middleware.ts.
+ * Tests for the CSRF origin validation logic in src/proxy.ts.
  *
- * The middleware verifies that mutation requests (POST, PUT, PATCH, DELETE)
- * originate from the expected application URL by checking the Origin and
- * Referer headers. We test the logic in isolation rather than importing
- * the middleware module (same pattern as middleware-env-check.test.ts).
+ * The proxy verifies that mutation requests (POST, PUT, PATCH, DELETE)
+ * originate from the expected application URL (Origin/Referer), and fails
+ * closed — a missing appUrl or missing BOTH headers is blocked. The
+ * secret-authenticated public API surface (`/api/intake/*`, `/api/webhooks/*`)
+ * is exempt: it's cross-origin/server-to-server by design and self-authenticates
+ * in-route, so the browser CSRF check doesn't apply.
+ *
+ * We mirror the logic in isolation (same pattern as middleware-env-check.test.ts);
+ * keep these mirrors in lockstep with src/proxy.ts.
  */
 
 type CsrfResult = 'allow' | 'block'
 
-/** Mirrors the verifyCsrfOrigin logic from src/middleware.ts */
+/** Mirrors verifyCsrfOrigin from src/proxy.ts (fails closed). */
 const verifyCsrfOrigin = (opts: {
   method: string
   appUrl?: string
@@ -20,8 +25,8 @@ const verifyCsrfOrigin = (opts: {
 }): CsrfResult => {
   const mutationMethods = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
   if (!mutationMethods.has(opts.method)) return 'allow'
-  if (!opts.appUrl) return 'allow'
-  if (!opts.origin && !opts.referer) return 'allow'
+  if (!opts.appUrl) return 'block' // fail closed — cannot verify origin
+  if (!opts.origin && !opts.referer) return 'block' // missing both is suspicious
 
   const allowedOrigin = new URL(opts.appUrl).origin
 
@@ -29,8 +34,7 @@ const verifyCsrfOrigin = (opts: {
 
   if (!opts.origin && opts.referer) {
     try {
-      const refererOrigin = new URL(opts.referer).origin
-      if (refererOrigin !== allowedOrigin) return 'block'
+      if (new URL(opts.referer).origin !== allowedOrigin) return 'block'
     } catch {
       return 'block'
     }
@@ -39,93 +43,125 @@ const verifyCsrfOrigin = (opts: {
   return 'allow'
 }
 
+/** Mirrors isCsrfExemptPath from src/proxy.ts. */
+const CSRF_EXEMPT_PREFIXES = ['/api/intake/', '/api/webhooks/']
+const isCsrfExemptPath = (pathname: string): boolean =>
+  CSRF_EXEMPT_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+
+/** Mirrors the proxy() gate: exempt public paths skip the CSRF check entirely. */
+const csrfGate = (opts: {
+  pathname: string
+  method: string
+  appUrl?: string
+  origin?: string
+  referer?: string
+}): CsrfResult => (isCsrfExemptPath(opts.pathname) ? 'allow' : verifyCsrfOrigin(opts))
+
 describe('CSRF Origin Validation', () => {
   const appUrl = 'https://crm.billie.loans'
 
   test('GET requests always pass (not a mutation)', () => {
-    expect(verifyCsrfOrigin({
-      method: 'GET',
-      appUrl,
-      origin: 'https://evil.com',
-    })).toBe('allow')
+    expect(verifyCsrfOrigin({ method: 'GET', appUrl, origin: 'https://evil.com' })).toBe('allow')
   })
 
   test('POST with matching origin passes', () => {
-    expect(verifyCsrfOrigin({
-      method: 'POST',
-      appUrl,
-      origin: 'https://crm.billie.loans',
-    })).toBe('allow')
+    expect(verifyCsrfOrigin({ method: 'POST', appUrl, origin: 'https://crm.billie.loans' })).toBe(
+      'allow',
+    )
   })
 
   test('POST with mismatched origin is blocked', () => {
-    expect(verifyCsrfOrigin({
-      method: 'POST',
-      appUrl,
-      origin: 'https://evil.com',
-    })).toBe('block')
+    expect(verifyCsrfOrigin({ method: 'POST', appUrl, origin: 'https://evil.com' })).toBe('block')
   })
 
-  test('POST with no origin/referer passes (server-to-server)', () => {
-    expect(verifyCsrfOrigin({
-      method: 'POST',
-      appUrl,
-    })).toBe('allow')
+  test('POST with no origin AND no referer is blocked (fail closed)', () => {
+    expect(verifyCsrfOrigin({ method: 'POST', appUrl })).toBe('block')
   })
 
   test('POST with matching referer (no origin) passes', () => {
-    expect(verifyCsrfOrigin({
-      method: 'POST',
-      appUrl,
-      referer: 'https://crm.billie.loans/admin/accounts',
-    })).toBe('allow')
+    expect(
+      verifyCsrfOrigin({
+        method: 'POST',
+        appUrl,
+        referer: 'https://crm.billie.loans/admin/accounts',
+      }),
+    ).toBe('allow')
   })
 
   test('POST with mismatched referer is blocked', () => {
-    expect(verifyCsrfOrigin({
-      method: 'POST',
-      appUrl,
-      referer: 'https://evil.com/phish',
-    })).toBe('block')
+    expect(verifyCsrfOrigin({ method: 'POST', appUrl, referer: 'https://evil.com/phish' })).toBe(
+      'block',
+    )
   })
 
   test('POST with malformed referer is blocked', () => {
-    expect(verifyCsrfOrigin({
-      method: 'POST',
-      appUrl,
-      referer: 'not-a-valid-url',
-    })).toBe('block')
+    expect(verifyCsrfOrigin({ method: 'POST', appUrl, referer: 'not-a-valid-url' })).toBe('block')
   })
 
   test('PUT, PATCH, DELETE are also checked (not just POST)', () => {
     for (const method of ['PUT', 'PATCH', 'DELETE']) {
-      expect(verifyCsrfOrigin({
-        method,
-        appUrl,
-        origin: 'https://evil.com',
-      })).toBe('block')
-
-      expect(verifyCsrfOrigin({
-        method,
-        appUrl,
-        origin: 'https://crm.billie.loans',
-      })).toBe('allow')
+      expect(verifyCsrfOrigin({ method, appUrl, origin: 'https://evil.com' })).toBe('block')
+      expect(verifyCsrfOrigin({ method, appUrl, origin: 'https://crm.billie.loans' })).toBe('allow')
     }
   })
 
-  test('no appUrl configured = always allow (cannot verify)', () => {
-    expect(verifyCsrfOrigin({
-      method: 'POST',
-      appUrl: undefined,
-      origin: 'https://evil.com',
-    })).toBe('allow')
+  test('no appUrl configured is blocked (fail closed — cannot verify)', () => {
+    expect(
+      verifyCsrfOrigin({ method: 'POST', appUrl: undefined, origin: 'https://evil.com' }),
+    ).toBe('block')
   })
 
   test('origin matches even if appUrl has a path', () => {
-    expect(verifyCsrfOrigin({
-      method: 'POST',
-      appUrl: 'https://crm.billie.loans/admin',
-      origin: 'https://crm.billie.loans',
-    })).toBe('allow')
+    expect(
+      verifyCsrfOrigin({
+        method: 'POST',
+        appUrl: 'https://crm.billie.loans/admin',
+        origin: 'https://crm.billie.loans',
+      }),
+    ).toBe('allow')
+  })
+})
+
+describe('CSRF exemption for the public API surface', () => {
+  const appUrl = 'https://crm.billie.loans'
+
+  test('inbound webhooks are exempt (no Origin/Referer — server-to-server)', () => {
+    expect(isCsrfExemptPath('/api/webhooks/clicksend')).toBe(true)
+    // …so the gate lets them through even with no origin (which verifyCsrfOrigin blocks).
+    expect(csrfGate({ pathname: '/api/webhooks/clicksend', method: 'POST', appUrl })).toBe('allow')
+  })
+
+  test('public intake forms are exempt (cross-origin marketing site)', () => {
+    expect(isCsrfExemptPath('/api/intake/waitlist')).toBe(true)
+    expect(isCsrfExemptPath('/api/intake/feedback')).toBe(true)
+    // Exempt even with a mismatched origin — auth is API-key + HMAC in-route.
+    expect(
+      csrfGate({
+        pathname: '/api/intake/feedback',
+        method: 'POST',
+        appUrl,
+        origin: 'https://billie.loans',
+      }),
+    ).toBe('allow')
+  })
+
+  test('non-exempt routes are still CSRF-checked (no free pass)', () => {
+    expect(isCsrfExemptPath('/api/marketing/contacts')).toBe(false)
+    expect(isCsrfExemptPath('/admin/accounts')).toBe(false)
+    // A cookie-authed route with no origin is blocked as before.
+    expect(csrfGate({ pathname: '/api/marketing/contacts', method: 'POST', appUrl })).toBe('block')
+    expect(
+      csrfGate({
+        pathname: '/api/marketing/contacts',
+        method: 'POST',
+        appUrl,
+        origin: 'https://evil.com',
+      }),
+    ).toBe('block')
+  })
+
+  test('a lookalike prefix is NOT exempt (exact segment boundary)', () => {
+    expect(isCsrfExemptPath('/api/intake-notes')).toBe(false)
+    expect(isCsrfExemptPath('/api/webhooksX/y')).toBe(false)
   })
 })


### PR DESCRIPTION
**Bug:** the CSRF origin guard in `src/proxy.ts` blocks *every* mutation (POST/PUT/PATCH/DELETE) that lacks a matching `Origin`/`Referer` — including the **secret-authenticated public API surface**: `/api/webhooks/clicksend` (inbound webhooks) and `/api/intake/waitlist` + `/api/intake/feedback` (marketing-site forms). Those authenticate by shared secret / API-key+HMAC, carry **no session cookie**, and are cross-origin/server-to-server by design, so CSRF doesn't apply and external callers (ClickSend, the marketing site) can't send a matching Origin. Result: `403 CSRF_REJECTED` on the ClickSend webhook (found while wiring B1 to demo).

**Fix:** exempt the `/api/intake/` and `/api/webhooks/` prefixes from the CSRF check. Everything else stays fail-closed.

**Also:** realigns `tests/unit/security/csrf-origin.test.ts` with the real `proxy.ts` — its mirrored logic was **stale** (asserted no-Origin and no-appUrl *pass*, but the real code fails closed and *blocks* both), which is exactly why this gap wasn't caught. Now mirrors current behaviour + covers the exemption and prefix boundaries. **14/14**, typecheck + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)