### PR TITLE
feat(marketing): feedback queue shows contact names + peek modal

### DIFF
--- a/src/app/api/marketing/feedback/route.ts
+++ b/src/app/api/marketing/feedback/route.ts
@@ -3,6 +3,11 @@
  *
  * Lists the feedback queue from the read-only `feedback` projection, filterable
  * by `status` and `product_area`. Gated on `canReadMarketing`.
+ *
+ * The projection stores only `contactIdString`; the queue UI wants a human
+ * name, so each page is enriched with `contactName` via one batched contacts
+ * lookup (no N+1). A missing contact leaves `contactName: null` — the UI
+ * falls back to a shortened id.
  */
 
 import { NextRequest, NextResponse } from 'next/server'
@@ -30,5 +35,28 @@ export async function GET(request: NextRequest) {
     user,
   })
 
-  return NextResponse.json(result)
+  const contactIds = Array.from(
+    new Set(result.docs.map((d) => d.contactIdString).filter((v): v is string => !!v)),
+  )
+  const nameByContactId = new Map<string, string | null>()
+  if (contactIds.length > 0) {
+    const contacts = await payload.find({
+      collection: 'contacts',
+      where: { contactId: { in: contactIds } } as never,
+      limit: contactIds.length,
+      overrideAccess: false,
+      user,
+    })
+    for (const c of contacts.docs) {
+      if (c.contactId) nameByContactId.set(c.contactId, c.firstName ?? null)
+    }
+  }
+
+  return NextResponse.json({
+    ...result,
+    docs: result.docs.map((d) => ({
+      ...d,
+      contactName: d.contactIdString ? (nameByContactId.get(d.contactIdString) ?? null) : null,
+    })),
+  })
 }

--- a/src/components/MarketingView/ContactPeekModal.tsx
+++ b/src/components/MarketingView/ContactPeekModal.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { useMarketingContact } from '@/hooks/queries/useMarketingContact'
+import { formatDateMedium } from '@/lib/formatters'
+import { getMarketingConsentGranted } from '@/lib/marketing'
+import styles from './styles.module.css'
+
+interface ContactPeekModalProps {
+  contactId: string
+  onClose: () => void
+}
+
+const STAGE_LABELS: Record<string, string> = {
+  lead: 'Lead',
+  waitlist: 'Waitlist',
+  invited: 'Invited',
+  applicant: 'Applicant',
+  customer: 'Customer',
+  former_customer: 'Former customer',
+}
+
+/**
+ * Compact contact card opened from the feedback queue's Contact column —
+ * enough context to triage without leaving the queue (and losing your place),
+ * with a link out to the full profile. Fixed-layout rows: every field is
+ * always present, empty values render as an em dash.
+ */
+export const ContactPeekModal: React.FC<ContactPeekModalProps> = ({ contactId, onClose }) => {
+  const { data, isLoading, isError } = useMarketingContact(contactId)
+  const contact = data?.contact
+
+  const consentGranted = contact ? getMarketingConsentGranted(contact.consent) : null
+  const consentLabel =
+    consentGranted === true ? 'Granted' : consentGranted === false ? 'Declined' : '—'
+
+  const rows: Array<{ label: string; value: React.ReactNode }> = [
+    { label: 'Mobile', value: contact?.mobileE164 ?? '—' },
+    { label: 'Email', value: contact?.email ?? '—' },
+    {
+      label: 'Stage',
+      value: contact?.derivedStage ? (
+        <span className={styles.badge}>
+          {STAGE_LABELS[contact.derivedStage] ?? contact.derivedStage}
+        </span>
+      ) : (
+        '—'
+      ),
+    },
+    { label: 'Source', value: contact?.source ?? '—' },
+    { label: 'City', value: contact?.city ?? '—' },
+    { label: 'Consent', value: consentLabel },
+    { label: 'Customer', value: contact?.customerId ? 'Linked' : 'Not linked' },
+    { label: 'Referral code', value: contact?.referralCode ?? '—' },
+    { label: 'Updated', value: contact?.updatedAt ? formatDateMedium(contact.updatedAt) : '—' },
+  ]
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h2 className={styles.modalTitle}>
+            {isLoading ? 'Loading contact…' : (contact?.firstName ?? 'Unnamed contact')}
+          </h2>
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <div className={styles.modalBody}>
+          {isError ? (
+            <div className={styles.errorMessage}>Failed to load the contact. Please retry.</div>
+          ) : (
+            <div className={styles.panelBody}>
+              {rows.map((row) => (
+                <div key={row.label} className={styles.panelRow}>
+                  <span className={styles.panelRowLabel}>{row.label}</span>
+                  <span className={styles.panelRowValue}>{row.value}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className={styles.modalFooter}>
+          <Link
+            href={`/admin/marketing/contacts/${encodeURIComponent(contactId)}`}
+            className={styles.btnSubmit}
+          >
+            Open full profile →
+          </Link>
+          <button type="button" className={styles.btnCancel} onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ContactPeekModal

--- a/src/components/MarketingView/FeedbackQueueView.tsx
+++ b/src/components/MarketingView/FeedbackQueueView.tsx
@@ -6,6 +6,7 @@ import { useFeedbackQueue } from '@/hooks/queries/useFeedbackQueue'
 import { useSetFeedbackStatus } from '@/hooks/mutations/useMarketingCommands'
 import type { Feedback } from '@/payload-types'
 import { formatDateShort } from '@/lib/formatters'
+import { ContactPeekModal } from './ContactPeekModal'
 import styles from './styles.module.css'
 
 const STATUS_OPTIONS = [
@@ -14,6 +15,9 @@ const STATUS_OPTIONS = [
   { value: 'acknowledged', label: 'Acknowledged' },
   { value: 'resolved', label: 'Resolved' },
 ]
+
+/** Fallback label when the contact has no name (or the lookup missed). */
+const shortId = (id: string) => `${id.slice(0, 8)}…`
 
 /**
  * FeedbackQueueView — the marketing feedback triage queue at
@@ -24,6 +28,7 @@ const STATUS_OPTIONS = [
 export const FeedbackQueueView: React.FC = () => {
   const [status, setStatus] = useState('')
   const [page, setPage] = useState(1)
+  const [peekContactId, setPeekContactId] = useState<string | null>(null)
 
   const filters = useMemo(() => ({ status: status || undefined, page }), [status, page])
   const { data, isLoading, isError } = useFeedbackQueue(filters)
@@ -104,12 +109,13 @@ export const FeedbackQueueView: React.FC = () => {
                     <tr key={fb.id} className={styles.row}>
                       <td>
                         {fb.contactIdString ? (
-                          <Link
-                            href={`/admin/marketing/contacts/${fb.contactIdString}`}
-                            className={styles.nameLink}
+                          <button
+                            type="button"
+                            className={styles.linkButton}
+                            onClick={() => setPeekContactId(fb.contactIdString!)}
                           >
-                            {fb.contactIdString}
-                          </Link>
+                            {fb.contactName ?? shortId(fb.contactIdString)}
+                          </button>
                         ) : (
                           '—'
                         )}
@@ -166,6 +172,10 @@ export const FeedbackQueueView: React.FC = () => {
           </>
         )}
       </div>
+
+      {peekContactId && (
+        <ContactPeekModal contactId={peekContactId} onClose={() => setPeekContactId(null)} />
+      )}
     </div>
   )
 }

--- a/src/components/MarketingView/styles.module.css
+++ b/src/components/MarketingView/styles.module.css
@@ -421,6 +421,21 @@
   margin-left: auto;
 }
 
+/* Button that reads as an inline name link (feedback queue contact peek). */
+.linkButton {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--theme-elevation-800, #333);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.linkButton:hover {
+  text-decoration: underline;
+}
+
 /* Criteria snapshot list in the new-batch modal. */
 .criteriaList {
   margin: 0;
@@ -536,6 +551,8 @@
 }
 
 .btnSubmit {
+  display: inline-flex;
+  align-items: center;
   padding: 0.625rem 1.25rem;
   background: #2563eb;
   color: white;
@@ -544,6 +561,7 @@
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
+  text-decoration: none;
 }
 
 .btnSubmit:hover:not(:disabled) {

--- a/src/hooks/queries/useFeedbackQueue.ts
+++ b/src/hooks/queries/useFeedbackQueue.ts
@@ -10,8 +10,11 @@ export interface FeedbackQueueFilters {
   page?: number
 }
 
+/** Feedback row enriched server-side with the contact's name (GET route). */
+export type FeedbackWithContact = Feedback & { contactName?: string | null }
+
 export interface FeedbackQueueResponse {
-  docs: Feedback[]
+  docs: FeedbackWithContact[]
   totalDocs: number
   totalPages: number
   page: number

--- a/tests/unit/components/ContactPeekModal.test.tsx
+++ b/tests/unit/components/ContactPeekModal.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { ContactPeekModal } from '@/components/MarketingView/ContactPeekModal'
+
+const CONTACT_ID = 'a79ae28f-2e9d-4650-b466-b5a00e5abfc5'
+
+const contactResponse = {
+  contact: {
+    contactId: CONTACT_ID,
+    firstName: 'Rohan',
+    mobileE164: '+61403320117',
+    email: 'rohan@example.com',
+    derivedStage: 'lead',
+    source: 'referral',
+    city: null,
+    customerId: null,
+    referralCode: '23CTBW',
+    consent: null,
+    updatedAt: '2026-07-07T11:04:00.000Z',
+  },
+  interactions: [],
+  audit: [],
+}
+
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient()
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+beforeEach(() => {
+  cleanup()
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => contactResponse,
+  })) as unknown as typeof fetch
+})
+
+describe('ContactPeekModal', () => {
+  it('renders the contact facts once loaded, with fixed rows for empty fields', async () => {
+    renderWithProviders(<ContactPeekModal contactId={CONTACT_ID} onClose={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getByText('Rohan')).toBeInTheDocument())
+    expect(screen.getByText('+61403320117')).toBeInTheDocument()
+    expect(screen.getByText('rohan@example.com')).toBeInTheDocument()
+    expect(screen.getByText('Lead')).toBeInTheDocument()
+    expect(screen.getByText('Not linked')).toBeInTheDocument()
+    expect(screen.getByText('23CTBW')).toBeInTheDocument()
+    // Fixed layout: the City row is present with an em-dash value.
+    expect(screen.getByText('City')).toBeInTheDocument()
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    expect(String(fetchMock.mock.calls[0]![0])).toBe(`/api/marketing/contacts/${CONTACT_ID}`)
+  })
+
+  it('links out to the full profile', async () => {
+    renderWithProviders(<ContactPeekModal contactId={CONTACT_ID} onClose={vi.fn()} />)
+    const link = await screen.findByRole('link', { name: 'Open full profile →' })
+    expect(link).toHaveAttribute('href', `/admin/marketing/contacts/${CONTACT_ID}`)
+  })
+
+  it('both close controls (× and footer button) call onClose', async () => {
+    const onClose = vi.fn()
+    renderWithProviders(<ContactPeekModal contactId={CONTACT_ID} onClose={onClose} />)
+    // Two controls share the accessible name "Close": the × and the footer button.
+    const closeButtons = await screen.findAllByRole('button', { name: 'Close' })
+    expect(closeButtons).toHaveLength(2)
+    closeButtons.forEach((btn) => fireEvent.click(btn))
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces a load failure', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => null,
+    })) as unknown as typeof fetch
+
+    renderWithProviders(<ContactPeekModal contactId={CONTACT_ID} onClose={vi.fn()} />)
+    await waitFor(() =>
+      expect(screen.getByText('Failed to load the contact. Please retry.')).toBeInTheDocument(),
+    )
+  })
+})

--- a/tests/unit/components/FeedbackQueueContact.test.tsx
+++ b/tests/unit/components/FeedbackQueueContact.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * FeedbackQueueView — Contact column behavior: shows the enriched contactName
+ * (shortened GUID fallback), and opens the ContactPeekModal instead of
+ * navigating away from the queue.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { FeedbackQueueView } from '@/components/MarketingView/FeedbackQueueView'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const NAMED_ID = 'a79ae28f-2e9d-4650-b466-b5a00e5abfc5'
+const NAMELESS_ID = 'bb12cd34-0000-4000-8000-000000000000'
+
+const feedbackResponse = {
+  docs: [
+    {
+      id: 1,
+      feedbackId: 'f-1',
+      contactIdString: NAMED_ID,
+      contactName: 'Rohan',
+      feedbackType: 'praise',
+      body: 'Great stuff',
+      status: 'new',
+      receivedAt: '2026-07-07T11:21:30.000Z',
+    },
+    {
+      id: 2,
+      feedbackId: 'f-2',
+      contactIdString: NAMELESS_ID,
+      contactName: null,
+      feedbackType: 'bug',
+      body: 'Broken thing',
+      status: 'new',
+      receivedAt: '2026-07-07T11:22:30.000Z',
+    },
+  ],
+  totalDocs: 2,
+  totalPages: 1,
+  page: 1,
+  hasNextPage: false,
+  hasPrevPage: false,
+  limit: 50,
+}
+
+const contactResponse = {
+  contact: { contactId: NAMED_ID, firstName: 'Rohan', updatedAt: null, consent: null },
+  interactions: [],
+  audit: [],
+}
+
+const renderView = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <FeedbackQueueView />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  cleanup()
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    return {
+      ok: true,
+      json: async () =>
+        url.includes('/api/marketing/contacts/') ? contactResponse : feedbackResponse,
+    }
+  }) as unknown as typeof fetch
+})
+
+describe('FeedbackQueueView contact column', () => {
+  it('shows the contact name, with a shortened GUID fallback', async () => {
+    renderView()
+    await waitFor(() => expect(screen.getByText('Rohan')).toBeInTheDocument())
+    expect(screen.getByText('bb12cd34…')).toBeInTheDocument()
+    // The raw GUID never renders.
+    expect(screen.queryByText(NAMED_ID)).not.toBeInTheDocument()
+  })
+
+  it('clicking the name opens the contact peek modal (stays on the queue)', async () => {
+    renderView()
+    fireEvent.click(await screen.findByRole('button', { name: 'Rohan' }))
+
+    const link = await screen.findByRole('link', { name: 'Open full profile →' })
+    expect(link).toHaveAttribute('href', `/admin/marketing/contacts/${NAMED_ID}`)
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(urls.some((u) => u === `/api/marketing/contacts/${NAMED_ID}`)).toBe(true)
+  })
+})

--- a/tests/unit/routes/feedbackListEnrichment.test.ts
+++ b/tests/unit/routes/feedbackListEnrichment.test.ts
@@ -1,0 +1,107 @@
+/**
+ * GET /api/marketing/feedback — contactName enrichment.
+ *
+ * The feedback projection stores only contactIdString; the route enriches each
+ * page with the contact's firstName via ONE batched contacts lookup. These
+ * tests pin the batching (single `in` query, deduped ids) and the null
+ * fallback for unknown/nameless contacts.
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+const findMock = vi.hoisted(() => vi.fn())
+const authHolder = vi.hoisted(() => ({
+  current: {} as Record<string, unknown>,
+}))
+vi.mock('@/lib/auth', () => ({
+  requireAuth: vi.fn(async () => authHolder.current),
+}))
+
+import { GET } from '@/app/api/marketing/feedback/route'
+
+function req(qs = ''): NextRequest {
+  return { nextUrl: new URL(`http://x/api/marketing/feedback${qs}`) } as unknown as NextRequest
+}
+
+const feedbackPage = (docs: unknown[]) => ({
+  docs,
+  totalDocs: docs.length,
+  totalPages: 1,
+  page: 1,
+  hasNextPage: false,
+  hasPrevPage: false,
+  limit: 50,
+})
+
+beforeEach(() => {
+  findMock.mockReset()
+  authHolder.current = { payload: { find: findMock }, user: { id: 'staff-1' } }
+})
+
+describe('GET /api/marketing/feedback contactName enrichment', () => {
+  test('attaches firstName per row via one batched contacts lookup (deduped ids)', async () => {
+    findMock
+      .mockResolvedValueOnce(
+        feedbackPage([
+          { feedbackId: 'f-1', contactIdString: 'c-1' },
+          { feedbackId: 'f-2', contactIdString: 'c-2' },
+          { feedbackId: 'f-3', contactIdString: 'c-1' }, // duplicate contact
+        ]),
+      )
+      .mockResolvedValueOnce({
+        docs: [
+          { contactId: 'c-1', firstName: 'Rohan' },
+          { contactId: 'c-2', firstName: null },
+        ],
+      })
+
+    const res = (await GET(req())) as unknown as {
+      body: { docs: Array<{ feedbackId: string; contactName: string | null }> }
+    }
+
+    expect(res.body.docs.map((d) => [d.feedbackId, d.contactName])).toEqual([
+      ['f-1', 'Rohan'],
+      ['f-2', null],
+      ['f-3', 'Rohan'],
+    ])
+
+    // Exactly two finds: feedback page + ONE batched contacts query with deduped ids.
+    expect(findMock).toHaveBeenCalledTimes(2)
+    const contactsCall = findMock.mock.calls[1]![0]
+    expect(contactsCall.collection).toBe('contacts')
+    expect(contactsCall.where).toEqual({ contactId: { in: ['c-1', 'c-2'] } })
+    expect(contactsCall.limit).toBe(2)
+  })
+
+  test('unknown contact id → contactName null; no contacts query when the page is empty', async () => {
+    findMock.mockResolvedValueOnce(
+      feedbackPage([{ feedbackId: 'f-1', contactIdString: 'c-ghost' }]),
+    )
+    findMock.mockResolvedValueOnce({ docs: [] })
+
+    const res = (await GET(req())) as unknown as {
+      body: { docs: Array<{ contactName: string | null }> }
+    }
+    expect(res.body.docs[0]!.contactName).toBeNull()
+
+    findMock.mockReset()
+    findMock.mockResolvedValueOnce(feedbackPage([]))
+    await GET(req())
+    expect(findMock).toHaveBeenCalledTimes(1) // no second (contacts) query
+  })
+
+  test('returns the auth error when requireAuth denies', async () => {
+    authHolder.current = { error: { body: { error: 'nope' }, status: 401 } }
+    const res = (await GET(req())) as unknown as { status: number }
+    expect(res.status).toBe(401)
+  })
+})


### PR DESCRIPTION
## Summary

The feedback queue's Contact column showed the raw contact GUID (screenshot feedback, 7 Jul). Now it shows the **contact's name**, clicking it opens a **peek modal** with the contact's key facts — triage without losing your place in the queue — and the modal links out to the full profile.

```
│ CONTACT     │ TYPE   │ FEEDBACK               │ STATUS       │
│ Rohan       │ praise │ Feedback retest after… │ acknowledged │
│ bb12cd34…   │ bug    │ (nameless contact)     │ new          │
     ▲ click → peek modal: mobile / email / stage / source / city /
                consent / customer link / referral code / updated
                [Open full profile →]  [Close]
```

### How
- **Server**: `GET /api/marketing/feedback` enriches each page with `contactName` via **one batched contacts lookup** (deduped ids — no N+1). Unknown/nameless → `null`, UI falls back to `bb12cd34…`.
- **Client**: `ContactPeekModal` reuses `useMarketingContact` (same source as the detail page); fixed-layout rows with em-dash placeholders.

## Tests
- Route: enrichment mapping, single batched `in` query with deduped ids, null fallback, empty-page short-circuit, auth denial
- ContactPeekModal: field render, full-profile href, both close controls, load-failure state
- FeedbackQueueView: name + shortened-GUID fallback, GUID never rendered, click opens modal

9/9 green; eslint/prettier/tsc clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi