### PR TITLE
feat(marketing): batch creation + trigger-invitations UI (spec §5.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ event-processor/src/billie_servicing/handlers/__pycache__
 event-processor/.venv/*
 
 .superpowers/
+.playwright-mcp/

--- a/src/components/MarketingView/MarketingView.tsx
+++ b/src/components/MarketingView/MarketingView.tsx
@@ -6,12 +6,13 @@ import { useRouter } from 'next/navigation'
 import { useMarketingContacts } from '@/hooks/queries/useMarketingContacts'
 import type { MarketingContactsFilters } from '@/hooks/queries/useMarketingContacts'
 import { useBatches } from '@/hooks/queries/useBatches'
-import { useAssignBatch } from '@/hooks/mutations/useMarketingCommands'
+import { useAssignBatch, useTriggerInvitations } from '@/hooks/mutations/useMarketingCommands'
 import type { Contact } from '@/payload-types'
 import { formatDateShort } from '@/lib/formatters'
 import { getMarketingConsentGranted } from '@/lib/marketing'
 import { ContactDetail } from './ContactDetail'
 import { FeedbackQueueView } from './FeedbackQueueView'
+import { NewBatchModal } from './NewBatchModal'
 import { NewContactModal } from './NewContactModal'
 import styles from './styles.module.css'
 
@@ -43,6 +44,14 @@ const SOURCE_OPTIONS: Array<{ value: Contact['source'] & string; label: string }
 // Free-text on the backend (a `like` filter) — this is a curated shortlist of
 // the cities marketing campaigns currently target, not an exhaustive enum.
 const CITY_OPTIONS = ['Sydney', 'Melbourne', 'Brisbane', 'Perth', 'Adelaide', 'Canberra']
+
+// Sentinel value for the assign dropdown's "＋ New batch…" option — never a
+// real batchId (batch ids are UUIDs minted by marketingService).
+const NEW_BATCH_SENTINEL = '__new_batch__'
+
+// Bounds for the post-create projection poll (see handleBatchCreated).
+const BATCH_POLL_MAX_ATTEMPTS = 8
+const BATCH_POLL_INTERVAL_MS = 1500
 
 function stageLabel(stage: Contact['derivedStage']): string {
   return STAGE_OPTIONS.find((o) => o.value === stage)?.label ?? stage ?? '—'
@@ -91,6 +100,8 @@ const MarketingContactsGrid: React.FC = () => {
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [assignTarget, setAssignTarget] = useState('')
   const [showNewContact, setShowNewContact] = useState(false)
+  const [showNewBatch, setShowNewBatch] = useState(false)
+  const [showInviteConfirm, setShowInviteConfirm] = useState(false)
 
   const filters = useMemo<MarketingContactsFilters>(
     () => ({
@@ -105,8 +116,9 @@ const MarketingContactsGrid: React.FC = () => {
   )
 
   const { data, isLoading, isError } = useMarketingContacts(filters)
-  const { data: batchesData } = useBatches()
+  const { data: batchesData, refetch: refetchBatches } = useBatches()
   const assign = useAssignBatch()
+  const invite = useTriggerInvitations()
   const docs = data?.docs ?? []
   const batchOptions = batchesData?.docs ?? []
   const batchNameFor = (id?: string | null) =>
@@ -150,6 +162,50 @@ const MarketingContactsGrid: React.FC = () => {
         },
       },
     )
+  }
+
+  const handleAssignTargetChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value === NEW_BATCH_SENTINEL) {
+      setShowNewBatch(true)
+      return // leave the current target untouched while the modal is open
+    }
+    setAssignTarget(e.target.value)
+  }
+
+  // The batch projection lags the CreateBatch 202 (command → event → projection).
+  // Poll the batches list until the new id appears, then pre-select it as the
+  // assign target so "New batch… → Assign" is a single flow. Bounded: on
+  // timeout the batch still lands via the list's regular 30s refetch — the
+  // pre-selection is just skipped.
+  const handleBatchCreated = async (batchId: string) => {
+    setShowNewBatch(false)
+    for (let attempt = 0; attempt < BATCH_POLL_MAX_ATTEMPTS; attempt++) {
+      const res = await refetchBatches()
+      if (res.data?.docs?.some((b) => b.batchId === batchId)) {
+        setAssignTarget(batchId)
+        return
+      }
+      await new Promise((resolve) => setTimeout(resolve, BATCH_POLL_INTERVAL_MS))
+    }
+  }
+
+  // Segment snapshot for a new batch: the grid's active filters, verbatim.
+  const criteriaSnapshot = useMemo(() => {
+    const snapshot: Record<string, string> = {}
+    if (q) snapshot.q = q
+    if (stage) snapshot.stage = stage
+    if (source) snapshot.source = source
+    if (city) snapshot.city = city
+    if (batch) snapshot.batch = batch
+    return snapshot
+  }, [q, stage, source, city, batch])
+
+  // Invitations fire for the batch chosen in the Batch FILTER — filter to the
+  // batch (seeing exactly its members), then send.
+  const canInvite = !!batch && !invite.isPending
+  const handleInviteConfirm = () => {
+    if (!canInvite) return
+    invite.mutate(batch, { onSettled: () => setShowInviteConfirm(false) })
   }
 
   const contactHref = (contact: Contact) => `/admin/marketing/contacts/${contact.contactId}`
@@ -254,7 +310,8 @@ const MarketingContactsGrid: React.FC = () => {
       </div>
 
       {/* Assign-to-batch bar — always present (fixed layout); controls disable
-          until a selection + target batch exist. */}
+          until a selection + target batch exist. Invitations live on the right:
+          they fire for the batch chosen in the Batch filter above. */}
       <div className={styles.filters}>
         <span className={styles.pageStatus}>{selected.size} selected</span>
         <div className={styles.filterGroup}>
@@ -265,7 +322,7 @@ const MarketingContactsGrid: React.FC = () => {
             id="marketing-assign-batch"
             className={styles.filterSelect}
             value={assignTarget}
-            onChange={(e) => setAssignTarget(e.target.value)}
+            onChange={handleAssignTargetChange}
             disabled={selected.size === 0}
           >
             <option value="">Choose a batch…</option>
@@ -274,6 +331,7 @@ const MarketingContactsGrid: React.FC = () => {
                 {b.name ?? b.batchId}
               </option>
             ))}
+            <option value={NEW_BATCH_SENTINEL}>＋ New batch…</option>
           </select>
         </div>
         <button
@@ -283,6 +341,18 @@ const MarketingContactsGrid: React.FC = () => {
           disabled={!canAssign}
         >
           {assign.isPending ? 'Assigning…' : 'Assign'}
+        </button>
+        <div className={styles.spacer} />
+        <span className={styles.pageStatus}>
+          Invitations: {batch ? batchNameFor(batch) : 'choose a batch in the filter'}
+        </span>
+        <button
+          type="button"
+          className={styles.pageButton}
+          onClick={() => setShowInviteConfirm(true)}
+          disabled={!canInvite}
+        >
+          {invite.isPending ? 'Sending…' : 'Send invitations'}
         </button>
       </div>
 
@@ -399,6 +469,59 @@ const MarketingContactsGrid: React.FC = () => {
           onClose={() => setShowNewContact(false)}
           onSuccess={() => setShowNewContact(false)}
         />
+      )}
+
+      {showNewBatch && (
+        <NewBatchModal
+          criteria={criteriaSnapshot}
+          onClose={() => setShowNewBatch(false)}
+          onSuccess={handleBatchCreated}
+        />
+      )}
+
+      {showInviteConfirm && (
+        <div className={styles.modalOverlay} onClick={() => setShowInviteConfirm(false)}>
+          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <h2 className={styles.modalTitle}>Send invitations</h2>
+              <button
+                type="button"
+                className={styles.closeBtn}
+                onClick={() => setShowInviteConfirm(false)}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+            <div className={styles.modalBody}>
+              <p>
+                Send invitations to all consented members of <strong>{batchNameFor(batch)}</strong>?
+              </p>
+              <p className={styles.formHint}>
+                Members without marketing consent are skipped automatically. Repeating the send for
+                this batch is deduplicated platform-side, so a double-click can&apos;t fan out a
+                second wave.
+              </p>
+            </div>
+            <div className={styles.modalFooter}>
+              <button
+                type="button"
+                className={styles.btnCancel}
+                onClick={() => setShowInviteConfirm(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={styles.btnSubmit}
+                onClick={handleInviteConfirm}
+                disabled={!canInvite}
+              >
+                {invite.isPending ? 'Sending…' : 'Send invitations'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/src/components/MarketingView/NewBatchModal.tsx
+++ b/src/components/MarketingView/NewBatchModal.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useCreateBatch } from '@/hooks/mutations/useMarketingCommands'
+import styles from './styles.module.css'
+
+interface NewBatchModalProps {
+  /**
+   * Segment snapshot the batch is being built from — the grid's active
+   * filters. Stored verbatim as the batch's `criteria` so the batch records
+   * what defined its membership at creation time.
+   */
+  criteria: Record<string, string>
+  onClose: () => void
+  onSuccess: (batchId: string) => void
+}
+
+/**
+ * Staff-initiated batch creation (spec §5.4). Posts to
+ * MarketingService.CreateBatch via /api/marketing/batches — the batch is
+ * created in the marketing system of record and projects back into the batch
+ * pickers. Reached from the assign bar's "＋ New batch…" option, so on success
+ * the caller pre-selects the new batch as the assign target.
+ */
+export const NewBatchModal: React.FC<NewBatchModalProps> = ({ criteria, onClose, onSuccess }) => {
+  const [name, setName] = useState('')
+
+  const create = useCreateBatch()
+  const canSubmit = !!name.trim() && !create.isPending
+  const criteriaEntries = Object.entries(criteria)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    create.mutate({ name: name.trim(), criteria }, { onSuccess: (res) => onSuccess(res.batchId) })
+  }
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h2 className={styles.modalTitle}>New batch</h2>
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className={styles.modalBody}>
+            {create.isError && (
+              <div className={styles.errorMessage}>
+                {create.error instanceof Error ? create.error.message : 'Failed to create batch'}
+              </div>
+            )}
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="new-batch-name">
+                Batch name
+              </label>
+              <input
+                id="new-batch-name"
+                type="text"
+                className={styles.formInput}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Campus wave 2"
+              />
+            </div>
+
+            <div className={styles.formGroup}>
+              <span className={styles.formLabel}>Criteria snapshot</span>
+              {criteriaEntries.length === 0 ? (
+                <p className={styles.formHint}>None — no grid filters are active.</p>
+              ) : (
+                <ul className={styles.criteriaList}>
+                  {criteriaEntries.map(([key, value]) => (
+                    <li key={key} className={styles.formHint}>
+                      {key}: {value}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+
+          <div className={styles.modalFooter}>
+            <button type="button" className={styles.btnCancel} onClick={onClose}>
+              Cancel
+            </button>
+            <button type="submit" className={styles.btnSubmit} disabled={!canSubmit}>
+              {create.isPending ? 'Creating…' : 'Create batch'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default NewBatchModal

--- a/src/components/MarketingView/styles.module.css
+++ b/src/components/MarketingView/styles.module.css
@@ -416,6 +416,17 @@
   white-space: nowrap;
 }
 
+/* Pushes the invitations controls to the right edge of the assign bar. */
+.spacer {
+  margin-left: auto;
+}
+
+/* Criteria snapshot list in the new-batch modal. */
+.criteriaList {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
 /* --- New-contact modal (mirrors the LoanAccountServicing modal styles) --- */
 .modalOverlay {
   position: fixed;

--- a/src/hooks/mutations/useMarketingCommands.ts
+++ b/src/hooks/mutations/useMarketingCommands.ts
@@ -33,7 +33,8 @@ export interface CreateBatchVars {
 export function useCreateBatch() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (vars: CreateBatchVars) => postCommand('/api/marketing/batches', vars),
+    mutationFn: (vars: CreateBatchVars) =>
+      postCommand<{ batchId: string; eventId: string }>('/api/marketing/batches', vars),
     onSuccess: () => {
       toast.success('Batch created')
       qc.invalidateQueries({ queryKey: ['marketing-batches'] })

--- a/tests/unit/components/NewBatchModal.test.tsx
+++ b/tests/unit/components/NewBatchModal.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { NewBatchModal } from '@/components/MarketingView/NewBatchModal'
+
+// Mock sonner
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient()
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+beforeEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ batchId: 'batch-123', eventId: 'evt-1' }),
+  })) as unknown as typeof fetch
+})
+
+describe('NewBatchModal', () => {
+  it('disables Create until a name is entered', () => {
+    renderWithProviders(<NewBatchModal criteria={{}} onClose={vi.fn()} onSuccess={vi.fn()} />)
+    const submit = screen.getByRole('button', { name: 'Create batch' })
+    expect(submit).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Batch name'), { target: { value: 'Campus wave 2' } })
+    expect(submit).not.toBeDisabled()
+  })
+
+  it('shows the criteria snapshot entries, or a none-hint when empty', () => {
+    const { unmount } = renderWithProviders(
+      <NewBatchModal
+        criteria={{ source: 'campus', city: 'Sydney' }}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('source: campus')).toBeInTheDocument()
+    expect(screen.getByText('city: Sydney')).toBeInTheDocument()
+    unmount()
+
+    renderWithProviders(<NewBatchModal criteria={{}} onClose={vi.fn()} onSuccess={vi.fn()} />)
+    expect(screen.getByText('None — no grid filters are active.')).toBeInTheDocument()
+  })
+
+  it('POSTs name + criteria and hands the new batchId to onSuccess', async () => {
+    const onSuccess = vi.fn()
+    renderWithProviders(
+      <NewBatchModal criteria={{ source: 'campus' }} onClose={vi.fn()} onSuccess={onSuccess} />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Batch name'), { target: { value: 'Campus wave 2' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create batch' }))
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith('batch-123'))
+
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toBe('/api/marketing/batches')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({
+      name: 'Campus wave 2',
+      criteria: { source: 'campus' },
+    })
+  })
+
+  it('surfaces the API error message and does not call onSuccess', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        error: { code: 'COMMAND_FAILED', message: 'Creating the batch failed. Please retry.' },
+      }),
+    })) as unknown as typeof fetch
+
+    const onSuccess = vi.fn()
+    renderWithProviders(<NewBatchModal criteria={{}} onClose={vi.fn()} onSuccess={onSuccess} />)
+
+    fireEvent.change(screen.getByLabelText('Batch name'), { target: { value: 'Doomed' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create batch' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Creating the batch failed. Please retry.')).toBeInTheDocument(),
+    )
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Completes the B6 batch surface. `useCreateBatch` and `useTriggerInvitations` existed since PR #44 but had no UI — flagged during the #46 demo QA.

### New batch (create)
- The assign dropdown gains a **＋ New batch…** option → opens `NewBatchModal`: batch name + a read-only **criteria snapshot of the grid's active filters** (q/stage/source/city/batch), stored verbatim as the batch's segment criteria — per the route doc, "the criteria object is the segment snapshot the batch was built from".
- After the 202, the grid polls the batches projection (bounded 8 × 1.5s, command → poll projection per the write-off precedent) until the new id appears, then **pre-selects it as the assign target** — "New batch… → Assign" is one flow. On timeout the batch still arrives via the list's 30s refetch.

### Send invitations (trigger)
- Right side of the assign bar, always present (fixed layout), disabled until the **Batch filter** selects a batch — filter to the batch (seeing exactly its members), then send.
- Confirm modal before sending: consented members only; a repeat send is deduplicated platform-side (stable `invite:{batchId}` idempotency key).

### Flow
```
[3 selected] [Assign to batch ▾        ] [Assign]      Invitations: Campus wave 2 [Send invitations]
              ├ Choose a batch…
              ├ Campus wave 2
              └ ＋ New batch…  ──► modal: name + criteria snapshot ──► created ──► auto-selected
```

## Tests
- `NewBatchModal` component tests: submit gating, criteria snapshot render, POST shape + `onSuccess(batchId)`, API error surfacing — 4/4 ✓ (follows the ClearBlockModal conventions)
- Hook tests unchanged and green (9/9 across both files); eslint 0/0, prettier clean, tsc clean on touched files

## Notes
- End-to-end create currently blocked by the **platform `CreateBatch` 503** found in demo QA — the modal surfaces the error; once the platform fix lands this works without changes here.
- Also gitignores `.playwright-mcp/` (browser-QA artefacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi