### PR TITLE
feat(marketing): resolution note on feedback resolve (required)

### DIFF
--- a/event-processor/src/billie_servicing/handlers/marketing.py
+++ b/event-processor/src/billie_servicing/handlers/marketing.py
@@ -405,17 +405,23 @@ async def handle_feedback_status_changed(pool: asyncpg.Pool, event: Any) -> None
     delivery leaves no phantom audit).
     """
     p = event.payload
+    # `note` (what was done) arrived with the resolution-note feature —
+    # getattr keeps this tolerant of pre-note SDK models during rollout.
+    note = getattr(p, "note", None)
+    values = {
+        "status": p.status,
+        "status_changed_at": coerce_date(p.changed_at),
+        "status_actor": p.actor,
+        "updated_at": _now(),
+    }
+    if note:
+        values["status_note"] = note
     await update_by_key(
         pool,
         "feedback",
         key_column="feedback_id",
         key_value=p.feedback_id,
-        values={
-            "status": p.status,
-            "status_changed_at": coerce_date(p.changed_at),
-            "status_actor": p.actor,
-            "updated_at": _now(),
-        },
+        values=values,
     )
     contact_ref = await pool.fetchval(
         "SELECT contact_id_string FROM feedback WHERE feedback_id = $1", p.feedback_id

--- a/event-processor/tests/test_marketing_handlers.py
+++ b/event-processor/tests/test_marketing_handlers.py
@@ -275,3 +275,30 @@ async def test_referral_attributed_sets_referred_by_on_referee(mock_pool):
     audit_row = mock_pool.last_insert("contact_audit_log")
     assert audit_row["contact_id_string"] == "c-1"
     assert json.loads(audit_row["detail"])["referrer_contact_id"] == "c-ref"
+
+
+async def test_feedback_status_changed_stores_resolution_note(mock_pool) -> None:
+    # `note` (what was done) travels on the status event; extra="allow" on the
+    # SDK model means it parses even before the SDK adds the field explicitly.
+    mock_pool.set_fetchval("c-1")
+    await handle_feedback_status_changed(mock_pool, _parsed("feedback.status.changed.v1", {
+        "feedback_id": "f-1", "status": "resolved", "actor": "ops",
+        "changed_at": "2026-07-07T00:00:00+00:00",
+        "note": "Called the contact; fixed in release 1.4"}))
+
+    updated = mock_pool.last_update("feedback")
+    assert updated["status"] == "resolved"
+    assert updated["status_note"] == "Called the contact; fixed in release 1.4"
+
+
+async def test_feedback_status_changed_without_note_leaves_column_untouched(mock_pool) -> None:
+    # Pre-note events (and pre-note SDK models) keep working — status_note is
+    # omitted from the UPDATE rather than nulled.
+    mock_pool.set_fetchval("c-1")
+    await handle_feedback_status_changed(mock_pool, _parsed("feedback.status.changed.v1", {
+        "feedback_id": "f-1", "status": "acknowledged", "actor": "ops",
+        "changed_at": "2026-07-07T00:00:00+00:00"}))
+
+    updated = mock_pool.last_update("feedback")
+    assert updated["status"] == "acknowledged"
+    assert "status_note" not in updated

--- a/proto/marketing_service.proto
+++ b/proto/marketing_service.proto
@@ -156,6 +156,7 @@ message SetFeedbackStatusRequest {
   string feedback_id = 2;
   string status = 3;                // new | acknowledged | resolved
   string actor = 4;
+  string note = 5;                  // what was done — required by the CRM when resolving
 }
 
 message SetFeedbackStatusResponse {

--- a/src/app/api/marketing/feedback/[feedbackId]/status/route.ts
+++ b/src/app/api/marketing/feedback/[feedbackId]/status/route.ts
@@ -45,13 +45,14 @@ export async function POST(
     )
   }
 
-  const { status } = parsed.data
+  const { status, note } = parsed.data
 
   try {
     const result = await setFeedbackStatus({
       idempotencyKey: `feedback-status:${feedbackId}:${status}`,
       feedbackId,
       status,
+      note: note?.trim() || undefined,
       actor: String(user.id),
     })
     return NextResponse.json(

--- a/src/collections/Feedback.ts
+++ b/src/collections/Feedback.ts
@@ -42,6 +42,14 @@ export const Feedback: CollectionConfig = {
     },
     { name: 'statusChangedAt', type: 'date', admin: { readOnly: true } },
     { name: 'statusActor', type: 'text', admin: { readOnly: true } },
+    {
+      name: 'statusNote',
+      type: 'textarea',
+      admin: {
+        readOnly: true,
+        description: 'What was done — carried on feedback.status.changed.v1',
+      },
+    },
   ],
   timestamps: true,
 }

--- a/src/components/MarketingView/FeedbackQueueView.tsx
+++ b/src/components/MarketingView/FeedbackQueueView.tsx
@@ -3,10 +3,12 @@
 import React, { useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useFeedbackQueue } from '@/hooks/queries/useFeedbackQueue'
+import type { FeedbackWithContact } from '@/hooks/queries/useFeedbackQueue'
 import { useSetFeedbackStatus } from '@/hooks/mutations/useMarketingCommands'
 import type { Feedback } from '@/payload-types'
 import { formatDateShort } from '@/lib/formatters'
 import { ContactPeekModal } from './ContactPeekModal'
+import { ResolveFeedbackModal } from './ResolveFeedbackModal'
 import styles from './styles.module.css'
 
 const STATUS_OPTIONS = [
@@ -29,15 +31,18 @@ export const FeedbackQueueView: React.FC = () => {
   const [status, setStatus] = useState('')
   const [page, setPage] = useState(1)
   const [peekContactId, setPeekContactId] = useState<string | null>(null)
+  const [resolveTarget, setResolveTarget] = useState<FeedbackWithContact | null>(null)
 
   const filters = useMemo(() => ({ status: status || undefined, page }), [status, page])
   const { data, isLoading, isError } = useFeedbackQueue(filters)
   const setStatusMutation = useSetFeedbackStatus()
   const docs = data?.docs ?? []
 
-  const advance = (feedbackId: string | null | undefined, to: 'acknowledged' | 'resolved') => {
+  // Acknowledge is a one-click nudge; Resolve requires a note (see
+  // ResolveFeedbackModal), matching the approval flows' comment requirement.
+  const acknowledge = (feedbackId: string | null | undefined) => {
     if (!feedbackId) return
-    setStatusMutation.mutate({ feedbackId, status: to })
+    setStatusMutation.mutate({ feedbackId, status: 'acknowledged' })
   }
 
   const statusBadge = (s: Feedback['status']) => <span className={styles.badge}>{s ?? 'new'}</span>
@@ -87,6 +92,7 @@ export const FeedbackQueueView: React.FC = () => {
                   <th>Type</th>
                   <th>Feedback</th>
                   <th>Status</th>
+                  <th>Resolution</th>
                   <th>Received</th>
                   <th>Actions</th>
                 </tr>
@@ -94,13 +100,13 @@ export const FeedbackQueueView: React.FC = () => {
               <tbody>
                 {isLoading && docs.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className={styles.emptyCell}>
+                    <td colSpan={7} className={styles.emptyCell}>
                       Loading feedback…
                     </td>
                   </tr>
                 ) : docs.length === 0 ? (
                   <tr>
-                    <td colSpan={6} className={styles.emptyCell}>
+                    <td colSpan={7} className={styles.emptyCell}>
                       No feedback matches the current filter.
                     </td>
                   </tr>
@@ -123,12 +129,21 @@ export const FeedbackQueueView: React.FC = () => {
                       <td>{fb.feedbackType ?? '—'}</td>
                       <td>{fb.body ?? '—'}</td>
                       <td>{statusBadge(fb.status)}</td>
+                      <td>
+                        {fb.statusNote ? (
+                          <span className={styles.noteCell} title={fb.statusNote}>
+                            {fb.statusNote}
+                          </span>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
                       <td>{fb.receivedAt ? formatDateShort(fb.receivedAt) : '—'}</td>
                       <td>
                         <button
                           type="button"
                           className={styles.pageButton}
-                          onClick={() => advance(fb.feedbackId, 'acknowledged')}
+                          onClick={() => acknowledge(fb.feedbackId)}
                           disabled={setStatusMutation.isPending || fb.status !== 'new'}
                         >
                           Acknowledge
@@ -136,7 +151,7 @@ export const FeedbackQueueView: React.FC = () => {
                         <button
                           type="button"
                           className={styles.pageButton}
-                          onClick={() => advance(fb.feedbackId, 'resolved')}
+                          onClick={() => setResolveTarget(fb)}
                           disabled={setStatusMutation.isPending || fb.status === 'resolved'}
                         >
                           Resolve
@@ -175,6 +190,10 @@ export const FeedbackQueueView: React.FC = () => {
 
       {peekContactId && (
         <ContactPeekModal contactId={peekContactId} onClose={() => setPeekContactId(null)} />
+      )}
+
+      {resolveTarget && (
+        <ResolveFeedbackModal feedback={resolveTarget} onClose={() => setResolveTarget(null)} />
       )}
     </div>
   )

--- a/src/components/MarketingView/ResolveFeedbackModal.tsx
+++ b/src/components/MarketingView/ResolveFeedbackModal.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useSetFeedbackStatus } from '@/hooks/mutations/useMarketingCommands'
+import type { FeedbackWithContact } from '@/hooks/queries/useFeedbackQueue'
+import styles from './styles.module.css'
+
+interface ResolveFeedbackModalProps {
+  feedback: FeedbackWithContact
+  onClose: () => void
+}
+
+/**
+ * Resolution-note capture for the feedback queue. Resolving is an action taken
+ * on behalf of a contact, so — like the approval flows' comments — it must say
+ * what was done. The note travels on SetFeedbackStatus →
+ * feedback.status.changed.v1 → the projection's statusNote, and shows in the
+ * queue's Resolution column.
+ */
+export const ResolveFeedbackModal: React.FC<ResolveFeedbackModalProps> = ({
+  feedback,
+  onClose,
+}) => {
+  const [note, setNote] = useState('')
+  const setStatusMutation = useSetFeedbackStatus()
+  const canSubmit = !!note.trim() && !setStatusMutation.isPending
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit || !feedback.feedbackId) return
+    setStatusMutation.mutate(
+      { feedbackId: feedback.feedbackId, status: 'resolved', note: note.trim() },
+      { onSuccess: () => onClose() },
+    )
+  }
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h2 className={styles.modalTitle}>Resolve feedback</h2>
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className={styles.modalBody}>
+            {setStatusMutation.isError && (
+              <div className={styles.errorMessage}>
+                {setStatusMutation.error instanceof Error
+                  ? setStatusMutation.error.message
+                  : 'Failed to resolve feedback'}
+              </div>
+            )}
+
+            <blockquote className={styles.feedbackQuote}>{feedback.body ?? '—'}</blockquote>
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="resolve-feedback-note">
+                What was done?
+              </label>
+              <textarea
+                id="resolve-feedback-note"
+                className={styles.noteTextarea}
+                rows={4}
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                placeholder="e.g. Called the contact, issue fixed in release 1.4"
+                maxLength={2000}
+              />
+              <p className={styles.formHint}>Required — recorded against the feedback item.</p>
+            </div>
+          </div>
+
+          <div className={styles.modalFooter}>
+            <button type="button" className={styles.btnCancel} onClick={onClose}>
+              Cancel
+            </button>
+            <button type="submit" className={styles.btnSubmit} disabled={!canSubmit}>
+              {setStatusMutation.isPending ? 'Resolving…' : 'Resolve'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default ResolveFeedbackModal

--- a/src/components/MarketingView/styles.module.css
+++ b/src/components/MarketingView/styles.module.css
@@ -421,6 +421,26 @@
   margin-left: auto;
 }
 
+/* Truncated resolution note in the feedback queue (full text in title). */
+.noteCell {
+  display: inline-block;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
+/* The feedback being resolved, quoted in the resolve modal. */
+.feedbackQuote {
+  margin: 0 0 1rem 0;
+  padding: 0.5rem 0.75rem;
+  border-left: 3px solid var(--theme-elevation-200, #d5d5d5);
+  color: var(--theme-elevation-600, #666);
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+}
+
 /* Button that reads as an inline name link (feedback queue contact peek). */
 .linkButton {
   background: none;

--- a/src/hooks/mutations/useMarketingCommands.ts
+++ b/src/hooks/mutations/useMarketingCommands.ts
@@ -84,6 +84,8 @@ export function useTriggerInvitations() {
 export interface SetFeedbackStatusVars {
   feedbackId: string
   status: 'new' | 'acknowledged' | 'resolved'
+  /** What was done — required by the API when resolving. */
+  note?: string
 }
 
 export function useSetFeedbackStatus() {
@@ -92,6 +94,7 @@ export function useSetFeedbackStatus() {
     mutationFn: (vars: SetFeedbackStatusVars) =>
       postCommand(`/api/marketing/feedback/${encodeURIComponent(vars.feedbackId)}/status`, {
         status: vars.status,
+        ...(vars.note ? { note: vars.note } : {}),
       }),
     onSuccess: () => {
       toast.success('Feedback status updated')

--- a/src/lib/schemas/marketing.ts
+++ b/src/lib/schemas/marketing.ts
@@ -86,8 +86,16 @@ export const AssignBatchSchema = z.object({
 
 export type AssignBatch = z.infer<typeof AssignBatchSchema>
 
-export const SetFeedbackStatusSchema = z.object({
-  status: z.enum(['new', 'acknowledged', 'resolved']),
-})
+export const SetFeedbackStatusSchema = z
+  .object({
+    status: z.enum(['new', 'acknowledged', 'resolved']),
+    // What was done with the feedback. Required when resolving (matches the
+    // approval flows' comment requirement); optional on acknowledge.
+    note: z.string().max(2000).optional(),
+  })
+  .refine((d) => d.status !== 'resolved' || !!d.note?.trim(), {
+    message: 'A resolution note is required when resolving feedback',
+    path: ['note'],
+  })
 
 export type SetFeedbackStatus = z.infer<typeof SetFeedbackStatusSchema>

--- a/src/migrations/20260707_121002.json
+++ b/src/migrations/20260707_121002.json
@@ -1,0 +1,7723 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_users_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'readonly'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_id": {
+          "name": "avatar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "enable_a_p_i_key": {
+          "name": "enable_a_p_i_key",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_index": {
+          "name": "api_key_index",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_avatar_idx": {
+          "name": "users_avatar_idx",
+          "columns": [
+            {
+              "expression": "avatar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_avatar_id_media_id_fk": {
+          "name": "users_avatar_id_media_id_fk",
+          "tableFrom": "users",
+          "tableTo": "media",
+          "columnsFrom": [
+            "avatar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers_identity_documents": {
+      "name": "customers_identity_documents",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "enum_customers_identity_documents_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_subtype": {
+          "name": "document_subtype",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_of_issue": {
+          "name": "state_of_issue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_issue": {
+          "name": "country_of_issue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "additional_info": {
+          "name": "additional_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_identity_documents_order_idx": {
+          "name": "customers_identity_documents_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_identity_documents_parent_id_idx": {
+          "name": "customers_identity_documents_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_identity_documents_parent_id_fk": {
+          "name": "customers_identity_documents_parent_id_fk",
+          "tableFrom": "customers_identity_documents",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into": {
+          "name": "merged_into",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "middle_name": {
+          "name": "middle_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_phone_number": {
+          "name": "mobile_phone_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verified": {
+          "name": "identity_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_number": {
+          "name": "residential_address_street_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_name": {
+          "name": "residential_address_street_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_type": {
+          "name": "residential_address_street_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_unit_number": {
+          "name": "residential_address_unit_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street": {
+          "name": "residential_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_suburb": {
+          "name": "residential_address_suburb",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_city": {
+          "name": "residential_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_state": {
+          "name": "residential_address_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_postcode": {
+          "name": "residential_address_postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_country": {
+          "name": "residential_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "residential_address_full_address": {
+          "name": "residential_address_full_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_street": {
+          "name": "mailing_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_city": {
+          "name": "mailing_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_state": {
+          "name": "mailing_address_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_postcode": {
+          "name": "mailing_address_postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_country": {
+          "name": "mailing_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "staff_flag": {
+          "name": "staff_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "investor_flag": {
+          "name": "investor_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founder_flag": {
+          "name": "founder_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerable_flag": {
+          "name": "vulnerable_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ekyc_entity_id": {
+          "name": "ekyc_entity_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ekyc_status": {
+          "name": "ekyc_status",
+          "type": "enum_customers_ekyc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "individual_status": {
+          "name": "individual_status",
+          "type": "enum_customers_individual_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_reason": {
+          "name": "reapplication_block_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_until": {
+          "name": "reapplication_block_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_at": {
+          "name": "reapplication_block_blocked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_application_number": {
+          "name": "reapplication_block_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_status": {
+          "name": "reapplication_block_clear_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_cleared_at": {
+          "name": "reapplication_block_cleared_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_overall_result": {
+          "name": "identity_verification_overall_result",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_provider": {
+          "name": "identity_verification_provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_provider_reference": {
+          "name": "identity_verification_provider_reference",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_lab_request_id": {
+          "name": "identity_verification_lab_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_checked_at": {
+          "name": "identity_verification_checked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_archived": {
+          "name": "identity_verification_report_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_archived_at": {
+          "name": "identity_verification_archived_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "customers_customer_id_idx": {
+          "name": "customers_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_merged_into_idx": {
+          "name": "customers_merged_into_idx",
+          "columns": [
+            {
+              "expression": "merged_into",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_updated_at_idx": {
+          "name": "customers_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_created_at_idx": {
+          "name": "customers_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers_rels": {
+      "name": "customers_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applications_id": {
+          "name": "applications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_accounts_id": {
+          "name": "loan_accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_rels_order_idx": {
+          "name": "customers_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_parent_idx": {
+          "name": "customers_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_path_idx": {
+          "name": "customers_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_applications_id_idx": {
+          "name": "customers_rels_applications_id_idx",
+          "columns": [
+            {
+              "expression": "applications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_conversations_id_idx": {
+          "name": "customers_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_loan_accounts_id_idx": {
+          "name": "customers_rels_loan_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "loan_accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_rels_parent_fk": {
+          "name": "customers_rels_parent_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_applications_fk": {
+          "name": "customers_rels_applications_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "applications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_conversations_fk": {
+          "name": "customers_rels_conversations_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_loan_accounts_fk": {
+          "name": "customers_rels_loan_accounts_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_utterances": {
+      "name": "conversations_utterances",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utterance": {
+          "name": "utterance",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_input_type": {
+          "name": "answer_input_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_seq": {
+          "name": "prev_seq",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_conversation": {
+          "name": "end_conversation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_utterances_order_idx": {
+          "name": "conversations_utterances_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_utterances_parent_id_idx": {
+          "name": "conversations_utterances_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_utterances_parent_id_fk": {
+          "name": "conversations_utterances_parent_id_fk",
+          "tableFrom": "conversations_utterances",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_facts": {
+      "name": "conversations_facts",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fact": {
+          "name": "fact",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_facts_order_idx": {
+          "name": "conversations_facts_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_facts_parent_id_idx": {
+          "name": "conversations_facts_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_facts_parent_id_fk": {
+          "name": "conversations_facts_parent_id_fk",
+          "tableFrom": "conversations_facts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_noticeboard": {
+      "name": "conversations_noticeboard",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_noticeboard_order_idx": {
+          "name": "conversations_noticeboard_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_noticeboard_parent_id_idx": {
+          "name": "conversations_noticeboard_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_noticeboard_parent_id_fk": {
+          "name": "conversations_noticeboard_parent_id_fk",
+          "tableFrom": "conversations_noticeboard",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_number": {
+          "name": "application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id_string": {
+          "name": "customer_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id_id": {
+          "name": "application_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_conversations_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "last_utterance_time": {
+          "name": "last_utterance_time",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_decision": {
+          "name": "final_decision",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_reason": {
+          "name": "decision_detail_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_retry_eligible": {
+          "name": "decision_detail_retry_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_source_application_number": {
+          "name": "decision_detail_source_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_blocked_until": {
+          "name": "decision_detail_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_reason": {
+          "name": "reapplication_block_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_message_variant": {
+          "name": "reapplication_block_message_variant",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_stop_message": {
+          "name": "reapplication_block_stop_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_application_number": {
+          "name": "reapplication_block_source_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_account_id": {
+          "name": "reapplication_block_source_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_decided_at": {
+          "name": "reapplication_block_source_decided_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_until": {
+          "name": "reapplication_block_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_at": {
+          "name": "reapplication_block_blocked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_canonical_customer_id": {
+          "name": "reapplication_block_canonical_customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_disposition_kind": {
+          "name": "reapplication_block_disposition_kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_manual_review_candidate": {
+          "name": "reapplication_block_manual_review_candidate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_recognition": {
+          "name": "reapplication_block_recognition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_status": {
+          "name": "reapplication_block_clear_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_cleared_at": {
+          "name": "reapplication_block_cleared_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_cleared_by": {
+          "name": "reapplication_block_cleared_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_justification": {
+          "name": "reapplication_block_clear_justification",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_request_id": {
+          "name": "reapplication_block_clear_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_lab_request_id": {
+          "name": "identity_verification_report_lab_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_provider_reference": {
+          "name": "identity_verification_report_provider_reference",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_report_file_location": {
+          "name": "identity_verification_report_report_file_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_report_file_name": {
+          "name": "identity_verification_report_report_file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_raw_response_file_location": {
+          "name": "identity_verification_report_raw_response_file_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_raw_response_file_name": {
+          "name": "identity_verification_report_raw_response_file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_archived_at": {
+          "name": "identity_verification_report_archived_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_identity_risk": {
+          "name": "assessments_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_serviceability": {
+          "name": "assessments_serviceability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_fraud_check": {
+          "name": "assessments_fraud_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_account_conduct": {
+          "name": "assessments_account_conduct",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_post_identity_risk": {
+          "name": "assessments_post_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_credit_assessment_complete": {
+          "name": "assessments_credit_assessment_complete",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture": {
+          "name": "statement_capture",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_status": {
+          "name": "decision_status",
+          "type": "enum_conversations_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_data": {
+          "name": "application_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_conversation_id_idx": {
+          "name": "conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_application_number_idx": {
+          "name": "conversations_application_number_idx",
+          "columns": [
+            {
+              "expression": "application_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_customer_id_idx": {
+          "name": "conversations_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_customer_id_string_idx": {
+          "name": "conversations_customer_id_string_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_application_id_idx": {
+          "name": "conversations_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_status_idx": {
+          "name": "conversations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_decision_status_idx": {
+          "name": "conversations_decision_status_idx",
+          "columns": [
+            {
+              "expression": "decision_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_created_at_idx": {
+          "name": "conversations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_monitor_grid_idx": {
+          "name": "conversations_monitor_grid_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_by_customer_idx": {
+          "name": "conversations_by_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_customer_id_id_customers_id_fk": {
+          "name": "conversations_customer_id_id_customers_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_application_id_id_applications_id_fk": {
+          "name": "conversations_application_id_id_applications_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_proc_state_steps": {
+      "name": "app_proc_state_steps",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "step_name": {
+          "name": "step_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_app_proc_state_steps_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        },
+        "completion_event_name": {
+          "name": "completion_event_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_input_type": {
+          "name": "answer_input_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_main": {
+          "name": "prompts_main",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_completeness_check": {
+          "name": "prompts_completeness_check",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_confirmation": {
+          "name": "prompts_confirmation",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_output_json": {
+          "name": "prompts_output_json",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_mapping_out": {
+          "name": "prompts_mapping_out",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_module_name": {
+          "name": "business_logic_module_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_method_name": {
+          "name": "business_logic_method_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_mapping_in": {
+          "name": "business_logic_mapping_in",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_mapping_out": {
+          "name": "business_logic_mapping_out",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_proc_state_steps_order_idx": {
+          "name": "app_proc_state_steps_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_proc_state_steps_parent_id_idx": {
+          "name": "app_proc_state_steps_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_proc_state_steps_parent_id_fk": {
+          "name": "app_proc_state_steps_parent_id_fk",
+          "tableFrom": "app_proc_state_steps",
+          "tableTo": "app_proc_state",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_proc_state": {
+      "name": "app_proc_state",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stage_name": {
+          "name": "stage_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_proc_state_order_idx": {
+          "name": "app_proc_state_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_proc_state_parent_id_idx": {
+          "name": "app_proc_state_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_proc_state_parent_id_fk": {
+          "name": "app_proc_state_parent_id_fk",
+          "tableFrom": "app_proc_state",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_application_process_conversation": {
+      "name": "applications_application_process_conversation",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_applications_application_process_conversation_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_application_process_conversation_order_idx": {
+          "name": "applications_application_process_conversation_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_application_process_conversation_parent_id_idx": {
+          "name": "applications_application_process_conversation_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_application_process_conversation_parent_id_fk": {
+          "name": "applications_application_process_conversation_parent_id_fk",
+          "tableFrom": "applications_application_process_conversation",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_noticeboard_versions": {
+      "name": "applications_noticeboard_versions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_noticeboard_versions_order_idx": {
+          "name": "applications_noticeboard_versions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_noticeboard_versions_parent_id_idx": {
+          "name": "applications_noticeboard_versions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_noticeboard_versions_parent_id_fk": {
+          "name": "applications_noticeboard_versions_parent_id_fk",
+          "tableFrom": "applications_noticeboard_versions",
+          "tableTo": "applications_noticeboard",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_noticeboard": {
+      "name": "applications_noticeboard",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "applications_noticeboard_order_idx": {
+          "name": "applications_noticeboard_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_noticeboard_parent_id_idx": {
+          "name": "applications_noticeboard_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_noticeboard_parent_id_fk": {
+          "name": "applications_noticeboard_parent_id_fk",
+          "tableFrom": "applications_noticeboard",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_number": {
+          "name": "application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_purpose": {
+          "name": "loan_purpose",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_amount": {
+          "name": "loan_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_fee": {
+          "name": "loan_fee",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_total_payable": {
+          "name": "loan_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_term": {
+          "name": "loan_term",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_attestation_acceptance": {
+          "name": "customer_attestation_acceptance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture_consent_provided": {
+          "name": "statement_capture_consent_provided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture_completed": {
+          "name": "statement_capture_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_offer_acceptance": {
+          "name": "product_offer_acceptance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_outcome": {
+          "name": "application_outcome",
+          "type": "enum_applications_application_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_current_process_stage": {
+          "name": "application_process_current_process_stage",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_current_process_step": {
+          "name": "application_process_current_process_step",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_started_at": {
+          "name": "application_process_started_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_updated_at": {
+          "name": "application_process_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_identity_risk": {
+          "name": "assessments_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_serviceability": {
+          "name": "assessments_serviceability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_fraud_check": {
+          "name": "assessments_fraud_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applications_application_number_idx": {
+          "name": "applications_application_number_idx",
+          "columns": [
+            {
+              "expression": "application_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_customer_id_idx": {
+          "name": "applications_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_application_outcome_idx": {
+          "name": "applications_application_outcome_idx",
+          "columns": [
+            {
+              "expression": "application_outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_updated_at_idx": {
+          "name": "applications_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_created_at_idx": {
+          "name": "applications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_customer_id_id_customers_id_fk": {
+          "name": "applications_customer_id_id_customers_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_rels": {
+      "name": "applications_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_rels_order_idx": {
+          "name": "applications_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_parent_idx": {
+          "name": "applications_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_path_idx": {
+          "name": "applications_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_conversations_id_idx": {
+          "name": "applications_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_rels_parent_fk": {
+          "name": "applications_rels_parent_fk",
+          "tableFrom": "applications_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_rels_conversations_fk": {
+          "name": "applications_rels_conversations_fk",
+          "tableFrom": "applications_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_accounts_repayment_schedule_payments": {
+      "name": "loan_accounts_repayment_schedule_payments",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payment_number": {
+          "name": "payment_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_loan_accounts_repayment_schedule_payments_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'scheduled'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_remaining": {
+          "name": "amount_remaining",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_transaction_ids": {
+          "name": "linked_transaction_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "loan_accounts_repayment_schedule_payments_order_idx": {
+          "name": "loan_accounts_repayment_schedule_payments_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_repayment_schedule_payments_parent_id_idx": {
+          "name": "loan_accounts_repayment_schedule_payments_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accts_repay_sched_payments_natural_key_idx": {
+          "name": "loan_accts_repay_sched_payments_natural_key_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_accounts_repayment_schedule_payments_parent_id_fk": {
+          "name": "loan_accounts_repayment_schedule_payments_parent_id_fk",
+          "tableFrom": "loan_accounts_repayment_schedule_payments",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_accounts": {
+      "name": "loan_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id_string": {
+          "name": "customer_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_loan_amount": {
+          "name": "loan_terms_loan_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_loan_fee": {
+          "name": "loan_terms_loan_fee",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_total_payable": {
+          "name": "loan_terms_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_opened_date": {
+          "name": "loan_terms_opened_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_disbursed_date": {
+          "name": "loan_terms_disbursed_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_current_balance": {
+          "name": "balances_current_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_total_outstanding": {
+          "name": "balances_total_outstanding",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_total_paid": {
+          "name": "balances_total_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_payment_date": {
+          "name": "last_payment_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_payment_amount": {
+          "name": "last_payment_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_is_in_arrears": {
+          "name": "aging_is_in_arrears",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "aging_bucket": {
+          "name": "aging_bucket",
+          "type": "enum_loan_accounts_aging_bucket",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_current_d_p_d": {
+          "name": "aging_current_d_p_d",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_last_updated": {
+          "name": "aging_last_updated",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_status": {
+          "name": "account_status",
+          "type": "enum_loan_accounts_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "sdk_status": {
+          "name": "sdk_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commencement_date": {
+          "name": "commencement_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_loan_agreement_url": {
+          "name": "signed_loan_agreement_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "enum_loan_accounts_closure_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_previous_status": {
+          "name": "closure_previous_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_closed_date": {
+          "name": "closure_closed_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_final_balance": {
+          "name": "closure_final_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_total_paid": {
+          "name": "closure_total_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_loan_total_payable": {
+          "name": "closure_loan_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_triggered_by_transaction_id": {
+          "name": "closure_triggered_by_transaction_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_schedule_id": {
+          "name": "repayment_schedule_schedule_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_number_of_payments": {
+          "name": "repayment_schedule_number_of_payments",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_payment_frequency": {
+          "name": "repayment_schedule_payment_frequency",
+          "type": "enum_loan_accounts_repayment_schedule_payment_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_created_date": {
+          "name": "repayment_schedule_created_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "loan_accounts_loan_account_id_idx": {
+          "name": "loan_accounts_loan_account_id_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_account_number_idx": {
+          "name": "loan_accounts_account_number_idx",
+          "columns": [
+            {
+              "expression": "account_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_customer_id_idx": {
+          "name": "loan_accounts_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_customer_id_string_idx": {
+          "name": "loan_accounts_customer_id_string_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_loan_terms_loan_terms_disbursed_date_idx": {
+          "name": "loan_accounts_loan_terms_loan_terms_disbursed_date_idx",
+          "columns": [
+            {
+              "expression": "loan_terms_disbursed_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_aging_aging_is_in_arrears_idx": {
+          "name": "loan_accounts_aging_aging_is_in_arrears_idx",
+          "columns": [
+            {
+              "expression": "aging_is_in_arrears",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_aging_aging_bucket_idx": {
+          "name": "loan_accounts_aging_aging_bucket_idx",
+          "columns": [
+            {
+              "expression": "aging_bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_account_status_idx": {
+          "name": "loan_accounts_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_commencement_date_idx": {
+          "name": "loan_accounts_commencement_date_idx",
+          "columns": [
+            {
+              "expression": "commencement_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_updated_at_idx": {
+          "name": "loan_accounts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_created_at_idx": {
+          "name": "loan_accounts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_accounts_customer_id_id_customers_id_fk": {
+          "name": "loan_accounts_customer_id_id_customers_id_fk",
+          "tableFrom": "loan_accounts",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.write_off_requests_supporting_documents": {
+      "name": "write_off_requests_supporting_documents",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "write_off_requests_supporting_documents_order_idx": {
+          "name": "write_off_requests_supporting_documents_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_supporting_documents_parent_id_idx": {
+          "name": "write_off_requests_supporting_documents_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_supporting_documents_document_idx": {
+          "name": "write_off_requests_supporting_documents_document_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "write_off_requests_supporting_documents_document_id_media_id_fk": {
+          "name": "write_off_requests_supporting_documents_document_id_media_id_fk",
+          "tableFrom": "write_off_requests_supporting_documents",
+          "tableTo": "media",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "write_off_requests_supporting_documents_parent_id_fk": {
+          "name": "write_off_requests_supporting_documents_parent_id_fk",
+          "tableFrom": "write_off_requests_supporting_documents",
+          "tableTo": "write_off_requests",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.write_off_requests": {
+      "name": "write_off_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_number": {
+          "name": "request_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_balance": {
+          "name": "original_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "enum_write_off_requests_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_write_off_requests_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum_write_off_requests_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "requires_senior_approval": {
+          "name": "requires_senior_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_by_id": {
+          "name": "approval_details_decided_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_by_name": {
+          "name": "approval_details_decided_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_at": {
+          "name": "approval_details_decided_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_comment": {
+          "name": "approval_details_comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by": {
+          "name": "approval_details_approved_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by_name": {
+          "name": "approval_details_approved_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_at": {
+          "name": "approval_details_approved_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by": {
+          "name": "approval_details_rejected_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by_name": {
+          "name": "approval_details_rejected_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_at": {
+          "name": "approval_details_rejected_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_reason": {
+          "name": "approval_details_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by": {
+          "name": "cancellation_details_cancelled_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by_name": {
+          "name": "cancellation_details_cancelled_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_at": {
+          "name": "cancellation_details_cancelled_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "write_off_requests_request_id_idx": {
+          "name": "write_off_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_event_id_idx": {
+          "name": "write_off_requests_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_request_number_idx": {
+          "name": "write_off_requests_request_number_idx",
+          "columns": [
+            {
+              "expression": "request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_loan_account_id_idx": {
+          "name": "write_off_requests_loan_account_id_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_customer_id_idx": {
+          "name": "write_off_requests_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_status_idx": {
+          "name": "write_off_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_requested_by_idx": {
+          "name": "write_off_requests_requested_by_idx",
+          "columns": [
+            {
+              "expression": "requested_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_approval_details_approval_details_dec_idx": {
+          "name": "write_off_requests_approval_details_approval_details_dec_idx",
+          "columns": [
+            {
+              "expression": "approval_details_decided_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_updated_at_idx": {
+          "name": "write_off_requests_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_created_at_idx": {
+          "name": "write_off_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "write_off_requests_requested_by_id_users_id_fk": {
+          "name": "write_off_requests_requested_by_id_users_id_fk",
+          "tableFrom": "write_off_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "write_off_requests_approval_details_decided_by_id_users_id_fk": {
+          "name": "write_off_requests_approval_details_decided_by_id_users_id_fk",
+          "tableFrom": "write_off_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approval_details_decided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reapplication_block_clear_requests": {
+      "name": "reapplication_block_clear_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_number": {
+          "name": "request_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_customer_id": {
+          "name": "canonical_customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "justification": {
+          "name": "justification",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_reapplication_block_clear_requests_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by": {
+          "name": "approval_details_approved_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by_name": {
+          "name": "approval_details_approved_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_at": {
+          "name": "approval_details_approved_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_comment": {
+          "name": "approval_details_comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by": {
+          "name": "approval_details_rejected_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by_name": {
+          "name": "approval_details_rejected_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_at": {
+          "name": "approval_details_rejected_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_reason": {
+          "name": "approval_details_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by": {
+          "name": "cancellation_details_cancelled_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by_name": {
+          "name": "cancellation_details_cancelled_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_at": {
+          "name": "cancellation_details_cancelled_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reapplication_block_clear_requests_request_id_idx": {
+          "name": "reapplication_block_clear_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_event_id_idx": {
+          "name": "reapplication_block_clear_requests_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_request_number_idx": {
+          "name": "reapplication_block_clear_requests_request_number_idx",
+          "columns": [
+            {
+              "expression": "request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_canonical_customer_id_idx": {
+          "name": "reapplication_block_clear_requests_canonical_customer_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_status_idx": {
+          "name": "reapplication_block_clear_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_requested_by_idx": {
+          "name": "reapplication_block_clear_requests_requested_by_idx",
+          "columns": [
+            {
+              "expression": "requested_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_updated_at_idx": {
+          "name": "reapplication_block_clear_requests_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_created_at_idx": {
+          "name": "reapplication_block_clear_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reapplication_block_clear_requests_requested_by_id_users_id_fk": {
+          "name": "reapplication_block_clear_requests_requested_by_id_users_id_fk",
+          "tableFrom": "reapplication_block_clear_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_notes": {
+      "name": "contact_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "enum_contact_notes_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "enum_contact_notes_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_direction": {
+          "name": "contact_direction",
+          "type": "enum_contact_notes_contact_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum_contact_notes_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "enum_contact_notes_sentiment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'neutral'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amends_note_id": {
+          "name": "amends_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_contact_notes_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_notes_customer_idx": {
+          "name": "contact_notes_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_loan_account_idx": {
+          "name": "contact_notes_loan_account_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_application_idx": {
+          "name": "contact_notes_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_conversation_idx": {
+          "name": "contact_notes_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_created_by_idx": {
+          "name": "contact_notes_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_amends_note_idx": {
+          "name": "contact_notes_amends_note_idx",
+          "columns": [
+            {
+              "expression": "amends_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_status_idx": {
+          "name": "contact_notes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_created_at_idx": {
+          "name": "contact_notes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_updated_at_idx": {
+          "name": "contact_notes_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_notes_customer_id_customers_id_fk": {
+          "name": "contact_notes_customer_id_customers_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_loan_account_id_loan_accounts_id_fk": {
+          "name": "contact_notes_loan_account_id_loan_accounts_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_application_id_applications_id_fk": {
+          "name": "contact_notes_application_id_applications_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_conversation_id_conversations_id_fk": {
+          "name": "contact_notes_conversation_id_conversations_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_created_by_id_users_id_fk": {
+          "name": "contact_notes_created_by_id_users_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_amends_note_id_contact_notes_id_fk": {
+          "name": "contact_notes_amends_note_id_contact_notes_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "contact_notes",
+          "columnsFrom": [
+            "amends_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_ref_id": {
+          "name": "customer_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_notifications_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "enum_notifications_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_content_hash": {
+          "name": "template_content_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_git_sha": {
+          "name": "template_git_sha",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_hash": {
+          "name": "recipient_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_category": {
+          "name": "tags_category",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_reason": {
+          "name": "tags_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_step": {
+          "name": "tags_step",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_failed_at": {
+          "name": "failure_failed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_error_type": {
+          "name": "failure_error_type",
+          "type": "enum_notifications_failure_error_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_error_message": {
+          "name": "failure_error_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_attempt": {
+          "name": "failure_attempt",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_fallback_suggested": {
+          "name": "failure_fallback_suggested",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_account_id": {
+          "name": "statement_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_start": {
+          "name": "statement_period_start",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_end": {
+          "name": "statement_period_end",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_dispatched_at": {
+          "name": "statement_dispatched_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_mode": {
+          "name": "suppression_mode",
+          "type": "enum_notifications_suppression_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_reason": {
+          "name": "suppression_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_set_by": {
+          "name": "suppression_set_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_set_at": {
+          "name": "suppression_set_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_expires_at": {
+          "name": "suppression_expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_notification_id_idx": {
+          "name": "notifications_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_idempotency_key_idx": {
+          "name": "notifications_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_customer_ref_idx": {
+          "name": "notifications_customer_ref_idx",
+          "columns": [
+            {
+              "expression": "customer_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_customer_id_idx": {
+          "name": "notifications_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_status_idx": {
+          "name": "notifications_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_event_at_idx": {
+          "name": "notifications_event_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_customer_ref_id_customers_id_fk": {
+          "name": "notifications_customer_ref_id_customers_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_cases": {
+      "name": "collection_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_ref_id": {
+          "name": "customer_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum_collection_cases_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rung": {
+          "name": "rung",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardship_paused": {
+          "name": "hardship_paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_contact": {
+          "name": "stopped_contact",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overdue_amount": {
+          "name": "overdue_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_overdue": {
+          "name": "days_overdue",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_step": {
+          "name": "last_step",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cured_at": {
+          "name": "cured_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhausted_at": {
+          "name": "exhausted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_at": {
+          "name": "resumed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_contact_at": {
+          "name": "stop_contact_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_cases_account_id_idx": {
+          "name": "collection_cases_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_customer_ref_idx": {
+          "name": "collection_cases_customer_ref_idx",
+          "columns": [
+            {
+              "expression": "customer_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_customer_id_idx": {
+          "name": "collection_cases_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_state_idx": {
+          "name": "collection_cases_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_rung_idx": {
+          "name": "collection_cases_rung_idx",
+          "columns": [
+            {
+              "expression": "rung",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_hardship_paused_idx": {
+          "name": "collection_cases_hardship_paused_idx",
+          "columns": [
+            {
+              "expression": "hardship_paused",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_stopped_contact_idx": {
+          "name": "collection_cases_stopped_contact_idx",
+          "columns": [
+            {
+              "expression": "stopped_contact",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_opened_at_idx": {
+          "name": "collection_cases_opened_at_idx",
+          "columns": [
+            {
+              "expression": "opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_worklist_idx": {
+          "name": "collection_cases_worklist_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rung",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_by_customer_idx": {
+          "name": "collection_cases_by_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_cases_customer_ref_id_customers_id_fk": {
+          "name": "collection_cases_customer_ref_id_customers_id_fk",
+          "tableFrom": "collection_cases",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_e164": {
+          "name": "mobile_e164",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postcode": {
+          "name": "postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "enum_contacts_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm": {
+          "name": "utm",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_preference": {
+          "name": "channel_preference",
+          "type": "enum_contacts_channel_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_code": {
+          "name": "referral_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_contact_id": {
+          "name": "referred_by_contact_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitlist_joined_at": {
+          "name": "waitlist_joined_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitlist_position": {
+          "name": "waitlist_position",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "panel_member": {
+          "name": "panel_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_basis": {
+          "name": "link_basis",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derived_stage": {
+          "name": "derived_stage",
+          "type": "enum_contacts_derived_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_status": {
+          "name": "loan_status",
+          "type": "enum_contacts_loan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "erased": {
+          "name": "erased",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_contact_id_idx": {
+          "name": "contacts_contact_id_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_email_idx": {
+          "name": "contacts_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_mobile_e164_idx": {
+          "name": "contacts_mobile_e164_idx",
+          "columns": [
+            {
+              "expression": "mobile_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_referral_code_idx": {
+          "name": "contacts_referral_code_idx",
+          "columns": [
+            {
+              "expression": "referral_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_referred_by_contact_id_idx": {
+          "name": "contacts_referred_by_contact_id_idx",
+          "columns": [
+            {
+              "expression": "referred_by_contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_customer_id_idx": {
+          "name": "contacts_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_derived_stage_idx": {
+          "name": "contacts_derived_stage_idx",
+          "columns": [
+            {
+              "expression": "derived_stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_updated_at_idx": {
+          "name": "contacts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_created_at_idx": {
+          "name": "contacts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interactions": {
+      "name": "interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id_string": {
+          "name": "contact_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "enum_interactions_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "enum_interactions_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_system": {
+          "name": "source_system",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interactions_interaction_id_idx": {
+          "name": "interactions_interaction_id_idx",
+          "columns": [
+            {
+              "expression": "interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_contact_id_string_idx": {
+          "name": "interactions_contact_id_string_idx",
+          "columns": [
+            {
+              "expression": "contact_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_contact_idx": {
+          "name": "interactions_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_occurred_at_idx": {
+          "name": "interactions_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_updated_at_idx": {
+          "name": "interactions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_created_at_idx": {
+          "name": "interactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interactions_contact_id_contacts_id_fk": {
+          "name": "interactions_contact_id_contacts_id_fk",
+          "tableFrom": "interactions",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_audit_log": {
+      "name": "contact_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contact_id_string": {
+          "name": "contact_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_audit_log_contact_id_string_idx": {
+          "name": "contact_audit_log_contact_id_string_idx",
+          "columns": [
+            {
+              "expression": "contact_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_audit_log_occurred_at_idx": {
+          "name": "contact_audit_log_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_audit_log_updated_at_idx": {
+          "name": "contact_audit_log_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_audit_log_created_at_idx": {
+          "name": "contact_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_actor": {
+          "name": "created_by_actor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_created_at": {
+          "name": "batch_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "batches_batch_id_idx": {
+          "name": "batches_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_updated_at_idx": {
+          "name": "batches_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_created_at_idx": {
+          "name": "batches_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id_string": {
+          "name": "contact_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_type": {
+          "name": "feedback_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_area": {
+          "name": "product_area",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_actor": {
+          "name": "status_actor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_note": {
+          "name": "status_note",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_feedback_id_idx": {
+          "name": "feedback_feedback_id_idx",
+          "columns": [
+            {
+              "expression": "feedback_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_contact_id_string_idx": {
+          "name": "feedback_contact_id_string_idx",
+          "columns": [
+            {
+              "expression": "contact_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_customer_id_idx": {
+          "name": "feedback_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_product_area_idx": {
+          "name": "feedback_product_area_idx",
+          "columns": [
+            {
+              "expression": "product_area",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_status_idx": {
+          "name": "feedback_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_updated_at_idx": {
+          "name": "feedback_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_created_at_idx": {
+          "name": "feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customers_id": {
+          "name": "customers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applications_id": {
+          "name": "applications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_accounts_id": {
+          "name": "loan_accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_off_requests_id": {
+          "name": "write_off_requests_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_requests_id": {
+          "name": "reapplication_block_clear_requests_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_notes_id": {
+          "name": "contact_notes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notifications_id": {
+          "name": "notifications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cases_id": {
+          "name": "collection_cases_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts_id": {
+          "name": "contacts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interactions_id": {
+          "name": "interactions_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_audit_log_id": {
+          "name": "contact_audit_log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batches_id": {
+          "name": "batches_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_customers_id_idx": {
+          "name": "payload_locked_documents_rels_customers_id_idx",
+          "columns": [
+            {
+              "expression": "customers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_conversations_id_idx": {
+          "name": "payload_locked_documents_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_applications_id_idx": {
+          "name": "payload_locked_documents_rels_applications_id_idx",
+          "columns": [
+            {
+              "expression": "applications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_loan_accounts_id_idx": {
+          "name": "payload_locked_documents_rels_loan_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "loan_accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_write_off_requests_id_idx": {
+          "name": "payload_locked_documents_rels_write_off_requests_id_idx",
+          "columns": [
+            {
+              "expression": "write_off_requests_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_reapplication_block_clear__idx": {
+          "name": "payload_locked_documents_rels_reapplication_block_clear__idx",
+          "columns": [
+            {
+              "expression": "reapplication_block_clear_requests_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contact_notes_id_idx": {
+          "name": "payload_locked_documents_rels_contact_notes_id_idx",
+          "columns": [
+            {
+              "expression": "contact_notes_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_notifications_id_idx": {
+          "name": "payload_locked_documents_rels_notifications_id_idx",
+          "columns": [
+            {
+              "expression": "notifications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_collection_cases_id_idx": {
+          "name": "payload_locked_documents_rels_collection_cases_id_idx",
+          "columns": [
+            {
+              "expression": "collection_cases_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contacts_id_idx": {
+          "name": "payload_locked_documents_rels_contacts_id_idx",
+          "columns": [
+            {
+              "expression": "contacts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_interactions_id_idx": {
+          "name": "payload_locked_documents_rels_interactions_id_idx",
+          "columns": [
+            {
+              "expression": "interactions_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contact_audit_log_id_idx": {
+          "name": "payload_locked_documents_rels_contact_audit_log_id_idx",
+          "columns": [
+            {
+              "expression": "contact_audit_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_batches_id_idx": {
+          "name": "payload_locked_documents_rels_batches_id_idx",
+          "columns": [
+            {
+              "expression": "batches_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_feedback_id_idx": {
+          "name": "payload_locked_documents_rels_feedback_id_idx",
+          "columns": [
+            {
+              "expression": "feedback_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_customers_fk": {
+          "name": "payload_locked_documents_rels_customers_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_conversations_fk": {
+          "name": "payload_locked_documents_rels_conversations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_applications_fk": {
+          "name": "payload_locked_documents_rels_applications_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "applications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_loan_accounts_fk": {
+          "name": "payload_locked_documents_rels_loan_accounts_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_write_off_requests_fk": {
+          "name": "payload_locked_documents_rels_write_off_requests_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "write_off_requests",
+          "columnsFrom": [
+            "write_off_requests_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_reapplication_block_clear_r_fk": {
+          "name": "payload_locked_documents_rels_reapplication_block_clear_r_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "reapplication_block_clear_requests",
+          "columnsFrom": [
+            "reapplication_block_clear_requests_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contact_notes_fk": {
+          "name": "payload_locked_documents_rels_contact_notes_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contact_notes",
+          "columnsFrom": [
+            "contact_notes_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_notifications_fk": {
+          "name": "payload_locked_documents_rels_notifications_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notifications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_collection_cases_fk": {
+          "name": "payload_locked_documents_rels_collection_cases_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "collection_cases",
+          "columnsFrom": [
+            "collection_cases_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contacts_fk": {
+          "name": "payload_locked_documents_rels_contacts_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contacts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_interactions_fk": {
+          "name": "payload_locked_documents_rels_interactions_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interactions_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contact_audit_log_fk": {
+          "name": "payload_locked_documents_rels_contact_audit_log_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contact_audit_log",
+          "columnsFrom": [
+            "contact_audit_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_batches_fk": {
+          "name": "payload_locked_documents_rels_batches_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batches_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_feedback_fk": {
+          "name": "payload_locked_documents_rels_feedback_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "feedback",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_users_role": {
+      "name": "enum_users_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "supervisor",
+        "operations",
+        "readonly",
+        "service",
+        "marketing"
+      ]
+    },
+    "public.enum_customers_identity_documents_document_type": {
+      "name": "enum_customers_identity_documents_document_type",
+      "schema": "public",
+      "values": [
+        "DRIVERS_LICENCE",
+        "PASSPORT",
+        "MEDICARE"
+      ]
+    },
+    "public.enum_customers_ekyc_status": {
+      "name": "enum_customers_ekyc_status",
+      "schema": "public",
+      "values": [
+        "successful",
+        "failed",
+        "pending"
+      ]
+    },
+    "public.enum_customers_individual_status": {
+      "name": "enum_customers_individual_status",
+      "schema": "public",
+      "values": [
+        "LIVING",
+        "DECEASED",
+        "MISSING"
+      ]
+    },
+    "public.enum_conversations_status": {
+      "name": "enum_conversations_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "soft_end",
+        "hard_end",
+        "approved",
+        "declined"
+      ]
+    },
+    "public.enum_conversations_decision_status": {
+      "name": "enum_conversations_decision_status",
+      "schema": "public",
+      "values": [
+        "approved",
+        "declined",
+        "referred",
+        "no_decision"
+      ]
+    },
+    "public.enum_app_proc_state_steps_type": {
+      "name": "enum_app_proc_state_steps_type",
+      "schema": "public",
+      "values": [
+        "llm",
+        "business_logic",
+        "user_input"
+      ]
+    },
+    "public.enum_applications_application_process_conversation_role": {
+      "name": "enum_applications_application_process_conversation_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ]
+    },
+    "public.enum_applications_application_outcome": {
+      "name": "enum_applications_application_outcome",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "declined",
+        "withdrawn"
+      ]
+    },
+    "public.enum_loan_accounts_repayment_schedule_payments_status": {
+      "name": "enum_loan_accounts_repayment_schedule_payments_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "paid",
+        "missed",
+        "partial"
+      ]
+    },
+    "public.enum_loan_accounts_aging_bucket": {
+      "name": "enum_loan_accounts_aging_bucket",
+      "schema": "public",
+      "values": [
+        "current",
+        "early_arrears",
+        "late_arrears",
+        "default",
+        "closed"
+      ]
+    },
+    "public.enum_loan_accounts_account_status": {
+      "name": "enum_loan_accounts_account_status",
+      "schema": "public",
+      "values": [
+        "pending_disbursement",
+        "active",
+        "paid_off",
+        "in_arrears",
+        "written_off"
+      ]
+    },
+    "public.enum_loan_accounts_closure_reason": {
+      "name": "enum_loan_accounts_closure_reason",
+      "schema": "public",
+      "values": [
+        "PAID_OFF",
+        "WRITTEN_OFF",
+        "ADMIN_CLOSED"
+      ]
+    },
+    "public.enum_loan_accounts_repayment_schedule_payment_frequency": {
+      "name": "enum_loan_accounts_repayment_schedule_payment_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "fortnightly",
+        "monthly"
+      ]
+    },
+    "public.enum_write_off_requests_reason": {
+      "name": "enum_write_off_requests_reason",
+      "schema": "public",
+      "values": [
+        "hardship",
+        "bankruptcy",
+        "deceased",
+        "unable_to_locate",
+        "fraud_victim",
+        "disputed",
+        "aged_debt",
+        "other"
+      ]
+    },
+    "public.enum_write_off_requests_status": {
+      "name": "enum_write_off_requests_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.enum_write_off_requests_priority": {
+      "name": "enum_write_off_requests_priority",
+      "schema": "public",
+      "values": [
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.enum_reapplication_block_clear_requests_status": {
+      "name": "enum_reapplication_block_clear_requests_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.enum_contact_notes_channel": {
+      "name": "enum_contact_notes_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "internal",
+        "system"
+      ]
+    },
+    "public.enum_contact_notes_topic": {
+      "name": "enum_contact_notes_topic",
+      "schema": "public",
+      "values": [
+        "general_enquiry",
+        "complaint",
+        "escalation",
+        "internal_note",
+        "account_update",
+        "collections"
+      ]
+    },
+    "public.enum_contact_notes_contact_direction": {
+      "name": "enum_contact_notes_contact_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.enum_contact_notes_priority": {
+      "name": "enum_contact_notes_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.enum_contact_notes_sentiment": {
+      "name": "enum_contact_notes_sentiment",
+      "schema": "public",
+      "values": [
+        "positive",
+        "neutral",
+        "negative",
+        "escalation"
+      ]
+    },
+    "public.enum_contact_notes_status": {
+      "name": "enum_contact_notes_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "amended"
+      ]
+    },
+    "public.enum_notifications_status": {
+      "name": "enum_notifications_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "blocked",
+        "statement",
+        "suppression_change"
+      ]
+    },
+    "public.enum_notifications_channel": {
+      "name": "enum_notifications_channel",
+      "schema": "public",
+      "values": [
+        "email",
+        "sms"
+      ]
+    },
+    "public.enum_notifications_failure_error_type": {
+      "name": "enum_notifications_failure_error_type",
+      "schema": "public",
+      "values": [
+        "transient",
+        "permanent",
+        "auth",
+        "template",
+        "contact_missing",
+        "opt_out",
+        "suppressed"
+      ]
+    },
+    "public.enum_notifications_suppression_mode": {
+      "name": "enum_notifications_suppression_mode",
+      "schema": "public",
+      "values": [
+        "all",
+        "non_essential",
+        "marketing_only",
+        "panic_button",
+        "off"
+      ]
+    },
+    "public.enum_collection_cases_state": {
+      "name": "enum_collection_cases_state",
+      "schema": "public",
+      "values": [
+        "open",
+        "awaiting_human",
+        "cured"
+      ]
+    },
+    "public.enum_contacts_source": {
+      "name": "enum_contacts_source",
+      "schema": "public",
+      "values": [
+        "meta",
+        "google",
+        "campus",
+        "referral",
+        "social_dm",
+        "ai_search",
+        "organic",
+        "other"
+      ]
+    },
+    "public.enum_contacts_channel_preference": {
+      "name": "enum_contacts_channel_preference",
+      "schema": "public",
+      "values": [
+        "whatsapp",
+        "sms"
+      ]
+    },
+    "public.enum_contacts_derived_stage": {
+      "name": "enum_contacts_derived_stage",
+      "schema": "public",
+      "values": [
+        "lead",
+        "waitlist",
+        "invited",
+        "applicant",
+        "customer",
+        "former_customer"
+      ]
+    },
+    "public.enum_contacts_loan_status": {
+      "name": "enum_contacts_loan_status",
+      "schema": "public",
+      "values": [
+        "approved",
+        "disbursed",
+        "repaid"
+      ]
+    },
+    "public.enum_interactions_kind": {
+      "name": "enum_interactions_kind",
+      "schema": "public",
+      "values": [
+        "signup",
+        "message_out",
+        "message_in",
+        "feedback_prompt",
+        "referral",
+        "stage_change",
+        "note",
+        "import"
+      ]
+    },
+    "public.enum_interactions_direction": {
+      "name": "enum_interactions_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "4d417f79-2ea3-4588-8e7e-46230d69d801",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/src/migrations/20260707_121002.ts
+++ b/src/migrations/20260707_121002.ts
@@ -1,0 +1,11 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "feedback" ADD COLUMN "status_note" varchar;`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "feedback" DROP COLUMN "status_note";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -10,6 +10,7 @@ import * as migration_20260628_120000_reapplication_block_clear_requests from '.
 import * as migration_20260702_052932 from './20260702_052932';
 import * as migration_20260702_223751_marketing_module from './20260702_223751_marketing_module';
 import * as migration_20260704_043533_marketing_phase2 from './20260704_043533_marketing_phase2';
+import * as migration_20260707_121002 from './20260707_121002';
 
 export const migrations = [
   {
@@ -71,5 +72,10 @@ export const migrations = [
     up: migration_20260704_043533_marketing_phase2.up,
     down: migration_20260704_043533_marketing_phase2.down,
     name: '20260704_043533_marketing_phase2',
+  },
+  {
+    up: migration_20260707_121002.up,
+    down: migration_20260707_121002.down,
+    name: '20260707_121002'
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1727,6 +1727,10 @@ export interface Feedback {
   status?: string | null;
   statusChangedAt?: string | null;
   statusActor?: string | null;
+  /**
+   * What was done — carried on feedback.status.changed.v1
+   */
+  statusNote?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -2563,6 +2567,7 @@ export interface FeedbackSelect<T extends boolean = true> {
   status?: T;
   statusChangedAt?: T;
   statusActor?: T;
+  statusNote?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/server/marketing-grpc-client.ts
+++ b/src/server/marketing-grpc-client.ts
@@ -184,6 +184,8 @@ export interface SetFeedbackStatusInput {
   idempotencyKey: string
   feedbackId: string
   status: string
+  /** What was done with the feedback — carried on feedback.status.changed.v1. */
+  note?: string
   actor?: string
 }
 

--- a/tests/unit/components/FeedbackQueueContact.test.tsx
+++ b/tests/unit/components/FeedbackQueueContact.test.tsx
@@ -38,8 +38,19 @@ const feedbackResponse = {
       status: 'new',
       receivedAt: '2026-07-07T11:22:30.000Z',
     },
+    {
+      id: 3,
+      feedbackId: 'f-3',
+      contactIdString: NAMED_ID,
+      contactName: 'Rohan',
+      feedbackType: 'complaint',
+      body: 'Was overcharged',
+      status: 'resolved',
+      statusNote: 'Refunded the fee and apologised',
+      receivedAt: '2026-07-06T10:00:00.000Z',
+    },
   ],
-  totalDocs: 2,
+  totalDocs: 3,
   totalPages: 1,
   page: 1,
   hasNextPage: false,
@@ -77,15 +88,34 @@ beforeEach(() => {
 describe('FeedbackQueueView contact column', () => {
   it('shows the contact name, with a shortened GUID fallback', async () => {
     renderView()
-    await waitFor(() => expect(screen.getByText('Rohan')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getAllByText('Rohan')).not.toHaveLength(0))
     expect(screen.getByText('bb12cd34…')).toBeInTheDocument()
     // The raw GUID never renders.
     expect(screen.queryByText(NAMED_ID)).not.toBeInTheDocument()
   })
 
+  it('shows the resolution note in the Resolution column', async () => {
+    renderView()
+    await waitFor(() =>
+      expect(screen.getByText('Refunded the fee and apologised')).toBeInTheDocument(),
+    )
+  })
+
+  it('Resolve opens the note modal instead of firing the command immediately', async () => {
+    renderView()
+    const resolveButtons = await screen.findAllByRole('button', { name: 'Resolve' })
+    fireEvent.click(resolveButtons[0]!) // first row (status: new)
+
+    // The modal is open, nothing was POSTed yet.
+    expect(await screen.findByText('What was done?')).toBeInTheDocument()
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    const postCalls = fetchMock.mock.calls.filter((c) => (c[1] as RequestInit)?.method === 'POST')
+    expect(postCalls).toHaveLength(0)
+  })
+
   it('clicking the name opens the contact peek modal (stays on the queue)', async () => {
     renderView()
-    fireEvent.click(await screen.findByRole('button', { name: 'Rohan' }))
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Rohan' }))[0]!)
 
     const link = await screen.findByRole('link', { name: 'Open full profile →' })
     expect(link).toHaveAttribute('href', `/admin/marketing/contacts/${NAMED_ID}`)

--- a/tests/unit/components/ResolveFeedbackModal.test.tsx
+++ b/tests/unit/components/ResolveFeedbackModal.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { ResolveFeedbackModal } from '@/components/MarketingView/ResolveFeedbackModal'
+import type { FeedbackWithContact } from '@/hooks/queries/useFeedbackQueue'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const feedback = {
+  id: 1,
+  feedbackId: 'f-1',
+  contactIdString: 'c-1',
+  contactName: 'Rohan',
+  body: 'The repayment screen is confusing',
+  status: 'acknowledged',
+} as unknown as FeedbackWithContact
+
+const renderModal = (onClose = vi.fn()) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ResolveFeedbackModal feedback={feedback} onClose={onClose} />
+    </QueryClientProvider>,
+  )
+  return onClose
+}
+
+beforeEach(() => {
+  cleanup()
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ feedbackId: 'f-1', status: 'resolved' }),
+  })) as unknown as typeof fetch
+})
+
+describe('ResolveFeedbackModal', () => {
+  it('quotes the feedback and disables Resolve until a note is entered', () => {
+    renderModal()
+    expect(screen.getByText('The repayment screen is confusing')).toBeInTheDocument()
+
+    const submit = screen.getByRole('button', { name: 'Resolve' })
+    expect(submit).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('What was done?'), {
+      target: { value: '   ' },
+    })
+    expect(submit).toBeDisabled() // whitespace-only stays disabled
+
+    fireEvent.change(screen.getByLabelText('What was done?'), {
+      target: { value: 'Walked the contact through the screen' },
+    })
+    expect(submit).not.toBeDisabled()
+  })
+
+  it('POSTs status=resolved with the trimmed note, then closes', async () => {
+    const onClose = renderModal()
+    fireEvent.change(screen.getByLabelText('What was done?'), {
+      target: { value: '  Walked the contact through the screen  ' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve' }))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(String(url)).toBe('/api/marketing/feedback/f-1/status')
+    expect(JSON.parse(init.body)).toEqual({
+      status: 'resolved',
+      note: 'Walked the contact through the screen',
+    })
+  })
+
+  it('surfaces the API error and stays open', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        error: { code: 'VALIDATION_ERROR', message: 'A resolution note is required' },
+      }),
+    })) as unknown as typeof fetch
+
+    const onClose = renderModal()
+    fireEvent.change(screen.getByLabelText('What was done?'), {
+      target: { value: 'x' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Resolve' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('A resolution note is required')).toBeInTheDocument(),
+    )
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/routes/marketingBatchFeedback.test.ts
+++ b/tests/unit/routes/marketingBatchFeedback.test.ts
@@ -160,4 +160,45 @@ describe('POST /api/marketing/feedback/[feedbackId]/status (SetFeedbackStatus)',
     expect(res.status).toBe(400)
     expect(grpc.setFeedbackStatus).not.toHaveBeenCalled()
   })
+
+  test('resolve passes the trimmed note through to the gRPC command', async () => {
+    const res = (await feedbackStatusPost(
+      req({ status: 'resolved', note: '  Called the contact; fixed in 1.4  ' }),
+      p({ feedbackId: 'f-1' }),
+    )) as { status: number }
+    expect(res.status).toBe(202)
+    const arg = grpc.setFeedbackStatus.mock.calls[0][0]
+    expect(arg.note).toBe('Called the contact; fixed in 1.4')
+    expect(arg.idempotencyKey).toBe('feedback-status:f-1:resolved')
+  })
+
+  test('400 when resolving without a note (required-on-resolve policy)', async () => {
+    const res = (await feedbackStatusPost(
+      req({ status: 'resolved' }),
+      p({ feedbackId: 'f-1' }),
+    )) as {
+      status: number
+    }
+    expect(res.status).toBe(400)
+    expect(grpc.setFeedbackStatus).not.toHaveBeenCalled()
+  })
+
+  test('400 when resolving with a whitespace-only note', async () => {
+    const res = (await feedbackStatusPost(
+      req({ status: 'resolved', note: '   ' }),
+      p({ feedbackId: 'f-1' }),
+    )) as { status: number }
+    expect(res.status).toBe(400)
+    expect(grpc.setFeedbackStatus).not.toHaveBeenCalled()
+  })
+
+  test('acknowledge stays note-free (one-click)', async () => {
+    const res = (await feedbackStatusPost(
+      req({ status: 'acknowledged' }),
+      p({ feedbackId: 'f-1' }),
+    )) as { status: number }
+    expect(res.status).toBe(202)
+    const arg = grpc.setFeedbackStatus.mock.calls[0][0]
+    expect(arg.note).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary

Feedback triage recorded *who* resolved and *when* — never **what was done**. Per the design decision (7 Jul): resolution notes are platform-proper and **required on resolve** (Acknowledge stays one-click), matching the approval flows' comment precedent.

```
Resolve click ──► ┌─ Resolve feedback ────────────────────┐
                  │ ▎"The repayment screen is confusing"  │
                  │ What was done?            (required)  │
                  │ ┌───────────────────────────────────┐ │
                  │ │ Walked the contact through the…   │ │
                  │ └───────────────────────────────────┘ │
                  │               [Cancel] [Resolve]      │
                  └───────────────────────────────────────┘

│ CONTACT │ TYPE      │ FEEDBACK        │ STATUS     │ RESOLUTION              │ ...
│ Rohan   │ complaint │ Was overcharged │ [resolved] │ Refunded the fee and a… │
```

### Chain
- **proto**: `SetFeedbackStatusRequest.note = 5` (backward-compatible)
- **API**: zod `refine` — 400 on resolve without a non-whitespace note; acknowledge unchanged
- **Processor**: stores `payload.note → feedback.status_note`; `getattr`-tolerant of pre-note events/SDK models (and the SDK model is `extra="allow"`, so notes parse even before an explicit SDK field)
- **Projection**: `statusNote` + migration `20260707_121002` (single `ADD COLUMN`)
- **UI**: `ResolveFeedbackModal` (quoted feedback + required note) and a truncated **Resolution** column (full text on hover)

## Tests
- Route: note passthrough (trimmed), 400 on missing/whitespace note when resolving, acknowledge note-free — plus existing suite
- Modal: submit gating (incl. whitespace), trimmed POST body, API error stays open
- Queue: Resolution column renders, Resolve opens the modal without an immediate POST
- Processor (pytest): note stored on resolve; absent note leaves the column untouched

**20 TS + 19 py green; eslint/ruff/tsc clean on touched files.**

## ⚠️ Deploy order
**Platform first** — marketingService must accept `note` and carry it on `feedback.status.changed.v1` (handoff prompt provided separately). A CRM-first demo deploy would collect notes the platform silently drops. Merge is safe anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi