### PR TITLE
feat(marketing): manual contact↔customer linking (search, link, unlink)

### DIFF
--- a/event-processor/src/billie_servicing/handlers/marketing.py
+++ b/event-processor/src/billie_servicing/handlers/marketing.py
@@ -137,7 +137,8 @@ async def handle_contact_linked(pool: asyncpg.Pool, event: Any) -> None:
         pool,
         p.contact_id,
         event.event_type,
-        None,
+        # Manual (staff) links carry the actor; matcher links don't.
+        getattr(p, "actor", None),
         {"customer_id": p.customer_id, "match_basis": p.match_basis},
     )
 
@@ -161,7 +162,7 @@ async def handle_contact_unlinked(pool: asyncpg.Pool, event: Any) -> None:
         pool,
         p.contact_id,
         event.event_type,
-        None,
+        getattr(p, "actor", None),
         {"customer_id": p.customer_id, "reason": p.reason},
     )
 

--- a/proto/marketing_service.proto
+++ b/proto/marketing_service.proto
@@ -8,6 +8,12 @@ service MarketingService {
   rpc SetConsent(SetConsentRequest) returns (CommandResponse);
   rpc LogInteraction(LogInteractionRequest) returns (CommandResponse);
   rpc EraseContact(EraseContactRequest) returns (CommandResponse);
+
+  // Manual contact<->customer linking from the CRM (staff command). The
+  // matcher links automatically on mobile/email; these cover the cases it
+  // can't, and undo. Emitted events carry match_basis/reason = "manual".
+  rpc LinkContact(LinkContactRequest) returns (CommandResponse);
+  rpc UnlinkContact(UnlinkContactRequest) returns (CommandResponse);
   rpc SubmitFeedback(SubmitFeedbackRequest) returns (SubmitFeedbackResponse);
   rpc CreateBatch(CreateBatchRequest) returns (CreateBatchResponse);
   rpc AssignBatch(AssignBatchRequest) returns (AssignBatchResponse);
@@ -83,6 +89,19 @@ message LogInteractionRequest {
 }
 
 message EraseContactRequest {
+  string idempotency_key = 1;
+  string contact_id = 2;
+  string actor = 3;
+}
+
+message LinkContactRequest {
+  string idempotency_key = 1;
+  string contact_id = 2;
+  string customer_id = 3;
+  string actor = 4;
+}
+
+message UnlinkContactRequest {
   string idempotency_key = 1;
   string contact_id = 2;
   string actor = 3;

--- a/src/app/api/marketing/contacts/[contactId]/link/route.ts
+++ b/src/app/api/marketing/contacts/[contactId]/link/route.ts
@@ -1,0 +1,69 @@
+/**
+ * API Route: POST /api/marketing/contacts/[contactId]/link
+ *
+ * Manually link a marketing contact to a customer via
+ * MarketingService.LinkContact — the matcher links automatically on
+ * mobile/email; this covers the cases it can't. The customer_id comes from
+ * the staff customer search picker, so it references a real customer row.
+ * Re-linking an already-linked contact overwrites (the correction path).
+ * Gated on `canMarketing`. Idempotency key is stable per (contact, customer)
+ * so a double-click can't double-emit.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { canMarketing } from '@/lib/access'
+import { LinkContactSchema } from '@/lib/schemas/marketing'
+import { linkContact } from '@/server/marketing-grpc-client'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ contactId: string }> },
+) {
+  const auth = await requireAuth(canMarketing)
+  if ('error' in auth) return auth.error
+  const { user } = auth
+  const { contactId } = await params
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: { code: 'VALIDATION_ERROR', message: 'Body must be valid JSON' } },
+      { status: 400 },
+    )
+  }
+
+  const parsed = LinkContactSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid link payload',
+          details: parsed.error.flatten().fieldErrors,
+        },
+      },
+      { status: 400 },
+    )
+  }
+
+  const { customer_id: customerId } = parsed.data
+
+  try {
+    const result = await linkContact({
+      idempotencyKey: `link:${contactId}:${customerId}`,
+      contactId,
+      customerId,
+      actor: String(user.id),
+    })
+    return NextResponse.json({ contactId, eventId: result.eventId }, { status: 202 })
+  } catch (e) {
+    console.error('[Marketing Link Contact] gRPC error:', e)
+    return NextResponse.json(
+      { error: { code: 'COMMAND_FAILED', message: 'Linking the contact failed. Please retry.' } },
+      { status: 503 },
+    )
+  }
+}

--- a/src/app/api/marketing/contacts/[contactId]/unlink/route.ts
+++ b/src/app/api/marketing/contacts/[contactId]/unlink/route.ts
@@ -1,0 +1,40 @@
+/**
+ * API Route: POST /api/marketing/contacts/[contactId]/unlink
+ *
+ * Remove a contact's customer link via MarketingService.UnlinkContact
+ * (reason="manual"). The platform rejects unlinking an unlinked contact
+ * (FAILED_PRECONDITION → surfaced as COMMAND_FAILED). Gated on
+ * `canMarketing`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { canMarketing } from '@/lib/access'
+import { unlinkContact } from '@/server/marketing-grpc-client'
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ contactId: string }> },
+) {
+  const auth = await requireAuth(canMarketing)
+  if ('error' in auth) return auth.error
+  const { user } = auth
+  const { contactId } = await params
+
+  try {
+    const result = await unlinkContact({
+      idempotencyKey: `unlink:${contactId}`,
+      contactId,
+      actor: String(user.id),
+    })
+    return NextResponse.json({ contactId, eventId: result.eventId }, { status: 202 })
+  } catch (e) {
+    console.error('[Marketing Unlink Contact] gRPC error:', e)
+    return NextResponse.json(
+      {
+        error: { code: 'COMMAND_FAILED', message: 'Unlinking the contact failed. Please retry.' },
+      },
+      { status: 503 },
+    )
+  }
+}

--- a/src/components/MarketingView/ContactDetail.tsx
+++ b/src/components/MarketingView/ContactDetail.tsx
@@ -7,6 +7,8 @@ import { toast } from 'sonner'
 import { useMarketingContact, marketingContactQueryKey } from '@/hooks/queries/useMarketingContact'
 import { useContactReferrals } from '@/hooks/queries/useContactReferrals'
 import { useFeedbackQueue } from '@/hooks/queries/useFeedbackQueue'
+import { useUnlinkContact } from '@/hooks/mutations/useMarketingCommands'
+import { LinkCustomerModal } from './LinkCustomerModal'
 import type { ContactAuditLog, Interaction } from '@/payload-types'
 import { formatDateMedium } from '@/lib/formatters'
 import { getMarketingConsentGranted } from '@/lib/marketing'
@@ -121,6 +123,9 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
   const { data: feedback } = useFeedbackQueue({ contact_id: contactId })
   const queryClient = useQueryClient()
   const [noteText, setNoteText] = useState('')
+  const [showLinkModal, setShowLinkModal] = useState(false)
+  const [showUnlinkConfirm, setShowUnlinkConfirm] = useState(false)
+  const unlink = useUnlinkContact()
 
   const logNoteMutation = useMutation({
     mutationFn: logNote,
@@ -237,6 +242,57 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
         </div>
 
         <div className={styles.detailRight}>
+          {/* Manual contact<->customer linking (LinkContact/UnlinkContact
+              commands). Fixed layout: both buttons always present; Unlink
+              disables when there is no link to remove. */}
+          <Panel title="Customer link">
+            <div className={styles.panelRow}>
+              <span className={styles.panelRowLabel}>Status</span>
+              <span className={styles.panelRowValue}>
+                {contact.customerId ? 'Linked' : 'Not linked'}
+              </span>
+            </div>
+            <div className={styles.panelRow}>
+              <span className={styles.panelRowLabel}>Customer</span>
+              <span className={styles.panelRowValue}>
+                {contact.customerId ? (
+                  <Link href={`/admin/servicing/${contact.customerId}`} className={styles.nameLink}>
+                    {contact.customerId}
+                  </Link>
+                ) : (
+                  '—'
+                )}
+              </span>
+            </div>
+            <div className={styles.panelRow}>
+              <span className={styles.panelRowLabel}>Basis</span>
+              <span className={styles.panelRowValue}>{contact.linkBasis ?? '—'}</span>
+            </div>
+            <div className={styles.panelRow}>
+              <span className={styles.panelRowLabel}>Linked</span>
+              <span className={styles.panelRowValue}>
+                {contact.linkedAt ? formatDateMedium(contact.linkedAt) : '—'}
+              </span>
+            </div>
+            <div className={styles.panelButtonRow}>
+              <button
+                type="button"
+                className={styles.pageButton}
+                onClick={() => setShowLinkModal(true)}
+              >
+                {contact.customerId ? 'Change…' : 'Link customer…'}
+              </button>
+              <button
+                type="button"
+                className={styles.pageButton}
+                onClick={() => setShowUnlinkConfirm(true)}
+                disabled={!contact.customerId || unlink.isPending}
+              >
+                {unlink.isPending ? 'Unlinking…' : 'Unlink'}
+              </button>
+            </div>
+          </Panel>
+
           <Panel title="Consent history">
             {consentHistory.length === 0 ? (
               <div className={styles.panelEmpty}>—</div>
@@ -318,6 +374,61 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
           </Panel>
         </div>
       </div>
+
+      {showLinkModal && (
+        <LinkCustomerModal
+          contactId={contactId}
+          contactName={contact.firstName ?? 'this contact'}
+          onClose={() => setShowLinkModal(false)}
+        />
+      )}
+
+      {showUnlinkConfirm && (
+        <div className={styles.modalOverlay} onClick={() => setShowUnlinkConfirm(false)}>
+          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <h2 className={styles.modalTitle}>Unlink customer</h2>
+              <button
+                type="button"
+                className={styles.closeBtn}
+                onClick={() => setShowUnlinkConfirm(false)}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+            <div className={styles.modalBody}>
+              <p>
+                Remove the link between <strong>{contact.firstName ?? 'this contact'}</strong> and
+                customer <strong>{contact.customerId}</strong>?
+              </p>
+              <p className={styles.formHint}>
+                The matcher may re-link automatically if the contact&apos;s mobile or email matches
+                a customer record.
+              </p>
+            </div>
+            <div className={styles.modalFooter}>
+              <button
+                type="button"
+                className={styles.btnCancel}
+                onClick={() => setShowUnlinkConfirm(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={styles.btnSubmit}
+                onClick={() =>
+                  unlink.mutate(contactId, { onSettled: () => setShowUnlinkConfirm(false) })
+                }
+                disabled={unlink.isPending}
+              >
+                {unlink.isPending ? 'Unlinking…' : 'Unlink'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/MarketingView/LinkCustomerModal.tsx
+++ b/src/components/MarketingView/LinkCustomerModal.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useCustomerSearch } from '@/hooks/queries/useCustomerSearch'
+import type { CustomerSearchResult } from '@/hooks/queries/useCustomerSearch'
+import { useLinkContact } from '@/hooks/mutations/useMarketingCommands'
+import styles from './styles.module.css'
+
+interface LinkCustomerModalProps {
+  contactId: string
+  contactName: string
+  onClose: () => void
+}
+
+/**
+ * Search-and-select picker for manually linking a contact to a customer.
+ * Reuses the staff customer search (name / email / mobile / customer ID,
+ * min 3 chars). The selected customerId goes to LinkContact
+ * (match_basis="manual"); the matcher keeps handling automatic links.
+ */
+export const LinkCustomerModal: React.FC<LinkCustomerModalProps> = ({
+  contactId,
+  contactName,
+  onClose,
+}) => {
+  const [query, setQuery] = useState('')
+  const [selected, setSelected] = useState<CustomerSearchResult | null>(null)
+
+  const { data, isFetching } = useCustomerSearch(query)
+  const link = useLinkContact()
+  const results = data?.results ?? []
+  const canSubmit = !!selected && !link.isPending
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit || !selected) return
+    link.mutate({ contactId, customerId: selected.customerId }, { onSuccess: () => onClose() })
+  }
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h2 className={styles.modalTitle}>Link {contactName} to a customer</h2>
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className={styles.modalBody}>
+            {link.isError && (
+              <div className={styles.errorMessage}>
+                {link.error instanceof Error ? link.error.message : 'Failed to link contact'}
+              </div>
+            )}
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="link-customer-search">
+                Search customers
+              </label>
+              <input
+                id="link-customer-search"
+                type="text"
+                className={styles.formInput}
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value)
+                  setSelected(null)
+                }}
+                placeholder="Name, email, mobile, or customer ID"
+                autoFocus
+              />
+              <p className={styles.formHint}>
+                {query.trim().length < 3
+                  ? 'Type at least 3 characters to search.'
+                  : isFetching
+                    ? 'Searching…'
+                    : `${results.length} match(es).`}
+              </p>
+            </div>
+
+            <div className={styles.searchResults} role="listbox" aria-label="Customer results">
+              {results.length === 0 ? (
+                <div className={styles.panelEmpty}>
+                  {query.trim().length < 3 ? '—' : 'No customers match.'}
+                </div>
+              ) : (
+                results.map((c) => (
+                  <button
+                    key={c.customerId}
+                    type="button"
+                    role="option"
+                    aria-selected={selected?.customerId === c.customerId}
+                    className={`${styles.searchResult} ${
+                      selected?.customerId === c.customerId ? styles.searchResultSelected : ''
+                    }`}
+                    onClick={() => setSelected(c)}
+                  >
+                    <span className={styles.panelRowPrimary}>{c.fullName ?? '—'}</span>
+                    <span className={styles.panelRowMeta}>
+                      {c.customerId}
+                      {c.emailAddress ? ` · ${c.emailAddress}` : ''}
+                      {c.identityVerified ? ' · ✓ ID verified' : ''}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+
+            <div className={styles.panelRow}>
+              <span className={styles.panelRowLabel}>Selected</span>
+              <span className={styles.panelRowValue}>
+                {selected ? `${selected.fullName ?? '—'} (${selected.customerId})` : '—'}
+              </span>
+            </div>
+          </div>
+
+          <div className={styles.modalFooter}>
+            <button type="button" className={styles.btnCancel} onClick={onClose}>
+              Cancel
+            </button>
+            <button type="submit" className={styles.btnSubmit} disabled={!canSubmit}>
+              {link.isPending ? 'Linking…' : 'Link customer'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default LinkCustomerModal

--- a/src/components/MarketingView/styles.module.css
+++ b/src/components/MarketingView/styles.module.css
@@ -421,6 +421,48 @@
   margin-left: auto;
 }
 
+/* Customer-link panel action row (fixed layout — both buttons always shown). */
+.panelButtonRow {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* Customer picker in the link modal. */
+.searchResults {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+  border: 1px solid var(--theme-elevation-100, #e5e5e5);
+  border-radius: 6px;
+  padding: 4px;
+}
+
+.searchResult {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.searchResult:hover {
+  background: var(--theme-elevation-50, #f5f5f5);
+}
+
+.searchResultSelected {
+  border-color: #2563eb;
+  background: var(--theme-elevation-50, #f5f5f5);
+}
+
 /* Truncated resolution note in the feedback queue (full text in title). */
 .noteCell {
   display: inline-block;

--- a/src/hooks/mutations/useMarketingCommands.ts
+++ b/src/hooks/mutations/useMarketingCommands.ts
@@ -104,6 +104,41 @@ export function useSetFeedbackStatus() {
   })
 }
 
+export interface LinkContactVars {
+  contactId: string
+  customerId: string
+}
+
+/** Manually link a contact to a customer (marketing detail view). */
+export function useLinkContact() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: LinkContactVars) =>
+      postCommand(`/api/marketing/contacts/${encodeURIComponent(vars.contactId)}/link`, {
+        customer_id: vars.customerId,
+      }),
+    onSuccess: () => {
+      toast.success('Contact linked')
+      qc.invalidateQueries({ queryKey: ['marketing-contacts'] })
+    },
+    onError: (e: Error) => toast.error('Failed to link contact', { description: e.message }),
+  })
+}
+
+/** Remove a contact's customer link (marketing detail view). */
+export function useUnlinkContact() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (contactId: string) =>
+      postCommand(`/api/marketing/contacts/${encodeURIComponent(contactId)}/unlink`),
+    onSuccess: () => {
+      toast.success('Contact unlinked')
+      qc.invalidateQueries({ queryKey: ['marketing-contacts'] })
+    },
+    onError: (e: Error) => toast.error('Failed to unlink contact', { description: e.message }),
+  })
+}
+
 export interface CreateContactVars {
   first_name?: string
   email?: string

--- a/src/lib/schemas/marketing.ts
+++ b/src/lib/schemas/marketing.ts
@@ -86,6 +86,12 @@ export const AssignBatchSchema = z.object({
 
 export type AssignBatch = z.infer<typeof AssignBatchSchema>
 
+export const LinkContactSchema = z.object({
+  customer_id: z.string().min(1).max(128),
+})
+
+export type LinkContact = z.infer<typeof LinkContactSchema>
+
 export const SetFeedbackStatusSchema = z
   .object({
     status: z.enum(['new', 'acknowledged', 'resolved']),

--- a/src/server/marketing-grpc-client.ts
+++ b/src/server/marketing-grpc-client.ts
@@ -117,6 +117,19 @@ export interface EraseContactInput {
   actor?: string
 }
 
+export interface LinkContactInput {
+  idempotencyKey: string
+  contactId: string
+  customerId: string
+  actor?: string
+}
+
+export interface UnlinkContactInput {
+  idempotencyKey: string
+  contactId: string
+  actor?: string
+}
+
 export interface CommandResult {
   contactId: string
   eventId: string
@@ -258,6 +271,14 @@ export class MarketingClient {
     return this.promisify<EraseContactInput, CommandResult>(this.client.eraseContact)(request)
   }
 
+  async linkContact(request: LinkContactInput): Promise<CommandResult> {
+    return this.promisify<LinkContactInput, CommandResult>(this.client.linkContact)(request)
+  }
+
+  async unlinkContact(request: UnlinkContactInput): Promise<CommandResult> {
+    return this.promisify<UnlinkContactInput, CommandResult>(this.client.unlinkContact)(request)
+  }
+
   async submitFeedback(request: SubmitFeedbackInput): Promise<SubmitFeedbackResult> {
     return this.promisify<SubmitFeedbackInput, SubmitFeedbackResult>(this.client.submitFeedback)(
       request,
@@ -322,6 +343,14 @@ export async function logInteraction(request: LogInteractionInput): Promise<Comm
 
 export async function eraseContact(request: EraseContactInput): Promise<CommandResult> {
   return getMarketingClient().eraseContact(request)
+}
+
+export async function linkContact(request: LinkContactInput): Promise<CommandResult> {
+  return getMarketingClient().linkContact(request)
+}
+
+export async function unlinkContact(request: UnlinkContactInput): Promise<CommandResult> {
+  return getMarketingClient().unlinkContact(request)
 }
 
 export async function submitFeedback(request: SubmitFeedbackInput): Promise<SubmitFeedbackResult> {

--- a/tests/unit/components/LinkCustomerModal.test.tsx
+++ b/tests/unit/components/LinkCustomerModal.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { LinkCustomerModal } from '@/components/MarketingView/LinkCustomerModal'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const CONTACT_ID = 'a79ae28f-2e9d-4650-b466-b5a00e5abfc5'
+
+const searchResponse = {
+  results: [
+    {
+      id: 1,
+      customerId: '08F7B13B',
+      fullName: 'John Smith',
+      emailAddress: 'john@example.com',
+      identityVerified: true,
+      accountCount: 1,
+    },
+    {
+      id: 2,
+      customerId: '0A11C22D',
+      fullName: 'Joan Park',
+      emailAddress: null,
+      identityVerified: false,
+      accountCount: 0,
+    },
+  ],
+  total: 2,
+}
+
+const renderModal = (onClose = vi.fn()) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <LinkCustomerModal contactId={CONTACT_ID} contactName="Rohan" onClose={onClose} />
+    </QueryClientProvider>,
+  )
+  return onClose
+}
+
+beforeEach(() => {
+  cleanup()
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    return {
+      ok: true,
+      json: async () =>
+        url.includes('/api/customer/search') ? searchResponse : { contactId: CONTACT_ID },
+    }
+  }) as unknown as typeof fetch
+})
+
+describe('LinkCustomerModal', () => {
+  it('searches once ≥3 chars and renders selectable results', async () => {
+    renderModal()
+    expect(screen.getByText('Type at least 3 characters to search.')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Search customers'), { target: { value: 'jo' } })
+    // Still below threshold — no search call.
+    expect(
+      (global.fetch as ReturnType<typeof vi.fn>).mock.calls.filter((c) =>
+        String(c[0]).includes('/api/customer/search'),
+      ),
+    ).toHaveLength(0)
+
+    fireEvent.change(screen.getByLabelText('Search customers'), { target: { value: 'john' } })
+    await waitFor(() => expect(screen.getByText('John Smith')).toBeInTheDocument())
+    expect(screen.getByText(/✓ ID verified/)).toBeInTheDocument()
+    expect(screen.getByText('Joan Park')).toBeInTheDocument()
+  })
+
+  it('Link stays disabled until a customer is selected, then POSTs and closes', async () => {
+    const onClose = renderModal()
+    const submit = screen.getByRole('button', { name: 'Link customer' })
+    expect(submit).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Search customers'), { target: { value: 'john' } })
+    fireEvent.click(await screen.findByRole('option', { name: /John Smith/ }))
+    expect(screen.getByText('John Smith (08F7B13B)')).toBeInTheDocument()
+    expect(submit).not.toBeDisabled()
+
+    fireEvent.click(submit)
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+
+    const linkCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.find((c) =>
+      String(c[0]).includes('/link'),
+    )!
+    expect(String(linkCall[0])).toBe(`/api/marketing/contacts/${CONTACT_ID}/link`)
+    expect(JSON.parse((linkCall[1] as RequestInit).body as string)).toEqual({
+      customer_id: '08F7B13B',
+    })
+  })
+
+  it('changing the query clears the selection', async () => {
+    renderModal()
+    fireEvent.change(screen.getByLabelText('Search customers'), { target: { value: 'john' } })
+    fireEvent.click(await screen.findByRole('option', { name: /John Smith/ }))
+    fireEvent.change(screen.getByLabelText('Search customers'), { target: { value: 'joan' } })
+    expect(screen.getByRole('button', { name: 'Link customer' })).toBeDisabled()
+  })
+})

--- a/tests/unit/routes/marketingLinkContact.test.ts
+++ b/tests/unit/routes/marketingLinkContact.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Manual contact<->customer linking routes:
+ *   POST /api/marketing/contacts/[contactId]/link    (LinkContact)
+ *   POST /api/marketing/contacts/[contactId]/unlink  (UnlinkContact)
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((body: unknown, init?: { status?: number }) => ({
+      body,
+      status: init?.status ?? 200,
+    })),
+  },
+}))
+
+const authHolder = vi.hoisted(() => ({
+  current: { user: { id: 'staff-1' } } as Record<string, unknown>,
+}))
+vi.mock('@/lib/auth', () => ({
+  requireAuth: vi.fn(async () => authHolder.current),
+}))
+
+const grpc = vi.hoisted(() => ({
+  linkContact: vi.fn(),
+  unlinkContact: vi.fn(),
+}))
+vi.mock('@/server/marketing-grpc-client', () => grpc)
+
+import { POST as linkPost } from '@/app/api/marketing/contacts/[contactId]/link/route'
+import { POST as unlinkPost } from '@/app/api/marketing/contacts/[contactId]/unlink/route'
+
+function req(body?: unknown): NextRequest {
+  return new Request('http://x/api/marketing', {
+    method: 'POST',
+    body: body === undefined ? undefined : JSON.stringify(body),
+  }) as unknown as NextRequest
+}
+const p = <T extends Record<string, string>>(v: T) => ({ params: Promise.resolve(v) })
+
+beforeEach(() => {
+  authHolder.current = { user: { id: 'staff-1' } }
+  grpc.linkContact.mockReset().mockResolvedValue({ contactId: 'c-1', eventId: 'e-1' })
+  grpc.unlinkContact.mockReset().mockResolvedValue({ contactId: 'c-1', eventId: 'e-2' })
+})
+
+describe('POST /api/marketing/contacts/[contactId]/link (LinkContact)', () => {
+  test('202 + stable idempotency key link:{contact}:{customer}, actor = staff id', async () => {
+    const res = (await linkPost(
+      req({ customer_id: 'CUST-1' }),
+      p({ contactId: 'c-1' }),
+    )) as unknown as {
+      body: { contactId: string }
+      status: number
+    }
+    expect(res.status).toBe(202)
+    expect(res.body.contactId).toBe('c-1')
+    const arg = grpc.linkContact.mock.calls[0][0]
+    expect(arg).toEqual({
+      idempotencyKey: 'link:c-1:CUST-1',
+      contactId: 'c-1',
+      customerId: 'CUST-1',
+      actor: 'staff-1',
+    })
+  })
+
+  test('400 on a missing customer_id', async () => {
+    const res = (await linkPost(req({}), p({ contactId: 'c-1' }))) as unknown as { status: number }
+    expect(res.status).toBe(400)
+    expect(grpc.linkContact).not.toHaveBeenCalled()
+  })
+
+  test('503 when the gRPC command fails', async () => {
+    grpc.linkContact.mockRejectedValueOnce(new Error('boom'))
+    const res = (await linkPost(
+      req({ customer_id: 'CUST-1' }),
+      p({ contactId: 'c-1' }),
+    )) as unknown as {
+      status: number
+      body: { error: { code: string } }
+    }
+    expect(res.status).toBe(503)
+    expect(res.body.error.code).toBe('COMMAND_FAILED')
+  })
+
+  test('returns the auth error when requireAuth denies', async () => {
+    authHolder.current = { error: { body: { error: 'nope' }, status: 403 } }
+    const res = (await linkPost(
+      req({ customer_id: 'CUST-1' }),
+      p({ contactId: 'c-1' }),
+    )) as unknown as {
+      status: number
+    }
+    expect(res.status).toBe(403)
+    expect(grpc.linkContact).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/marketing/contacts/[contactId]/unlink (UnlinkContact)', () => {
+  test('202 + stable idempotency key unlink:{contact}', async () => {
+    const res = (await unlinkPost(req(), p({ contactId: 'c-1' }))) as unknown as {
+      body: { contactId: string }
+      status: number
+    }
+    expect(res.status).toBe(202)
+    const arg = grpc.unlinkContact.mock.calls[0][0]
+    expect(arg).toEqual({
+      idempotencyKey: 'unlink:c-1',
+      contactId: 'c-1',
+      actor: 'staff-1',
+    })
+  })
+
+  test('503 when the platform rejects (e.g. contact not linked)', async () => {
+    grpc.unlinkContact.mockRejectedValueOnce(new Error('FAILED_PRECONDITION'))
+    const res = (await unlinkPost(req(), p({ contactId: 'c-1' }))) as unknown as { status: number }
+    expect(res.status).toBe(503)
+  })
+})


### PR DESCRIPTION
## Summary

Staff can now **manually link a contact to a customer** — search, select, link — and **remove a link**. Companion to billie-platform-services **#56** (`LinkContact`/`UnlinkContact` RPCs); the matcher keeps handling automatic links, these cover the cases it can't.

```
┌─ Customer link ────────────────┐   Link customer… ──► ┌─ Link Rohan to a customer ──────────┐
│ Status    Not linked           │                      │ Search  [john…              ]       │
│ Customer  —                    │                      │ ┌──────────────────────────────────┐│
│ Basis     —                    │                      │ │ John Smith                       ││
│ Linked    —                    │                      │ │ 08F7B13B · john@x.com · ✓ ID     ││
│ [Link customer…] [Unlink]      │                      │ │ Joan Park                        ││
└────────────────────────────────┘                      │ │ 0A11C22D                         ││
   after linking:                                       │ └──────────────────────────────────┘│
│ Status    Linked               │                      │ Selected  John Smith (08F7B13B)     │
│ Customer  08F7B13B →           │                      │            [Cancel] [Link customer] │
│ Basis     manual               │                      └─────────────────────────────────────┘
│ [Change…] [Unlink]             │
```

- **Panel** on the contact detail (fixed layout: both buttons always present; Unlink disabled when not linked; Customer links through to servicing)
- **Search picker** reuses the staff `useCustomerSearch` (≥3 chars — name/email/mobile/customer ID) with ID-verified markers
- **Unlink confirms** first, and warns the matcher may re-link automatically on identifier match
- **Audit**: manual link/unlink events record the acting staff id (matcher events keep `actor=None`)
- Projection/processor need no schema change — `contact.linked.v1`/`contact.unlinked.v1` handlers already existed

## Tests
Routes (stable idempotency keys `link:{contact}:{customer}` / `unlink:{contact}`, actor passthrough, 400/503/auth-denial), modal (search threshold, select→POST→close, selection reset on query change), pytest suite green. eslint/tsc clean on touched files.

## Deploy order
Platform **#56 first** — until then Link/Unlink surface as 503 COMMAND_FAILED (UNIMPLEMENTED underneath); nothing breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi