### PR TITLE
docs(marketing): incorporate design sign-off decisions (7 Jul 2026)

### DIFF
--- a/docs/superpowers/plans/2026-07-03-marketing-crm-phase2-sends.md
+++ b/docs/superpowers/plans/2026-07-03-marketing-crm-phase2-sends.md
@@ -128,8 +128,8 @@
 1. billieChat routes (A8) → 2. platform-services (A1–A7) → 3. billie-crm (B1–B6). Then C1 cutover. Rationale: routes + emitters must exist before the CRM relies on them, same as the intake-via-broker rollout.
 
 ## Not in this plan (explicit)
-- **Stream B — customer-state projection** in customerService (`customer.customer_state`, `customer.state.changed.v1`, derived Billie stage, §3/§4). Independent; can run in parallel or slip to Phase 3. **Blocked on Flagged Decision #1** (OTP-pass event vs A3 inference — billieChat owner).
-- **Phase 3** — WhatsApp provider + webhook; full DSR (XDEL sweep + subject-access export); backup restore test; `SETTLED_SHORT` SDK addition.
+- **Stream B — customer-state projection** in customerService (`customer.customer_state`, `customer.state.changed.v1`, derived Billie stage, §3/§4). Independent; can run in parallel or slip to Phase 3. **Blocked on Flagged Decision #1** (OTP-pass event vs A3 inference — billieChat owner). **Sign-off (7 Jul 2026):** the workstream itself is in discussion (A4); when built, `ADMIN_CLOSED` maps to **C-P (win-back-eligible) + review flag**, not C-N (B2 change — design spec §3).
+- **Phase 3** — WhatsApp provider + webhook (timing in discussion, B1); full DSR (XDEL sweep + subject-access export); backup restore test; `SETTLED_SHORT` SDK addition (settled-short → C-N at source; `ADMIN_CLOSED` stays win-back-eligible per B2).
 
 ## Flagged decisions / external dependencies
 - **#3 (web owner):** `billie.loans/r/{code}` → form `ref` param — A4 attribution works once `ref` arrives; confirm the website route.

--- a/docs/superpowers/specs/2026-07-02-marketing-crm-customer-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-02-marketing-crm-customer-lifecycle-design.md
@@ -143,6 +143,8 @@ Auth: internal network (Fly private networking), same posture as the accounting-
 
 ## 3. Customer state projection (new module in `customerService`)
 
+> **Open at sign-off (A4, discuss):** this added workstream — the governed Customer State Model driving stage and loan status — is under discussion; scope and sequencing may change. Per §10, it can slip to phase 3 without blocking the rest of phase 2.
+
 Implements the governed A × B\* × C × L tuple as a derived projection — platform-owned, exactly per the state model's D14 (C and L are projections over agreement records) and R4 (events move states; treatments read states).
 
 Persists `customer.customer_state` (canonical_id, `a_level`, `b_star`, `c_history`, `live`, current_application_ref, cause_event_id, updated_at); emits **`customer.state.changed.v1`** (added to the `customers` SDK package) carrying the full tuple + cause.
@@ -151,7 +153,7 @@ Persists `customer.customer_state` (canonical_id, `a_level`, `b_star`, `c_histor
 |---|---|---|
 | A (sticky, rises only) | `customer.changed.v1` → A2; OTP signal → A3; `customer.verified.v1` / IDV result → A4 | **Gap (flagged decision):** no explicit OTP-pass event exists today. Either billieChat emits one (preferred; small addition) or A3 is inferred from fields on `customer.changed.v1`. Resolve during phase-2 planning with the billieChat owner. |
 | B\* (per-application, mortal) | `applicationDetail_changed` → B0; `final_credit_decision` → B1/B2; `loan_agreement_accepted` → B3; `account.disbursed.v1` → B4 then concludes to B– (L carries on) | **Bx (exit)**: no abandonment event exists; a platform-side timeout sweep marks applications inactive for N days as Bx (N configurable, default 30). Terminal stages (B2, Bx) never persist as B\* (per D9a). |
-| C (sticky) + L | `account.created.v1`/`account.disbursed.v1` → L=true; `account.closed.v1` closure_reason: `PAID_OFF` → C-P; `WRITTEN_OFF` → C-N (dominant, sticky); `ADMIN_CLOSED` → C-N by default (settled-short semantics) | The accounts SDK lacks a `SETTLED_SHORT` closure reason; `ADMIN_CLOSED`→C-N is the conservative default mapping, configurable. Adding `SETTLED_SHORT` to the SDK is noted as future work. |
+| C (sticky) + L | `account.created.v1`/`account.disbursed.v1` → L=true; `account.closed.v1` closure_reason: `PAID_OFF` → C-P; `WRITTEN_OFF` → C-N (dominant, sticky); `ADMIN_CLOSED` → **C-P by default (win-back-eligible), surfaced for review** | **Changed at sign-off (B2, 7 Jul 2026):** admin closures must not default to negative — C-N would silently drop genuine former customers out of the win-back segment. Settled-short accounts are the exception, not the rule; they get C-N properly at source once the accounts SDK gains a `SETTLED_SHORT` closure reason (phase 3). Until then, every `ADMIN_CLOSED` mapping raises a review metric/flag so credit can reclassify individual accounts. |
 
 **Testing gift from the state model:** the projection ships with a property test asserting it can only ever emit tuples inside the 28 feasible cells (invariants I1–I5 from §5A of the model), and a metric/alert when a ◉ control-failure cell (concurrent applicant, returning non-performed applicant, etc.) is observed — those cells are representable by design and their observation is a control signal.
 
@@ -171,6 +173,8 @@ The stage on a contact is **derived, never hand-edited** — computed by marketi
 | 6 | Lead | contact observed |
 
 **Advocate is a flag overlay, not a stage** (per D16: type tests are attributes): `advocate = true` when ≥1 attributed referral reached Customer. The CRM grid can still filter/present it as a pseudo-stage.
+
+> **Open at sign-off (A2, discuss):** whether staff get a manual stage override or an "Other / needs review" stage, so we're never locked out of reclassifying as new situations emerge. Derivation-only stands until that discussion lands; if an override is approved it will be an explicit, audited command (an attribute overlay the derivation respects), never a hand-edit of the derived field. Note the general `attributes` field already absorbs unexpected campaign data — the gap is specifically stage correction.
 
 Loan-status mirror (minimal, per brief §3): `approved` (B1) / `disbursed` (B4 or L) / `repaid` (C-P ∧ ¬L). No amounts — structurally impossible (§2.2).
 
@@ -302,7 +306,7 @@ Customer-state projection in customerService + `customer.state.changed.v1` + lif
 *Note: the state projection and the notification work are independent streams — run in parallel if team capacity allows; otherwise state projection may slip to phase 3 without blocking anything else in phase 2.*
 
 **Phase 3 — Harden and complete:**
-WhatsApp provider client + webhook; DSR tooling complete (erase incl. XDEL sweep + subject-access export); one-click CSV exports; audit hardening review; backup restore test for `marketing.*`; `SETTLED_SHORT` SDK addition (with `ADMIN_CLOSED` mapping revisit).
+WhatsApp provider client + webhook; DSR tooling complete (erase incl. XDEL sweep + subject-access export); one-click CSV exports; audit hardening review; backup restore test for `marketing.*`; `SETTLED_SHORT` SDK addition so settled-short closures map to C-N at source (`ADMIN_CLOSED` itself stays win-back-eligible per the B2 sign-off change, §3).
 
 ---
 
@@ -327,10 +331,26 @@ WhatsApp provider client + webhook; DSR tooling complete (erase incl. XDEL sweep
 
 ## 13. Flagged decisions (owners, defaults)
 
-| # | Decision | Default in this spec | Owner to confirm |
-|---|---|---|---|
-| 1 | OTP-pass event from billieChat vs A3 inference | billieChat emits explicit event | billieChat owner, phase-2 planning |
-| 2 | WhatsApp before or after cutover | after (phase 3), SMS-first cutover | marketing/product |
-| 3 | Referral URL resolution on website | `/r/{code}` redirect → form `ref` param | web owner |
-| 4 | `ADMIN_CLOSED` → C-N mapping | conservative C-N until `SETTLED_SHORT` exists | product/credit, phase 3 |
-| 5 | Bx timeout window | 30 days inactivity | product |
+| # | Decision | Default in this spec | Owner to confirm | Status (sign-off, 7 Jul 2026) |
+|---|---|---|---|---|
+| 1 | OTP-pass event from billieChat vs A3 inference | billieChat emits explicit event | billieChat owner, phase-2 planning | open — awareness item (Part C), billieChat owner to confirm |
+| 2 | WhatsApp before or after cutover | after (phase 3), SMS-first cutover | marketing/product | in discussion (B1) — default stands until resolved |
+| 3 | Referral URL resolution on website | `/r/{code}` redirect → form `ref` param | web owner | open — awareness item (Part C), web owner to confirm |
+| 4 | `ADMIN_CLOSED` mapping | ~~conservative C-N~~ → **C-P (win-back-eligible) + review flag** | product/credit, phase 3 | **changed (B2)** — incorporated in §3; `SETTLED_SHORT` at source remains phase 3 |
+| 5 | Bx timeout window | 30 days inactivity | product | **approved as default (B3)** |
+| 6 | Manual stage override / "Other — needs review" stage | none — stage strictly derived (§4) | product + design | in discussion (A2) |
+| 7 | Customer State Model + state-projection workstream | new module in customerService (§3) | product/platform | in discussion (A4) |
+
+## 14. Sign-off record (7 July 2026)
+
+Design sign-off sheet reviewed against the build brief; decisions returned by Nichola Patterson:
+
+| Item | Outcome |
+|---|---|
+| A1 — marketingService masters the data; Payload is read-only view + command screens | **Approved** |
+| A2 — stage derived, never hand-edited (override / "needs review" stage proposed) | **Discuss** — recorded in §4 and decision #6; derivation-only stands meanwhile |
+| A3 — no Apps Script integration; all sends via platform notificationService; cutover + backfill | **Approved** |
+| A4 — Customer State Model + state-projection workstream | **Discuss** — recorded in §3 and decision #7 |
+| B1 — WhatsApp after cutover (phase 3) | **Discuss** — decision #2; default stands until resolved |
+| B2 — admin-closed loans treated as written-off/negative | **Changed** — now C-P (win-back-eligible) + review flag; §3, decision #4 |
+| B3 — abandoned application dead after 30 days | **Approved as default** — decision #5 |


### PR DESCRIPTION
## Summary

Incorporates the returned design sign-off sheet (Nichola Patterson, 7 Jul 2026) into the marketing CRM design spec and phase-2 plan.

### The one design change (B2)
**Admin-closed loans no longer default to written-off/negative.** `ADMIN_CLOSED` now maps to **C-P (win-back-eligible) + a review flag** instead of C-N — auto-negative could silently drop genuine former customers out of the win-back segment. Genuinely settled-short closures get C-N *at source* once the accounts SDK gains `SETTLED_SHORT` (phase 3). This lands in spec §3 (state-projection mapping), §10 (phase 3), §13 (decision #4), and the phase-2 plan's Stream B note — so Stream B is built to the corrected mapping.

### Recorded outcomes
| Item | Outcome |
|---|---|
| A1 — marketingService masters; Payload read-only + commands | Approved |
| A2 — manual stage override / "needs review" stage | Discuss (open — spec §4, decision #6) |
| A3 — no Apps Script; platform sends; cutover + backfill | Approved |
| A4 — state-projection workstream | Discuss (open — spec §3, decision #7) |
| B1 — WhatsApp timing | Discuss (default stands — decision #2) |
| B2 — admin-closed loans | **Changed** (see above) |
| B3 — 30-day abandonment | Approved as default |

Also adds a §14 sign-off record and a Status column on the flagged-decisions table.

Docs-only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi