### PR TITLE
feat(marketing): Stream B CRM side + needs-review flag (A2) + cutover tooling

### DIFF
--- a/docs/superpowers/plans/2026-07-08-marketing-cutover-runbook.md
+++ b/docs/superpowers/plans/2026-07-08-marketing-cutover-runbook.md
@@ -1,0 +1,57 @@
+# Marketing cutover runbook — Apps Script retirement (C1)
+
+**Goal:** all marketing sends flow through the platform (notificationService
+pipeline); the legacy Google Apps Script sender is retired; its send history
+is preserved on contact timelines.
+
+## Pre-conditions (all shipped)
+
+- Stream A end-to-end verified on demo (batches → invitations → dispatcher;
+  consent + needs-review gates enforced platform-side).
+- Stream B deployed (customer state projection → derived stages), so
+  segmentation (win-back, applicant exclusion) is live-data driven.
+- ClickSend inbound webhook live (replies land on timelines regardless of
+  which system sent the outbound).
+
+## Cutover order
+
+1. **Freeze the Apps Script sender** (disable its trigger in the Apps Script
+   console). From this moment the platform is the only sender.
+2. **Export the send log** from the Sheet as CSV with headers:
+   `timestamp, mobile, channel, subject, body` (extra columns ignored).
+3. **Backfill** the history into contact timelines:
+
+   ```bash
+   # from event-processor/, with demo/prod DATABASE_URI + MARKETING_GRPC_ADDRESS
+   python -m scripts.backfill_sendlog export.csv --dry-run   # counts + unmatched review
+   python -m scripts.backfill_sendlog export.csv             # idempotent (row-hash keys)
+   ```
+
+   Rows whose mobile matches no contact are written to
+   `export.unmatched.csv` — review these: genuinely unknown numbers can be
+   ignored; known people missing from the contacts projection should be
+   added via waitlist intake (or `import_waitlist`) and the importer re-run
+   (idempotency keys make re-runs safe).
+4. **Verify**: spot-check several contacts' timelines for
+   `message_out · source_system=apps_script` interactions; compare row
+   counts (`imported` vs sheet rows minus unmatched).
+5. **Retire**: archive the Apps Script project + revoke its ClickSend/WhatsApp
+   credentials. Record the retirement date below.
+
+## Decision record
+
+- **B1 (WhatsApp timing), decided 2026-07-08:** hold the phase-3 default —
+  SMS/email first through the platform pipeline. Rationale: WhatsApp needs a
+  Meta business account + pre-approved templates (external lead time Billie
+  does not control) and is the largest single chunk of phase 3; nothing else
+  in the cutover depends on it. **Parallel external task: start Meta template
+  approval now** so phase 3 isn't gated on it. Replies to any legacy WhatsApp
+  threads still surface via the inbound webhook path.
+- Retirement date: _________ (fill at execution)
+
+## Rollback
+
+The Apps Script trigger can be re-enabled at any point before step 5; the
+backfill is additive and idempotent, so no data cleanup is needed to roll
+back. After step 5, rollback means re-issuing credentials — prefer fixing
+forward through the platform pipeline.

--- a/docs/superpowers/plans/2026-07-08-marketing-cutover-runbook.md
+++ b/docs/superpowers/plans/2026-07-08-marketing-cutover-runbook.md
@@ -55,3 +55,13 @@ The Apps Script trigger can be re-enabled at any point before step 5; the
 backfill is additive and idempotent, so no data cleanup is needed to roll
 back. After step 5, rollback means re-issuing credentials — prefer fixing
 forward through the platform pipeline.
+
+## Deferred items (explicit — decided 8 Jul 2026 review passes)
+
+| Item | Why deferred | Where it lands |
+|---|---|---|
+| Batch send-history persistence (per-batch invited/skipped counts on the projection, not just the toast) | Needs a batch-outcome event + alembic + CRM migration; interactions already record per-contact `message_out` | Phase 3, with the campaign-measurement work |
+| Collections `stop_contact` ↔ marketing suppression bridge (customer-level suppression consulted for contact-addressed sends) | Cross-service design decision — suppression is keyed by customer_id in collections, contact_id in marketing; needs the collections owner | Raise with collections owner; candidate: dispatcher gate checks linked customer suppression |
+| Grid keyboard navigation (j/k/Enter, per AccountsBrowser) | UX polish, mouse + name-link paths work | Next UI pass |
+| XDEL stream sweep + subject-access export (full DSR) | Already-governed phase-3 scope (spec §10); projection + feedback + evidence redaction is DONE | Phase 3 |
+| WhatsApp provider + templates | B1 decision — external Meta lead time | Phase 3 (start template approval now) |

--- a/docs/superpowers/specs/2026-07-02-marketing-crm-customer-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-02-marketing-crm-customer-lifecycle-design.md
@@ -143,7 +143,7 @@ Auth: internal network (Fly private networking), same posture as the accounting-
 
 ## 3. Customer state projection (new module in `customerService`)
 
-> **Open at sign-off (A4, discuss):** this added workstream — the governed Customer State Model driving stage and loan status — is under discussion; scope and sequencing may change. Per §10, it can slip to phase 3 without blocking the rest of phase 2.
+> **BUILT (8 Jul 2026, billie-platform-services #57 + billieChat #134):** the A4 workstream was assessed as load-bearing for win-back/lifecycle segmentation and implemented. **Flagged decision #1 resolved without inference or new billieChat work:** billieChat already emits `customer.contact.verified.v1` on OTP pass — it was simply never routed to a projection; the state module consumes it directly (A3). A4 derives from `ekyc_status` on `customer.changed.v1` (verified-value set), with `customer.verified.v1` also honoured if emitted.
 
 Implements the governed A × B\* × C × L tuple as a derived projection — platform-owned, exactly per the state model's D14 (C and L are projections over agreement records) and R4 (events move states; treatments read states).
 
@@ -174,7 +174,7 @@ The stage on a contact is **derived, never hand-edited** — computed by marketi
 
 **Advocate is a flag overlay, not a stage** (per D16: type tests are attributes): `advocate = true` when ≥1 attributed referral reached Customer. The CRM grid can still filter/present it as a pseudo-stage.
 
-> **Open at sign-off (A2, discuss):** whether staff get a manual stage override or an "Other / needs review" stage, so we're never locked out of reclassifying as new situations emerge. Derivation-only stands until that discussion lands; if an override is approved it will be an explicit, audited command (an attribute overlay the derivation respects), never a hand-edit of the derived field. Note the general `attributes` field already absorbs unexpected campaign data — the gap is specifically stage correction.
+> **DECIDED + BUILT (8 Jul 2026):** no manual stage override — derivation stays authoritative (the §4 precedence list is safety-critical: it prevents messaging into open applications). Instead, staff get an audited **needs-review flag** (`attributes.needs_review`, per the model's D16 ruling that type tests are attributes — the same mechanism as advocate): flagged contacts are excluded from every invitation send (`skipped_needs_review` on TriggerBatchInvitations) and filterable in the grid, with reason + actor on the audit trail. Combined with batches (manual segmentation) and manual contact↔customer linking, this covers reclassification needs without letting a stale manual pin contradict live state.
 
 Loan-status mirror (minimal, per brief §3): `approved` (B1) / `disbursed` (B4 or L) / `repaid` (C-P ∧ ¬L). No amounts — structurally impossible (§2.2).
 
@@ -333,13 +333,13 @@ WhatsApp provider client + webhook; DSR tooling complete (erase incl. XDEL sweep
 
 | # | Decision | Default in this spec | Owner to confirm | Status (sign-off, 7 Jul 2026) |
 |---|---|---|---|---|
-| 1 | OTP-pass event from billieChat vs A3 inference | billieChat emits explicit event | billieChat owner, phase-2 planning | open — awareness item (Part C), billieChat owner to confirm |
-| 2 | WhatsApp before or after cutover | after (phase 3), SMS-first cutover | marketing/product | in discussion (B1) — default stands until resolved |
+| 1 | OTP-pass event from billieChat vs A3 inference | billieChat emits explicit event | billieChat owner, phase-2 planning | **RESOLVED (8 Jul)** — `customer.contact.verified.v1` already existed; now routed to the state projector (billieChat #134) |
+| 2 | WhatsApp before or after cutover | after (phase 3), SMS-first cutover | marketing/product | **DECIDED (8 Jul)** — default held (external Meta-template lead time); start template approval in parallel; see cutover runbook |
 | 3 | Referral URL resolution on website | `/r/{code}` redirect → form `ref` param | web owner | open — awareness item (Part C), web owner to confirm |
 | 4 | `ADMIN_CLOSED` mapping | ~~conservative C-N~~ → **C-P (win-back-eligible) + review flag** | product/credit, phase 3 | **changed (B2)** — incorporated in §3; `SETTLED_SHORT` at source remains phase 3 |
 | 5 | Bx timeout window | 30 days inactivity | product | **approved as default (B3)** |
-| 6 | Manual stage override / "Other — needs review" stage | none — stage strictly derived (§4) | product + design | in discussion (A2) |
-| 7 | Customer State Model + state-projection workstream | new module in customerService (§3) | product/platform | in discussion (A4) |
+| 6 | Manual stage override / "Other — needs review" stage | none — stage strictly derived (§4) | product + design | **DECIDED + BUILT (8 Jul)** — needs-review flag, no override (§4 note) |
+| 7 | Customer State Model + state-projection workstream | new module in customerService (§3) | product/platform | **BUILT (8 Jul)** — platform #57 + billieChat #134 (§3 note) |
 
 ## 14. Sign-off record (7 July 2026)
 

--- a/event-processor/scripts/backfill_sendlog.py
+++ b/event-processor/scripts/backfill_sendlog.py
@@ -1,0 +1,155 @@
+"""C1 cutover: backfill the legacy Apps Script send log into marketing interactions.
+
+The pre-cutover stack sent SMS/WhatsApp via Google Apps Script; its send log
+(exported to CSV) is the only record of those sends. This importer replays each
+row as a marketingService LogInteraction (kind=message_out,
+source_system=apps_script) against the contact resolved by mobile, so
+pre-cutover sends appear on contact timelines exactly like platform sends.
+
+Usage (run wherever DATABASE_URI + MARKETING_GRPC_ADDRESS reach the target env):
+
+    python -m scripts.backfill_sendlog export.csv --dry-run
+    python -m scripts.backfill_sendlog export.csv
+
+CSV columns (header required; extra columns ignored):
+    timestamp  — ISO-8601 or `DD/MM/YYYY HH:MM[:SS]` (AU sheet format)
+    mobile     — recipient (any AU format; normalised to E.164)
+    channel    — sms | whatsapp (defaults to sms)
+    subject    — optional (template name)
+    body       — message text
+
+Idempotent: the LogInteraction idempotency key is a hash of the raw row, so
+re-running the import (or resuming after a crash) never duplicates
+interactions. Rows whose mobile matches no contact are written to
+`<input>.unmatched.csv` for manual review — they are NOT dropped silently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import asyncpg
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from billie_servicing import marketing_client  # noqa: E402
+from billie_servicing.handlers.clicksend import normalise_au_mobile  # noqa: E402
+
+_AU_TZ = ZoneInfo("Australia/Sydney")
+
+
+def parse_timestamp(raw: str) -> str | None:
+    """Coerce a send-log timestamp to ISO-8601 UTC. Sheet exports use
+    DD/MM/YYYY; ISO inputs pass through."""
+    value = (raw or "").strip()
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        dt = None
+        for fmt in ("%d/%m/%Y %H:%M:%S", "%d/%m/%Y %H:%M", "%d/%m/%Y"):
+            try:
+                dt = datetime.strptime(value, fmt)
+                break
+            except ValueError:
+                continue
+        if dt is None:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=_AU_TZ)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def row_key(row: dict[str, str]) -> str:
+    """Stable idempotency key per raw row — re-imports are no-ops."""
+    canon = json.dumps(
+        {k: (row.get(k) or "").strip() for k in ("timestamp", "mobile", "channel", "subject", "body")},
+        sort_keys=True,
+    )
+    return "appsscript:" + hashlib.sha256(canon.encode()).hexdigest()[:24]
+
+
+async def run(csv_path: Path, *, dry_run: bool) -> int:
+    dsn = os.environ.get("DATABASE_URI")
+    if not dsn:
+        print("DATABASE_URI is required (CRM projection DB, for contact resolution)")
+        return 2
+
+    pool = await asyncpg.create_pool(dsn, min_size=1, max_size=2)
+    imported = skipped_unmatched = skipped_bad = 0
+    unmatched_rows: list[dict[str, str]] = []
+
+    with csv_path.open(newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            mobile = normalise_au_mobile(row.get("mobile"))
+            occurred_at = parse_timestamp(row.get("timestamp", ""))
+            body = (row.get("body") or "").strip()
+            if not mobile or not occurred_at or not body:
+                skipped_bad += 1
+                unmatched_rows.append({**row, "_reason": "unparseable"})
+                continue
+
+            contact_id = await pool.fetchval(
+                "SELECT contact_id FROM contacts WHERE mobile_e164 = $1 AND erased IS NOT TRUE",
+                mobile,
+            )
+            if contact_id is None:
+                skipped_unmatched += 1
+                unmatched_rows.append({**row, "_reason": "no contact"})
+                continue
+
+            if dry_run:
+                imported += 1
+                continue
+
+            await marketing_client.log_interaction(
+                idempotency_key=row_key(row),
+                contact_id=str(contact_id),
+                kind="message_out",
+                channel=(row.get("channel") or "sms").strip().lower(),
+                direction="outbound",
+                subject=(row.get("subject") or "").strip(),
+                body=body,
+                source_system="apps_script",
+                occurred_at=occurred_at,
+                metadata_json=json.dumps({"backfill": "apps_script_sendlog"}),
+                actor="backfill",
+            )
+            imported += 1
+
+    await pool.close()
+
+    if unmatched_rows:
+        out = csv_path.with_suffix(".unmatched.csv")
+        with out.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(unmatched_rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(unmatched_rows)
+        print(f"unmatched/bad rows written to {out}")
+
+    mode = "DRY RUN — would import" if dry_run else "imported"
+    print(f"{mode} {imported}; unmatched {skipped_unmatched}; unparseable {skipped_bad}")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv", type=Path, help="Apps Script send-log CSV export")
+    parser.add_argument("--dry-run", action="store_true", help="resolve + count only, no writes")
+    args = parser.parse_args()
+    raise SystemExit(asyncio.run(run(args.csv, dry_run=args.dry_run)))
+
+
+if __name__ == "__main__":
+    main()

--- a/event-processor/src/billie_servicing/handlers/clicksend.py
+++ b/event-processor/src/billie_servicing/handlers/clicksend.py
@@ -61,6 +61,28 @@ def _coerce_occurred_at(ts: str | int | None) -> str:
         return ""
 
 
+# Spam Act 2003: an unsubscribe request must actually work. Industry-standard
+# opt-out keywords, matched case-insensitively against the trimmed body (and
+# ClickSend's parsed _keyword field). A message that BEGINS with one counts —
+# "STOP", "Stop please" — but "please stop sending" does not auto-trigger
+# (staff still see it on the timeline).
+OPT_OUT_KEYWORDS = frozenset(
+    {"stop", "stopall", "stop all", "unsubscribe", "opt out", "optout", "end", "quit", "cancel"}
+)
+
+
+def is_opt_out(body: str | None, keyword: str | None = None) -> bool:
+    if keyword and keyword.strip().lower() in OPT_OUT_KEYWORDS:
+        return True
+    text = (body or "").strip().lower()
+    if not text:
+        return False
+    if text in OPT_OUT_KEYWORDS:
+        return True
+    first_word = text.split()[0].rstrip(".!,")
+    return first_word in OPT_OUT_KEYWORDS
+
+
 async def handle_clicksend_inbound(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
     """Handle ``clicksend.inbound.received.v1`` — resolve sender → LogInteraction."""
     payload = _parse_payload(event)
@@ -74,6 +96,10 @@ async def handle_clicksend_inbound(pool: asyncpg.Pool, event: dict[str, Any]) ->
         mobile,
     )
     if not contact_id:
+        # No contact ⇒ nothing to suppress: marketing sends only ever target
+        # contacts, so an unknown number is unreachable by construction. Log
+        # loudly (an opt-out from an unknown number may mean a mis-linked or
+        # erased contact) but there is no consent record to update.
         logger.warning("clicksend inbound: no contact for sender, skipping", mobile=mobile)
         return
 
@@ -96,3 +122,19 @@ async def handle_clicksend_inbound(pool: asyncpg.Pool, event: dict[str, Any]) ->
         actor="clicksend",
     )
     logger.info("clicksend inbound logged", contact_id=contact_id, message_id=message_id)
+
+    # Spam Act: STOP/unsubscribe replies withdraw marketing consent
+    # automatically — the dispatcher's fail-closed opt-in gate then blocks all
+    # future marketing sends with no further work.
+    body = payload.get("body") or ""
+    if is_opt_out(body, payload.get("_keyword")):
+        await marketing_client.set_consent(
+            idempotency_key=f"clicksend-optout:{message_id or mobile}",
+            contact_id=contact_id,
+            granted=False,
+            channels=["sms", "whatsapp", "email"],
+            method="sms_stop_reply",
+            evidence=f"Inbound SMS {message_id or '(no id)'}: {body[:200]}",
+            actor="clicksend",
+        )
+        logger.info("clicksend inbound OPT-OUT — consent withdrawn", contact_id=contact_id)

--- a/event-processor/src/billie_servicing/handlers/marketing.py
+++ b/event-processor/src/billie_servicing/handlers/marketing.py
@@ -102,8 +102,12 @@ async def handle_contact_updated(pool: asyncpg.Pool, event: Any) -> None:
         "channel_preference": p.channel_preference,
     }
     changed = {k: v for k, v in candidate.items() if v is not None}
-    if p.attributes is not None:
-        changed["attributes"] = json.dumps(p.attributes)
+    # attributes is a DELTA (the command's patch) — merge it, never overwrite,
+    # or flag overlays (advocate, needs_review) would wipe each other.
+    attributes_patch = p.attributes if p.attributes else None
+    if attributes_patch and "needs_review" in attributes_patch:
+        # Mirror to the dedicated column so the grid can filter on it.
+        changed["needs_review"] = bool(attributes_patch.get("needs_review"))
 
     values = {"contact_id": p.contact_id, **changed, "updated_at": _now()}
     await upsert(
@@ -113,8 +117,18 @@ async def handle_contact_updated(pool: asyncpg.Pool, event: Any) -> None:
         values=values,
         insert_only_columns=[],
     )
+    if attributes_patch:
+        await merge_jsonb(
+            pool,
+            "contacts",
+            column="attributes",
+            key_column="contact_id",
+            key_value=p.contact_id,
+            patch=attributes_patch,
+        )
+    audit_fields = sorted(set(changed) | ({"attributes"} if attributes_patch else set()))
     await _audit(
-        pool, p.contact_id, event.event_type, p.actor, {"changed_fields": sorted(changed.keys())}
+        pool, p.contact_id, event.event_type, p.actor, {"changed_fields": audit_fields}
     )
 
 
@@ -269,7 +283,17 @@ async def handle_contact_stage_changed(pool: asyncpg.Pool, event: Any) -> None:
         "contacts",
         key_column="contact_id",
         key_value=p.contact_id,
-        values={"derived_stage": p.stage, "updated_at": _now()},
+        values={
+            "derived_stage": p.stage,
+            "updated_at": _now(),
+            # Loan-status mirror rides on state-projection-driven stage
+            # changes (spec §4); tolerant of pre-field SDK models.
+            **(
+                {"loan_status": getattr(p, "loan_status", None)}
+                if getattr(p, "loan_status", None) is not None
+                else {}
+            ),
+        },
     )
     await _audit(
         pool,

--- a/event-processor/src/billie_servicing/handlers/marketing.py
+++ b/event-processor/src/billie_servicing/handlers/marketing.py
@@ -278,6 +278,16 @@ async def handle_contact_interaction_logged(pool: asyncpg.Pool, event: Any) -> N
 async def handle_contact_stage_changed(pool: asyncpg.Pool, event: Any) -> None:
     """Handle ``contact.stage.changed.v1`` — flip the ``derived_stage`` column."""
     p = event.payload
+    # Symmetric naive-downgrade guard (mirrors marketingService apply_stage):
+    # only the authoritative state derivation (basis="state") may move a
+    # protected stage back to lead/waitlist — a stray naive event must not
+    # make this projection disagree with the canonical one.
+    if getattr(p, "basis", None) != "state" and p.stage in ("lead", "waitlist"):
+        current = await pool.fetchval(
+            "SELECT derived_stage FROM contacts WHERE contact_id = $1", p.contact_id
+        )
+        if current in ("invited", "applicant", "customer", "former_customer", "closed"):
+            return
     await update_by_key(
         pool,
         "contacts",

--- a/event-processor/src/billie_servicing/handlers/marketing.py
+++ b/event-processor/src/billie_servicing/handlers/marketing.py
@@ -338,6 +338,14 @@ async def handle_contact_erased(pool: asyncpg.Pool, event: Any) -> None:
         json.dumps({}),
         p.contact_id,
     )
+    # DSR completeness: feedback text is free text typed by the data subject —
+    # often the most sensitive content held. Redact it (and the staff
+    # resolution note, which may quote it) alongside interactions.
+    await pool.execute(
+        "UPDATE feedback SET body = NULL, status_note = NULL "
+        "WHERE contact_id_string = $1",
+        p.contact_id,
+    )
     await _audit(pool, p.contact_id, event.event_type, p.actor, {})
 
 

--- a/event-processor/src/billie_servicing/marketing_client.py
+++ b/event-processor/src/billie_servicing/marketing_client.py
@@ -81,3 +81,40 @@ async def log_interaction(
     )
     response = await _get_stub().LogInteraction(request, timeout=5.0)
     return response.event_id
+
+
+async def set_consent(
+    *,
+    idempotency_key: str,
+    contact_id: str,
+    granted: bool,
+    channels: list[str],
+    method: str,
+    evidence: str = "",
+    actor: str = "",
+) -> str:
+    """Issue MarketingService.SetConsent; returns the emitted event_id.
+
+    Used by the inbound-SMS STOP handler to withdraw marketing consent
+    automatically (Spam Act: a functional unsubscribe must actually work).
+    """
+    from .marketing_grpc import marketing_service_pb2 as pb2
+
+    stub = _get_stub()
+    request = pb2.SetConsentRequest(
+        idempotency_key=idempotency_key,
+        contact_id=contact_id,
+        granted=granted,
+        channels=channels,
+        method=method,
+        evidence=evidence,
+        actor=actor,
+    )
+    response = await stub.SetConsent(request, timeout=10.0)
+    logger.info(
+        "marketing SetConsent issued",
+        contact_id=contact_id,
+        granted=granted,
+        event_id=response.event_id,
+    )
+    return response.event_id

--- a/event-processor/tests/test_clicksend_handler.py
+++ b/event-processor/tests/test_clicksend_handler.py
@@ -73,3 +73,53 @@ async def test_inbound_unnormalisable_sender_skips(mock_pool, monkeypatch):
 
     await handle_clicksend_inbound(mock_pool, _event({"from": "garbage", "body": "hi"}))
     log.assert_not_awaited()
+
+
+class TestOptOutDetection:
+    def test_keywords_match_case_insensitively(self):
+        from billie_servicing.handlers.clicksend import is_opt_out
+
+        assert is_opt_out("STOP")
+        assert is_opt_out("stop")
+        assert is_opt_out("Stop please")
+        assert is_opt_out("UNSUBSCRIBE")
+        assert is_opt_out("opt out")
+        assert is_opt_out(None, keyword="STOP")
+        assert not is_opt_out("please stop sending me these")  # mid-sentence
+        assert not is_opt_out("what time do you open?")
+        assert not is_opt_out("")
+        assert not is_opt_out(None)
+
+
+async def test_stop_reply_withdraws_consent(mock_pool, monkeypatch):
+    # Spam Act: a STOP reply must actually withdraw consent, automatically.
+    log = AsyncMock(return_value="ev-1")
+    consent = AsyncMock(return_value="ev-2")
+    monkeypatch.setattr(marketing_client, "log_interaction", log)
+    monkeypatch.setattr(marketing_client, "set_consent", consent)
+    mock_pool.set_fetchval("c-1")
+
+    await handle_clicksend_inbound(
+        mock_pool, _event({"from": "0403320117", "body": "STOP", "message_id": "M-1"})
+    )
+
+    assert log.await_args.kwargs["kind"] == "message_in"
+    kwargs = consent.await_args.kwargs
+    assert kwargs["granted"] is False
+    assert kwargs["method"] == "sms_stop_reply"
+    assert "M-1" in kwargs["evidence"]
+
+
+async def test_normal_reply_does_not_touch_consent(mock_pool, monkeypatch):
+    log = AsyncMock(return_value="ev-1")
+    consent = AsyncMock(return_value="ev-2")
+    monkeypatch.setattr(marketing_client, "log_interaction", log)
+    monkeypatch.setattr(marketing_client, "set_consent", consent)
+    mock_pool.set_fetchval("c-1")
+
+    await handle_clicksend_inbound(
+        mock_pool, _event({"from": "0403320117", "body": "thanks!", "message_id": "M-2"})
+    )
+
+    log.assert_awaited_once()
+    consent.assert_not_awaited()

--- a/event-processor/tests/test_marketing_handlers.py
+++ b/event-processor/tests/test_marketing_handlers.py
@@ -89,13 +89,18 @@ async def test_contact_updated_upserts_changed_fields_and_audit(mock_pool):
         "contact_id": "c-1", "city": "Melbourne", "attributes": {"segment": "vip"},
         "updated_at": "2026-07-02T00:00:00+00:00", "actor": "ops"}))
 
-    contact_row = mock_pool.last_upsert("contacts")
+    contact_row = mock_pool.last_insert("contacts")
     assert contact_row["contact_id"] == "c-1"
     assert contact_row["city"] == "Melbourne"
-    assert json.loads(contact_row["attributes"]) == {"segment": "vip"}
+    # attributes is a DELTA applied via jsonb merge (||), not an upsert column —
+    # overwriting would wipe flag overlays like advocate/needs_review.
+    assert "attributes" not in contact_row
+    sql_all = " ".join(c.sql for c in mock_pool.connection.calls)
+    assert "||" in sql_all
     audit_row = mock_pool.last_insert("contact_audit_log")
     assert audit_row["contact_id_string"] == "c-1"
-    assert "city" in json.loads(audit_row["detail"])["changed_fields"]
+    detail = json.loads(audit_row["detail"])["changed_fields"]
+    assert "city" in detail and "attributes" in detail
 
 
 async def test_contact_linked_sets_customer_and_link_basis(mock_pool):
@@ -302,3 +307,34 @@ async def test_feedback_status_changed_without_note_leaves_column_untouched(mock
     updated = mock_pool.last_update("feedback")
     assert updated["status"] == "acknowledged"
     assert "status_note" not in updated
+
+
+async def test_contact_updated_merges_attributes_and_mirrors_needs_review(mock_pool):
+    # attributes is a DELTA — merged via jsonb ||, never overwritten — and
+    # needs_review mirrors to its dedicated grid-filterable column (A2).
+    await handle_contact_updated(mock_pool, _parsed("contact.updated.v1", {
+        "contact_id": "c-1", "attributes": {"needs_review": True, "needs_review_reason": "dupe?"},
+        "updated_at": "2026-07-08T00:00:00+00:00", "actor": "staff-1"}))
+
+    upserted = mock_pool.last_insert("contacts")
+    assert upserted["needs_review"] is True
+    # merge_jsonb issues a jsonb-concat UPDATE for the attributes patch
+    sql_all = " ".join(c.sql for c in mock_pool.connection.calls)
+    assert "||" in sql_all and "attributes" in sql_all
+
+
+async def test_stage_changed_mirrors_loan_status_when_present(mock_pool):
+    await handle_contact_stage_changed(mock_pool, _parsed("contact.stage.changed.v1", {
+        "contact_id": "c-1", "previous_stage": "waitlist", "stage": "customer",
+        "changed_at": "2026-07-08T00:00:00+00:00", "loan_status": "disbursed"}))
+    updated = mock_pool.last_update("contacts")
+    assert updated["derived_stage"] == "customer"
+    assert updated["loan_status"] == "disbursed"
+
+
+async def test_stage_changed_without_loan_status_leaves_column_untouched(mock_pool):
+    await handle_contact_stage_changed(mock_pool, _parsed("contact.stage.changed.v1", {
+        "contact_id": "c-1", "stage": "waitlist",
+        "changed_at": "2026-07-08T00:00:00+00:00"}))
+    updated = mock_pool.last_update("contacts")
+    assert "loan_status" not in updated

--- a/event-processor/tests/test_marketing_handlers.py
+++ b/event-processor/tests/test_marketing_handlers.py
@@ -338,3 +338,22 @@ async def test_stage_changed_without_loan_status_leaves_column_untouched(mock_po
         "changed_at": "2026-07-08T00:00:00+00:00"}))
     updated = mock_pool.last_update("contacts")
     assert "loan_status" not in updated
+
+
+async def test_stage_changed_naive_downgrade_refused_without_state_basis(mock_pool):
+    # Mirrors marketingService's apply_stage guard: a naive lead/waitlist event
+    # must not downgrade a protected stage — only basis="state" may.
+    mock_pool.set_fetchval("customer")  # current derived_stage
+    await handle_contact_stage_changed(mock_pool, _parsed("contact.stage.changed.v1", {
+        "contact_id": "c-1", "stage": "waitlist",
+        "changed_at": "2026-07-08T00:00:00+00:00"}))
+    assert mock_pool.last_update("contacts") is None  # refused
+
+
+async def test_stage_changed_state_basis_may_downgrade(mock_pool):
+    mock_pool.set_fetchval("applicant")
+    await handle_contact_stage_changed(mock_pool, _parsed("contact.stage.changed.v1", {
+        "contact_id": "c-1", "stage": "waitlist", "basis": "state",
+        "changed_at": "2026-07-08T00:00:00+00:00"}))
+    updated = mock_pool.last_update("contacts")
+    assert updated["derived_stage"] == "waitlist"  # Bx abandonment — legitimate

--- a/src/app/api/marketing/batches/[batchId]/assign/route.ts
+++ b/src/app/api/marketing/batches/[batchId]/assign/route.ts
@@ -46,7 +46,9 @@ export async function POST(
 
   try {
     const result = await assignBatch({
-      idempotencyKey: `assign:${batchId}:${Date.now()}`,
+      // Stable per (batch, member-set) so a retry/double-click can't
+      // double-fire — matching the sibling command routes.
+      idempotencyKey: `assign:${batchId}:${[...parsed.data.contact_ids].sort().join(',').slice(0, 64)}:${parsed.data.contact_ids.length}`,
       batchId,
       contactIds: parsed.data.contact_ids,
       actor: String(user.id),

--- a/src/app/api/marketing/batches/[batchId]/invite/route.ts
+++ b/src/app/api/marketing/batches/[batchId]/invite/route.ts
@@ -34,6 +34,7 @@ export async function POST(
         batchId,
         invitedCount: result.invitedCount,
         skippedUnconsented: result.skippedUnconsented,
+        skippedNeedsReview: (result as { skippedNeedsReview?: number }).skippedNeedsReview ?? 0,
       },
       { status: 202 },
     )

--- a/src/app/api/marketing/batches/route.ts
+++ b/src/app/api/marketing/batches/route.ts
@@ -29,7 +29,25 @@ export async function GET(request: NextRequest) {
     user,
   })
 
-  return NextResponse.json(result)
+  // Enrich each page with a member count (one count query per row, page<=50)
+  // so pickers/summaries can show batch sizes without a filter round-trip.
+  const docs = await Promise.all(
+    result.docs.map(async (doc) => ({
+      ...doc,
+      memberCount: doc.batchId
+        ? (
+            await payload.count({
+              collection: 'contacts',
+              where: { batchId: { equals: doc.batchId } } as never,
+              overrideAccess: false,
+              user,
+            })
+          ).totalDocs
+        : 0,
+    })),
+  )
+
+  return NextResponse.json({ ...result, docs })
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/marketing/contacts/[contactId]/review-flag/route.ts
+++ b/src/app/api/marketing/contacts/[contactId]/review-flag/route.ts
@@ -1,0 +1,74 @@
+/**
+ * API Route: POST /api/marketing/contacts/[contactId]/review-flag
+ *
+ * Set or clear a contact's needs-review flag (A2 sign-off decision). The flag
+ * is a contact ATTRIBUTE (the model's D16 mechanism, like advocate) set via
+ * MarketingService.UpdateContact — while set, the platform skips the contact
+ * in every invitation send and the grid can filter on it. Audited via the
+ * contact.updated.v1 event trail. Gated on `canMarketing`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireAuth } from '@/lib/auth'
+import { canMarketing } from '@/lib/access'
+import { updateContact } from '@/server/marketing-grpc-client'
+
+const ReviewFlagSchema = z.object({
+  needs_review: z.boolean(),
+  reason: z.string().max(500).optional(),
+})
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ contactId: string }> },
+) {
+  const auth = await requireAuth(canMarketing)
+  if ('error' in auth) return auth.error
+  const { user } = auth
+  const { contactId } = await params
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { error: { code: 'VALIDATION_ERROR', message: 'Body must be valid JSON' } },
+      { status: 400 },
+    )
+  }
+
+  const parsed = ReviewFlagSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: { code: 'VALIDATION_ERROR', message: 'Invalid review-flag payload' } },
+      { status: 400 },
+    )
+  }
+
+  const { needs_review: needsReview, reason } = parsed.data
+
+  try {
+    const result = await updateContact({
+      idempotencyKey: `review-flag:${contactId}:${needsReview}`,
+      contactId,
+      attributesJson: JSON.stringify({
+        needs_review: needsReview,
+        needs_review_reason: needsReview ? (reason?.trim() ?? null) : null,
+      }),
+      actor: String(user.id),
+    })
+    return NextResponse.json({ contactId, eventId: result.eventId }, { status: 202 })
+  } catch (e) {
+    console.error('[Marketing Review Flag] gRPC error:', e)
+    return NextResponse.json(
+      {
+        error: {
+          code: 'COMMAND_FAILED',
+          message: 'Updating the review flag failed. Please retry.',
+        },
+      },
+      { status: 503 },
+    )
+  }
+}

--- a/src/app/api/marketing/contacts/route.ts
+++ b/src/app/api/marketing/contacts/route.ts
@@ -29,6 +29,7 @@ export async function GET(request: NextRequest) {
   if (sp.get('source')) where.source = { equals: sp.get('source') }
   if (sp.get('city')) where.city = { like: sp.get('city') }
   if (sp.get('batch')) where.batchId = { equals: sp.get('batch') }
+  if (sp.get('needs_review') === 'true') where.needsReview = { equals: true }
   if (sp.get('q')) {
     where.or = [
       { firstName: { like: sp.get('q') } },

--- a/src/app/api/marketing/contacts/route.ts
+++ b/src/app/api/marketing/contacts/route.ts
@@ -30,6 +30,9 @@ export async function GET(request: NextRequest) {
   if (sp.get('city')) where.city = { like: sp.get('city') }
   if (sp.get('batch')) where.batchId = { equals: sp.get('batch') }
   if (sp.get('needs_review') === 'true') where.needsReview = { equals: true }
+  // Win-back safety: former_customer alone mixes repaid (C-P) and written-off
+  // (C-N) people — loan_status distinguishes them ("repaid" only for C-P).
+  if (sp.get('loan_status')) where.loanStatus = { equals: sp.get('loan_status') }
   if (sp.get('q')) {
     where.or = [
       { firstName: { like: sp.get('q') } },

--- a/src/collections/Contacts.ts
+++ b/src/collections/Contacts.ts
@@ -28,7 +28,16 @@ export const Contacts: CollectionConfig = {
     {
       name: 'source',
       type: 'select',
-      options: ['meta', 'google', 'campus', 'referral', 'social_dm', 'ai_search', 'organic', 'other'],
+      options: [
+        'meta',
+        'google',
+        'campus',
+        'referral',
+        'social_dm',
+        'ai_search',
+        'organic',
+        'other',
+      ],
       admin: { readOnly: true },
     },
     { name: 'utm', type: 'json', admin: { readOnly: true } },
@@ -46,10 +55,23 @@ export const Contacts: CollectionConfig = {
     { name: 'batchId', type: 'text', admin: { readOnly: true } },
     { name: 'panelMember', type: 'checkbox', admin: { readOnly: true } },
     {
+      name: 'needsReview',
+      type: 'checkbox',
+      index: true,
+      admin: {
+        readOnly: true,
+        description:
+          'A2 flag (attributes.needs_review mirror) — parked for staff review; excluded from invitation sends',
+      },
+    },
+    {
       name: 'customerId',
       type: 'text',
       index: true,
-      admin: { readOnly: true, description: 'Canonical platform customer id once linked (one-way)' },
+      admin: {
+        readOnly: true,
+        description: 'Canonical platform customer id once linked (one-way)',
+      },
     },
     { name: 'linkBasis', type: 'text', admin: { readOnly: true } },
     { name: 'linkedAt', type: 'date', admin: { readOnly: true } },

--- a/src/components/FailedActions/FailedActionsPanel.tsx
+++ b/src/components/FailedActions/FailedActionsPanel.tsx
@@ -17,6 +17,10 @@ export interface FailedActionsPanelProps {
  */
 function getActionLabel(type: FailedActionType): string {
   switch (type) {
+    case 'marketing-command':
+      return '📣'
+    case 'marketing-command':
+      return 'Marketing command'
     case 'waive-fee':
       return 'Waive Fee'
     case 'record-repayment':
@@ -60,7 +64,6 @@ function getActionIcon(type: FailedActionType): string {
   }
 }
 
-
 /**
  * Individual failed action item component.
  */
@@ -89,9 +92,7 @@ const ActionItem: React.FC<ActionItemProps> = ({
             </span>
             {getActionLabel(action.type)}
           </span>
-          <span className={styles.actionAccount}>
-            {action.accountLabel || action.accountId}
-          </span>
+          <span className={styles.actionAccount}>{action.accountLabel || action.accountId}</span>
         </div>
         <span className={styles.actionTime}>{formatRelativeTime(action.timestamp)}</span>
       </div>
@@ -113,7 +114,11 @@ const ActionItem: React.FC<ActionItemProps> = ({
           }
           data-testid={`retry-action-${action.id}`}
         >
-          {isRetrying ? '⏳ Retrying...' : action.retryCount >= MAX_RETRY_ATTEMPTS ? '❌ Max retries' : '🔄 Retry'}
+          {isRetrying
+            ? '⏳ Retrying...'
+            : action.retryCount >= MAX_RETRY_ATTEMPTS
+              ? '❌ Max retries'
+              : '🔄 Retry'}
         </button>
         <button
           type="button"
@@ -163,7 +168,7 @@ export const FailedActionsPanel: React.FC<FailedActionsPanelProps> = ({ onClose 
       if (!panel) return
 
       const focusableElements = panel.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
       )
 
       const firstElement = focusableElements[0]

--- a/src/components/MarketingView/ContactDetail.tsx
+++ b/src/components/MarketingView/ContactDetail.tsx
@@ -9,6 +9,7 @@ import { useContactReferrals } from '@/hooks/queries/useContactReferrals'
 import { useFeedbackQueue } from '@/hooks/queries/useFeedbackQueue'
 import { useSetReviewFlag, useUnlinkContact } from '@/hooks/mutations/useMarketingCommands'
 import { LinkCustomerModal } from './LinkCustomerModal'
+import { RecordConsentModal } from './RecordConsentModal'
 import type { ContactAuditLog, Interaction } from '@/payload-types'
 import { formatDateMedium } from '@/lib/formatters'
 import { getMarketingConsentGranted } from '@/lib/marketing'
@@ -126,6 +127,7 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
   const [showLinkModal, setShowLinkModal] = useState(false)
   const [showUnlinkConfirm, setShowUnlinkConfirm] = useState(false)
   const [showFlagModal, setShowFlagModal] = useState(false)
+  const [showConsentModal, setShowConsentModal] = useState(false)
   const [flagReason, setFlagReason] = useState('')
   const unlink = useUnlinkContact()
   const reviewFlag = useSetReviewFlag()
@@ -135,7 +137,13 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
     onSuccess: () => {
       toast.success('Note logged')
       setNoteText('')
-      queryClient.invalidateQueries({ queryKey: marketingContactQueryKey(contactId) })
+      // Command → projection lag: refetch now and again shortly after so the
+      // note reliably appears without a manual refresh.
+      const invalidate = () =>
+        queryClient.invalidateQueries({ queryKey: marketingContactQueryKey(contactId) })
+      invalidate()
+      setTimeout(invalidate, 1500)
+      setTimeout(invalidate, 4000)
     },
     onError: (error) => {
       toast.error('Failed to log note', {
@@ -345,6 +353,15 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
                 </div>
               ))
             )}
+            <div className={styles.panelButtonRow}>
+              <button
+                type="button"
+                className={styles.pageButton}
+                onClick={() => setShowConsentModal(true)}
+              >
+                Record consent…
+              </button>
+            </div>
           </Panel>
 
           <Panel title="Referrals">
@@ -422,9 +439,22 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
         />
       )}
 
+      {showConsentModal && (
+        <RecordConsentModal
+          contactId={contactId}
+          contactName={contact.firstName ?? 'this contact'}
+          onClose={() => setShowConsentModal(false)}
+        />
+      )}
+
       {showFlagModal && (
         <div className={styles.modalOverlay} onClick={() => setShowFlagModal(false)}>
-          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+          <div
+            className={styles.modal}
+            role="dialog"
+            aria-modal="true"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className={styles.modalHeader}>
               <h2 className={styles.modalTitle}>Flag for review</h2>
               <button
@@ -489,7 +519,12 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
 
       {showUnlinkConfirm && (
         <div className={styles.modalOverlay} onClick={() => setShowUnlinkConfirm(false)}>
-          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+          <div
+            className={styles.modal}
+            role="dialog"
+            aria-modal="true"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className={styles.modalHeader}>
               <h2 className={styles.modalTitle}>Unlink customer</h2>
               <button

--- a/src/components/MarketingView/ContactDetail.tsx
+++ b/src/components/MarketingView/ContactDetail.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner'
 import { useMarketingContact, marketingContactQueryKey } from '@/hooks/queries/useMarketingContact'
 import { useContactReferrals } from '@/hooks/queries/useContactReferrals'
 import { useFeedbackQueue } from '@/hooks/queries/useFeedbackQueue'
-import { useUnlinkContact } from '@/hooks/mutations/useMarketingCommands'
+import { useSetReviewFlag, useUnlinkContact } from '@/hooks/mutations/useMarketingCommands'
 import { LinkCustomerModal } from './LinkCustomerModal'
 import type { ContactAuditLog, Interaction } from '@/payload-types'
 import { formatDateMedium } from '@/lib/formatters'
@@ -125,7 +125,10 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
   const [noteText, setNoteText] = useState('')
   const [showLinkModal, setShowLinkModal] = useState(false)
   const [showUnlinkConfirm, setShowUnlinkConfirm] = useState(false)
+  const [showFlagModal, setShowFlagModal] = useState(false)
+  const [flagReason, setFlagReason] = useState('')
   const unlink = useUnlinkContact()
+  const reviewFlag = useSetReviewFlag()
 
   const logNoteMutation = useMutation({
     mutationFn: logNote,
@@ -293,6 +296,42 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
             </div>
           </Panel>
 
+          {/* A2: needs-review flag — parked contacts receive no sends. */}
+          <Panel title="Review">
+            <div className={styles.panelRow}>
+              <span className={styles.panelRowLabel}>Status</span>
+              <span className={styles.panelRowValue}>
+                {contact.needsReview ? '⚑ Needs review' : '—'}
+              </span>
+            </div>
+            <div className={styles.panelRow}>
+              <span className={styles.panelRowLabel}>Reason</span>
+              <span className={styles.panelRowValue}>
+                {(contact.attributes as Record<string, unknown> | null)?.[
+                  'needs_review_reason'
+                ]?.toString() ?? '—'}
+              </span>
+            </div>
+            <div className={styles.panelButtonRow}>
+              <button
+                type="button"
+                className={styles.pageButton}
+                onClick={() => setShowFlagModal(true)}
+                disabled={!!contact.needsReview || reviewFlag.isPending}
+              >
+                Flag for review…
+              </button>
+              <button
+                type="button"
+                className={styles.pageButton}
+                onClick={() => reviewFlag.mutate({ contactId, needsReview: false })}
+                disabled={!contact.needsReview || reviewFlag.isPending}
+              >
+                {reviewFlag.isPending ? 'Saving…' : 'Clear flag'}
+              </button>
+            </div>
+          </Panel>
+
           <Panel title="Consent history">
             {consentHistory.length === 0 ? (
               <div className={styles.panelEmpty}>—</div>
@@ -381,6 +420,71 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
           contactName={contact.firstName ?? 'this contact'}
           onClose={() => setShowLinkModal(false)}
         />
+      )}
+
+      {showFlagModal && (
+        <div className={styles.modalOverlay} onClick={() => setShowFlagModal(false)}>
+          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <h2 className={styles.modalTitle}>Flag for review</h2>
+              <button
+                type="button"
+                className={styles.closeBtn}
+                onClick={() => setShowFlagModal(false)}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+            <div className={styles.modalBody}>
+              <p className={styles.formHint}>
+                While flagged, this contact is excluded from every invitation send. The flag and
+                reason are audited.
+              </p>
+              <div className={styles.formGroup}>
+                <label className={styles.formLabel} htmlFor="review-flag-reason">
+                  Reason (optional)
+                </label>
+                <textarea
+                  id="review-flag-reason"
+                  className={styles.noteTextarea}
+                  rows={3}
+                  value={flagReason}
+                  onChange={(e) => setFlagReason(e.target.value)}
+                  placeholder="e.g. Possible duplicate of another contact — confirm before messaging"
+                  maxLength={500}
+                />
+              </div>
+            </div>
+            <div className={styles.modalFooter}>
+              <button
+                type="button"
+                className={styles.btnCancel}
+                onClick={() => setShowFlagModal(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={styles.btnSubmit}
+                onClick={() =>
+                  reviewFlag.mutate(
+                    { contactId, needsReview: true, reason: flagReason.trim() || undefined },
+                    {
+                      onSettled: () => {
+                        setShowFlagModal(false)
+                        setFlagReason('')
+                      },
+                    },
+                  )
+                }
+                disabled={reviewFlag.isPending}
+              >
+                {reviewFlag.isPending ? 'Flagging…' : 'Flag for review'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {showUnlinkConfirm && (

--- a/src/components/MarketingView/ContactPeekModal.tsx
+++ b/src/components/MarketingView/ContactPeekModal.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useMarketingContact } from '@/hooks/queries/useMarketingContact'
 import { formatDateMedium } from '@/lib/formatters'
 import { getMarketingConsentGranted } from '@/lib/marketing'
+import { useEscapeClose } from '@/hooks/useModalA11y'
 import styles from './styles.module.css'
 
 interface ContactPeekModalProps {
@@ -56,9 +57,16 @@ export const ContactPeekModal: React.FC<ContactPeekModalProps> = ({ contactId, o
     { label: 'Updated', value: contact?.updatedAt ? formatDateMedium(contact.updatedAt) : '—' },
   ]
 
+  useEscapeClose(onClose)
+
   return (
     <div className={styles.modalOverlay} onClick={onClose}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className={styles.modalHeader}>
           <h2 className={styles.modalTitle}>
             {isLoading ? 'Loading contact…' : (contact?.firstName ?? 'Unnamed contact')}

--- a/src/components/MarketingView/FeedbackQueueView.tsx
+++ b/src/components/MarketingView/FeedbackQueueView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useFeedbackQueue } from '@/hooks/queries/useFeedbackQueue'
 import type { FeedbackWithContact } from '@/hooks/queries/useFeedbackQueue'
@@ -35,6 +35,11 @@ export const FeedbackQueueView: React.FC = () => {
 
   const filters = useMemo(() => ({ status: status || undefined, page }), [status, page])
   const { data, isLoading, isError } = useFeedbackQueue(filters)
+  // Render-pure clock snapshot for the Age column; refreshed with each fetch.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    setNow(Date.now())
+  }, [data])
   const setStatusMutation = useSetFeedbackStatus()
   const docs = data?.docs ?? []
 
@@ -46,6 +51,23 @@ export const FeedbackQueueView: React.FC = () => {
   }
 
   const statusBadge = (s: Feedback['status']) => <span className={styles.badge}>{s ?? 'new'}</span>
+
+  // Row-scoped pending: acknowledging one item must not freeze the buttons on
+  // every other row — triage is fast sequential work.
+  const isRowPending = (feedbackId: string | null | undefined) =>
+    setStatusMutation.isPending && setStatusMutation.variables?.feedbackId === feedbackId
+
+  // Days-open ages the queue; unresolved complaints older than 21 days get an
+  // overdue highlight (internal IDR posture: resolve complaints well inside
+  // 30 days).
+  const daysOpen = (receivedAt: string | null | undefined): number | null => {
+    if (!receivedAt) return null
+    return Math.floor((now - new Date(receivedAt).getTime()) / 86_400_000)
+  }
+  const isOverdue = (fb: Feedback) =>
+    fb.status !== 'resolved' &&
+    (fb.feedbackType ?? '').toLowerCase() === 'complaint' &&
+    (daysOpen(fb.receivedAt) ?? 0) > 21
 
   return (
     <div className={styles.container}>
@@ -93,6 +115,7 @@ export const FeedbackQueueView: React.FC = () => {
                   <th>Feedback</th>
                   <th>Status</th>
                   <th>Resolution</th>
+                  <th>Age</th>
                   <th>Received</th>
                   <th>Actions</th>
                 </tr>
@@ -100,13 +123,13 @@ export const FeedbackQueueView: React.FC = () => {
               <tbody>
                 {isLoading && docs.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className={styles.emptyCell}>
+                    <td colSpan={8} className={styles.emptyCell}>
                       Loading feedback…
                     </td>
                   </tr>
                 ) : docs.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className={styles.emptyCell}>
+                    <td colSpan={8} className={styles.emptyCell}>
                       No feedback matches the current filter.
                     </td>
                   </tr>
@@ -127,7 +150,15 @@ export const FeedbackQueueView: React.FC = () => {
                         )}
                       </td>
                       <td>{fb.feedbackType ?? '—'}</td>
-                      <td>{fb.body ?? '—'}</td>
+                      <td>
+                        {fb.body ? (
+                          <span className={styles.noteCell} title={fb.body}>
+                            {fb.body}
+                          </span>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
                       <td>{statusBadge(fb.status)}</td>
                       <td>
                         {fb.statusNote ? (
@@ -138,13 +169,31 @@ export const FeedbackQueueView: React.FC = () => {
                           '—'
                         )}
                       </td>
+                      <td>
+                        {daysOpen(fb.receivedAt) === null ? (
+                          '—'
+                        ) : (
+                          <span
+                            className={
+                              isOverdue(fb)
+                                ? `${styles.badge} ${styles.badgeConsentDeclined}`
+                                : undefined
+                            }
+                            title={
+                              isOverdue(fb) ? 'Unresolved complaint over 21 days old' : undefined
+                            }
+                          >
+                            {daysOpen(fb.receivedAt)}d
+                          </span>
+                        )}
+                      </td>
                       <td>{fb.receivedAt ? formatDateShort(fb.receivedAt) : '—'}</td>
                       <td>
                         <button
                           type="button"
                           className={styles.pageButton}
                           onClick={() => acknowledge(fb.feedbackId)}
-                          disabled={setStatusMutation.isPending || fb.status !== 'new'}
+                          disabled={isRowPending(fb.feedbackId) || fb.status !== 'new'}
                         >
                           Acknowledge
                         </button>{' '}
@@ -152,7 +201,7 @@ export const FeedbackQueueView: React.FC = () => {
                           type="button"
                           className={styles.pageButton}
                           onClick={() => setResolveTarget(fb)}
-                          disabled={setStatusMutation.isPending || fb.status === 'resolved'}
+                          disabled={isRowPending(fb.feedbackId) || fb.status === 'resolved'}
                         >
                           Resolve
                         </button>

--- a/src/components/MarketingView/LinkCustomerModal.tsx
+++ b/src/components/MarketingView/LinkCustomerModal.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { useCustomerSearch } from '@/hooks/queries/useCustomerSearch'
 import type { CustomerSearchResult } from '@/hooks/queries/useCustomerSearch'
 import { useLinkContact } from '@/hooks/mutations/useMarketingCommands'
+import { useEscapeClose } from '@/hooks/useModalA11y'
 import styles from './styles.module.css'
 
 interface LinkCustomerModalProps {
@@ -37,9 +38,16 @@ export const LinkCustomerModal: React.FC<LinkCustomerModalProps> = ({
     link.mutate({ contactId, customerId: selected.customerId }, { onSuccess: () => onClose() })
   }
 
+  useEscapeClose(onClose)
+
   return (
     <div className={styles.modalOverlay} onClick={onClose}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className={styles.modalHeader}>
           <h2 className={styles.modalTitle}>Link {contactName} to a customer</h2>
           <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">

--- a/src/components/MarketingView/MarketingView.tsx
+++ b/src/components/MarketingView/MarketingView.tsx
@@ -1,12 +1,16 @@
 'use client'
 
-import React, { useMemo, useState } from 'react'
+import React, { useDeferredValue, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useMarketingContacts } from '@/hooks/queries/useMarketingContacts'
 import type { MarketingContactsFilters } from '@/hooks/queries/useMarketingContacts'
 import { useBatches } from '@/hooks/queries/useBatches'
-import { useAssignBatch, useTriggerInvitations } from '@/hooks/mutations/useMarketingCommands'
+import {
+  useAssignBatch,
+  useMarketingCommandRetryListener,
+  useTriggerInvitations,
+} from '@/hooks/mutations/useMarketingCommands'
 import type { Contact } from '@/payload-types'
 import { formatDateShort } from '@/lib/formatters'
 import { getMarketingConsentGranted } from '@/lib/marketing'
@@ -92,32 +96,41 @@ export const MarketingView: React.FC<MarketingViewProps> = ({ contactId, feedbac
 const MarketingContactsGrid: React.FC = () => {
   const router = useRouter()
   const [q, setQ] = useState('')
+  // Defer the search term so keystrokes don't fire a network request each —
+  // same treatment as useCustomerSearch (React prioritises typing).
+  const deferredQ = useDeferredValue(q)
   const [stage, setStage] = useState('')
   const [source, setSource] = useState('')
   const [city, setCity] = useState('')
   const [batch, setBatch] = useState('')
   const [needsReview, setNeedsReview] = useState('')
+  const [loanStatus, setLoanStatus] = useState('')
   const [page, setPage] = useState(1)
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [assignTarget, setAssignTarget] = useState('')
+  // Invitations get their OWN target — deliberately decoupled from the grid's
+  // Batch filter so a leftover filter can never silently prime a send.
+  const [inviteTarget, setInviteTarget] = useState('')
   const [showNewContact, setShowNewContact] = useState(false)
   const [showNewBatch, setShowNewBatch] = useState(false)
   const [showInviteConfirm, setShowInviteConfirm] = useState(false)
 
   const filters = useMemo<MarketingContactsFilters>(
     () => ({
-      q: q || undefined,
+      q: deferredQ || undefined,
       stage: stage || undefined,
       source: source || undefined,
       city: city || undefined,
       batch: batch || undefined,
       needs_review: needsReview || undefined,
+      loan_status: loanStatus || undefined,
       page,
     }),
-    [q, stage, source, city, batch, needsReview, page],
+    [deferredQ, stage, source, city, batch, needsReview, loanStatus, page],
   )
 
-  const { data, isLoading, isError } = useMarketingContacts(filters)
+  const { data, isLoading, isError, isFetching } = useMarketingContacts(filters)
+  useMarketingCommandRetryListener()
   const { data: batchesData, refetch: refetchBatches } = useBatches()
   const assign = useAssignBatch()
   const invite = useTriggerInvitations()
@@ -125,6 +138,8 @@ const MarketingContactsGrid: React.FC = () => {
   const batchOptions = batchesData?.docs ?? []
   const batchNameFor = (id?: string | null) =>
     id ? (batchOptions.find((b) => b.batchId === id)?.name ?? id) : '—'
+  const batchLabelWithCount = (b: (typeof batchOptions)[number]) =>
+    `${b.name ?? b.batchId}${typeof b.memberCount === 'number' ? ` (${b.memberCount})` : ''}`
 
   const onFilter =
     (setter: (v: string) => void) =>
@@ -161,6 +176,8 @@ const MarketingContactsGrid: React.FC = () => {
         onSuccess: () => {
           setSelected(new Set())
           setAssignTarget('')
+          // The batch just assigned is the natural next invite target.
+          setInviteTarget(assignTarget)
         },
       },
     )
@@ -185,6 +202,7 @@ const MarketingContactsGrid: React.FC = () => {
       const res = await refetchBatches()
       if (res.data?.docs?.some((b) => b.batchId === batchId)) {
         setAssignTarget(batchId)
+        setInviteTarget(batchId)
         return
       }
       await new Promise((resolve) => setTimeout(resolve, BATCH_POLL_INTERVAL_MS))
@@ -202,12 +220,10 @@ const MarketingContactsGrid: React.FC = () => {
     return snapshot
   }, [q, stage, source, city, batch])
 
-  // Invitations fire for the batch chosen in the Batch FILTER — filter to the
-  // batch (seeing exactly its members), then send.
-  const canInvite = !!batch && !invite.isPending
+  const canInvite = !!inviteTarget && !invite.isPending
   const handleInviteConfirm = () => {
     if (!canInvite) return
-    invite.mutate(batch, { onSettled: () => setShowInviteConfirm(false) })
+    invite.mutate(inviteTarget, { onSettled: () => setShowInviteConfirm(false) })
   }
 
   const contactHref = (contact: Contact) => `/admin/marketing/contacts/${contact.contactId}`
@@ -311,6 +327,24 @@ const MarketingContactsGrid: React.FC = () => {
         </div>
 
         <div className={styles.filterGroup}>
+          <label className={styles.filterLabel} htmlFor="marketing-loan-outcome-filter">
+            Loan outcome
+          </label>
+          <select
+            id="marketing-loan-outcome-filter"
+            className={styles.filterSelect}
+            value={loanStatus}
+            onChange={onFilter(setLoanStatus)}
+            title="Win-back segments should target Repaid — written-off customers never re-enter"
+          >
+            <option value="">Any outcome</option>
+            <option value="repaid">Repaid (win-back safe)</option>
+            <option value="disbursed">Disbursed (active)</option>
+            <option value="approved">Approved</option>
+          </select>
+        </div>
+
+        <div className={styles.filterGroup}>
           <label className={styles.filterLabel} htmlFor="marketing-review-filter">
             Review
           </label>
@@ -327,8 +361,9 @@ const MarketingContactsGrid: React.FC = () => {
       </div>
 
       {/* Assign-to-batch bar — always present (fixed layout); controls disable
-          until a selection + target batch exist. Invitations live on the right:
-          they fire for the batch chosen in the Batch filter above. */}
+          until a selection + target batch exist. Invitations get their OWN
+          batch selector (seeded by assign/create) — deliberately independent
+          of the grid filter so a leftover filter never primes a send. */}
       <div className={styles.filters}>
         <span className={styles.pageStatus}>{selected.size} selected</span>
         <div className={styles.filterGroup}>
@@ -345,7 +380,7 @@ const MarketingContactsGrid: React.FC = () => {
             <option value="">Choose a batch…</option>
             {batchOptions.map((b) => (
               <option key={b.batchId} value={b.batchId}>
-                {b.name ?? b.batchId}
+                {batchLabelWithCount(b)}
               </option>
             ))}
             <option value={NEW_BATCH_SENTINEL}>＋ New batch…</option>
@@ -356,18 +391,41 @@ const MarketingContactsGrid: React.FC = () => {
           className={styles.pageButton}
           onClick={handleAssign}
           disabled={!canAssign}
+          title={
+            selected.size === 0
+              ? 'Select contacts first'
+              : !assignTarget
+                ? 'Choose a target batch'
+                : undefined
+          }
         >
           {assign.isPending ? 'Assigning…' : 'Assign'}
         </button>
         <div className={styles.spacer} />
-        <span className={styles.pageStatus}>
-          Invitations: {batch ? batchNameFor(batch) : 'choose a batch in the filter'}
-        </span>
+        <div className={styles.filterGroup}>
+          <label className={styles.filterLabel} htmlFor="marketing-invite-batch">
+            Send invitations to
+          </label>
+          <select
+            id="marketing-invite-batch"
+            className={styles.filterSelect}
+            value={inviteTarget}
+            onChange={(e) => setInviteTarget(e.target.value)}
+          >
+            <option value="">Choose a batch…</option>
+            {batchOptions.map((b) => (
+              <option key={b.batchId} value={b.batchId}>
+                {batchLabelWithCount(b)}
+              </option>
+            ))}
+          </select>
+        </div>
         <button
           type="button"
           className={styles.pageButton}
           onClick={() => setShowInviteConfirm(true)}
           disabled={!canInvite}
+          title={!inviteTarget ? 'Choose the batch to invite' : undefined}
         >
           {invite.isPending ? 'Sending…' : 'Send invitations'}
         </button>
@@ -445,7 +503,23 @@ const MarketingContactsGrid: React.FC = () => {
                         )}
                       </td>
                       <td>{contact.source ? sourceLabel(contact.source) : '—'}</td>
-                      <td>{batchNameFor(contact.batchId)}</td>
+                      <td onClick={(e) => e.stopPropagation()}>
+                        {contact.batchId ? (
+                          <button
+                            type="button"
+                            className={styles.linkButton}
+                            title="Filter the grid to this batch"
+                            onClick={() => {
+                              setBatch(contact.batchId!)
+                              setPage(1)
+                            }}
+                          >
+                            {batchNameFor(contact.batchId)}
+                          </button>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
                       <td>
                         {contact.needsReview ? (
                           <span
@@ -479,7 +553,7 @@ const MarketingContactsGrid: React.FC = () => {
               </button>
               <span className={styles.pageStatus}>
                 Page {data?.page ?? page} of {data?.totalPages ?? 1} · {data?.totalDocs ?? 0}{' '}
-                contacts
+                contacts{isFetching ? ' · refreshing…' : ''}
               </span>
               <button
                 type="button"
@@ -525,7 +599,8 @@ const MarketingContactsGrid: React.FC = () => {
             </div>
             <div className={styles.modalBody}>
               <p>
-                Send invitations to all consented members of <strong>{batchNameFor(batch)}</strong>?
+                Send invitations to all consented members of{' '}
+                <strong>{batchNameFor(inviteTarget)}</strong>?
               </p>
               <p className={styles.formHint}>
                 Members without marketing consent are skipped automatically. Repeating the send for

--- a/src/components/MarketingView/MarketingView.tsx
+++ b/src/components/MarketingView/MarketingView.tsx
@@ -96,6 +96,7 @@ const MarketingContactsGrid: React.FC = () => {
   const [source, setSource] = useState('')
   const [city, setCity] = useState('')
   const [batch, setBatch] = useState('')
+  const [needsReview, setNeedsReview] = useState('')
   const [page, setPage] = useState(1)
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [assignTarget, setAssignTarget] = useState('')
@@ -110,9 +111,10 @@ const MarketingContactsGrid: React.FC = () => {
       source: source || undefined,
       city: city || undefined,
       batch: batch || undefined,
+      needs_review: needsReview || undefined,
       page,
     }),
-    [q, stage, source, city, batch, page],
+    [q, stage, source, city, batch, needsReview, page],
   )
 
   const { data, isLoading, isError } = useMarketingContacts(filters)
@@ -307,6 +309,21 @@ const MarketingContactsGrid: React.FC = () => {
             ))}
           </select>
         </div>
+
+        <div className={styles.filterGroup}>
+          <label className={styles.filterLabel} htmlFor="marketing-review-filter">
+            Review
+          </label>
+          <select
+            id="marketing-review-filter"
+            className={styles.filterSelect}
+            value={needsReview}
+            onChange={onFilter(setNeedsReview)}
+          >
+            <option value="">All contacts</option>
+            <option value="true">⚑ Needs review</option>
+          </select>
+        </div>
       </div>
 
       {/* Assign-to-batch bar — always present (fixed layout); controls disable
@@ -377,6 +394,7 @@ const MarketingContactsGrid: React.FC = () => {
                   <th>Stage</th>
                   <th>Source</th>
                   <th>Batch</th>
+                  <th>Flags</th>
                   <th>Consent</th>
                   <th>Updated</th>
                 </tr>
@@ -384,13 +402,13 @@ const MarketingContactsGrid: React.FC = () => {
               <tbody>
                 {isLoading && docs.length === 0 ? (
                   <tr>
-                    <td colSpan={8} className={styles.emptyCell}>
+                    <td colSpan={9} className={styles.emptyCell}>
                       Loading contacts…
                     </td>
                   </tr>
                 ) : docs.length === 0 ? (
                   <tr>
-                    <td colSpan={8} className={styles.emptyCell}>
+                    <td colSpan={9} className={styles.emptyCell}>
                       No contacts match the current filters.
                     </td>
                   </tr>
@@ -428,6 +446,18 @@ const MarketingContactsGrid: React.FC = () => {
                       </td>
                       <td>{contact.source ? sourceLabel(contact.source) : '—'}</td>
                       <td>{batchNameFor(contact.batchId)}</td>
+                      <td>
+                        {contact.needsReview ? (
+                          <span
+                            className={`${styles.badge} ${styles.badgeConsentDeclined}`}
+                            title="Parked for review — excluded from invitation sends"
+                          >
+                            ⚑ Review
+                          </span>
+                        ) : (
+                          <span className={styles.placeholder}>—</span>
+                        )}
+                      </td>
                       <td>
                         <ConsentBadge consent={contact.consent} />
                       </td>

--- a/src/components/MarketingView/NewBatchModal.tsx
+++ b/src/components/MarketingView/NewBatchModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react'
 import { useCreateBatch } from '@/hooks/mutations/useMarketingCommands'
+import { useEscapeClose } from '@/hooks/useModalA11y'
 import styles from './styles.module.css'
 
 interface NewBatchModalProps {
@@ -35,9 +36,16 @@ export const NewBatchModal: React.FC<NewBatchModalProps> = ({ criteria, onClose,
     create.mutate({ name: name.trim(), criteria }, { onSuccess: (res) => onSuccess(res.batchId) })
   }
 
+  useEscapeClose(onClose)
+
   return (
     <div className={styles.modalOverlay} onClick={onClose}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className={styles.modalHeader}>
           <h2 className={styles.modalTitle}>New batch</h2>
           <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
@@ -59,6 +67,7 @@ export const NewBatchModal: React.FC<NewBatchModalProps> = ({ criteria, onClose,
               </label>
               <input
                 id="new-batch-name"
+                autoFocus
                 type="text"
                 className={styles.formInput}
                 value={name}

--- a/src/components/MarketingView/NewContactModal.tsx
+++ b/src/components/MarketingView/NewContactModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react'
 import { useCreateContact, type CreateContactVars } from '@/hooks/mutations/useMarketingCommands'
+import { useEscapeClose } from '@/hooks/useModalA11y'
 import styles from './styles.module.css'
 
 interface NewContactModalProps {
@@ -55,9 +56,16 @@ export const NewContactModal: React.FC<NewContactModalProps> = ({ onClose, onSuc
     create.mutate(vars, { onSuccess: () => onSuccess() })
   }
 
+  useEscapeClose(onClose)
+
   return (
     <div className={styles.modalOverlay} onClick={onClose}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className={styles.modalHeader}>
           <h2 className={styles.modalTitle}>New contact</h2>
           <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
@@ -79,6 +87,7 @@ export const NewContactModal: React.FC<NewContactModalProps> = ({ onClose, onSuc
               </label>
               <input
                 id="new-contact-first-name"
+                autoFocus
                 type="text"
                 className={styles.formInput}
                 value={firstName}

--- a/src/components/MarketingView/RecordConsentModal.tsx
+++ b/src/components/MarketingView/RecordConsentModal.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useRecordConsent } from '@/hooks/mutations/useMarketingCommands'
+import { useEscapeClose } from '@/hooks/useModalA11y'
+import styles from './styles.module.css'
+
+interface RecordConsentModalProps {
+  contactId: string
+  contactName: string
+  onClose: () => void
+}
+
+const CHANNELS: Array<'sms' | 'whatsapp' | 'email'> = ['sms', 'whatsapp', 'email']
+
+/**
+ * Staff consent capture — the follow-up step for offline-created contacts
+ * (campus stalls, referrals taken verbally) and for recording verbal
+ * opt-outs. Posts SetConsent with method + evidence so the consent trail
+ * satisfies the Spam Act record-keeping posture; the dispatcher's fail-closed
+ * opt-in gate reads the result.
+ */
+export const RecordConsentModal: React.FC<RecordConsentModalProps> = ({
+  contactId,
+  contactName,
+  onClose,
+}) => {
+  const [granted, setGranted] = useState(true)
+  const [channels, setChannels] = useState<Array<'sms' | 'whatsapp' | 'email'>>(['sms'])
+  const [method, setMethod] = useState('')
+  const [evidence, setEvidence] = useState('')
+
+  const consent = useRecordConsent()
+  useEscapeClose(onClose)
+  const canSubmit = !!method.trim() && (granted ? channels.length > 0 : true) && !consent.isPending
+
+  const toggleChannel = (channel: 'sms' | 'whatsapp' | 'email') =>
+    setChannels((prev) =>
+      prev.includes(channel) ? prev.filter((c) => c !== channel) : [...prev, channel],
+    )
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    consent.mutate(
+      {
+        contactId,
+        granted,
+        channels: granted ? channels : CHANNELS,
+        method: method.trim(),
+        evidence: evidence.trim() || undefined,
+      },
+      { onSuccess: () => onClose() },
+    )
+  }
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className={styles.modalHeader}>
+          <h2 className={styles.modalTitle}>Record consent — {contactName}</h2>
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className={styles.modalBody}>
+            {consent.isError && (
+              <div className={styles.errorMessage}>
+                {consent.error instanceof Error
+                  ? consent.error.message
+                  : 'Failed to record consent'}
+              </div>
+            )}
+
+            <div className={styles.formGroup}>
+              <span className={styles.formLabel}>Decision</span>
+              <div className={styles.panelButtonRow}>
+                <label className={styles.formHint}>
+                  <input
+                    type="radio"
+                    name="consent-decision"
+                    checked={granted}
+                    onChange={() => setGranted(true)}
+                  />{' '}
+                  Granted
+                </label>
+                <label className={styles.formHint}>
+                  <input
+                    type="radio"
+                    name="consent-decision"
+                    checked={!granted}
+                    onChange={() => setGranted(false)}
+                  />{' '}
+                  Withdrawn
+                </label>
+              </div>
+            </div>
+
+            <div className={styles.formGroup}>
+              <span className={styles.formLabel}>Channels</span>
+              <div className={styles.panelButtonRow}>
+                {CHANNELS.map((channel) => (
+                  <label key={channel} className={styles.formHint}>
+                    <input
+                      type="checkbox"
+                      checked={granted ? channels.includes(channel) : true}
+                      disabled={!granted}
+                      onChange={() => toggleChannel(channel)}
+                    />{' '}
+                    {channel}
+                  </label>
+                ))}
+              </div>
+              {!granted && (
+                <p className={styles.formHint}>Withdrawal always applies to every channel.</p>
+              )}
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="consent-method">
+                How was it captured?
+              </label>
+              <input
+                id="consent-method"
+                autoFocus
+                type="text"
+                className={styles.formInput}
+                value={method}
+                onChange={(e) => setMethod(e.target.value)}
+                placeholder="e.g. campus stall form, phone call, email request"
+                maxLength={50}
+              />
+              <p className={styles.formHint}>Required — recorded on the consent trail.</p>
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="consent-evidence">
+                Evidence (optional)
+              </label>
+              <textarea
+                id="consent-evidence"
+                className={styles.noteTextarea}
+                rows={2}
+                value={evidence}
+                onChange={(e) => setEvidence(e.target.value)}
+                placeholder="e.g. paper form ref, quote of the request"
+                maxLength={500}
+              />
+            </div>
+          </div>
+
+          <div className={styles.modalFooter}>
+            <button type="button" className={styles.btnCancel} onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className={styles.btnSubmit}
+              disabled={!canSubmit}
+              title={!method.trim() ? 'Describe how consent was captured' : undefined}
+            >
+              {consent.isPending ? 'Saving…' : granted ? 'Record consent' : 'Record withdrawal'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default RecordConsentModal

--- a/src/components/MarketingView/ResolveFeedbackModal.tsx
+++ b/src/components/MarketingView/ResolveFeedbackModal.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react'
 import { useSetFeedbackStatus } from '@/hooks/mutations/useMarketingCommands'
 import type { FeedbackWithContact } from '@/hooks/queries/useFeedbackQueue'
+import { useEscapeClose } from '@/hooks/useModalA11y'
 import styles from './styles.module.css'
 
 interface ResolveFeedbackModalProps {
@@ -34,9 +35,16 @@ export const ResolveFeedbackModal: React.FC<ResolveFeedbackModalProps> = ({
     )
   }
 
+  useEscapeClose(onClose)
+
   return (
     <div className={styles.modalOverlay} onClick={onClose}>
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className={styles.modalHeader}>
           <h2 className={styles.modalTitle}>Resolve feedback</h2>
           <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
@@ -62,6 +70,7 @@ export const ResolveFeedbackModal: React.FC<ResolveFeedbackModalProps> = ({
               </label>
               <textarea
                 id="resolve-feedback-note"
+                autoFocus
                 className={styles.noteTextarea}
                 rows={4}
                 value={note}

--- a/src/components/MarketingView/styles.module.css
+++ b/src/components/MarketingView/styles.module.css
@@ -459,7 +459,7 @@
 }
 
 .searchResultSelected {
-  border-color: #2563eb;
+  border-color: var(--theme-success-500, #2563eb);
   background: var(--theme-elevation-50, #f5f5f5);
 }
 
@@ -580,8 +580,8 @@
 .formInput:focus,
 .formSelect:focus {
   outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+  border-color: var(--theme-success-500, #2563eb);
+  box-shadow: 0 0 0 3px var(--theme-success-100, rgba(37, 99, 235, 0.1));
 }
 
 .formHint {
@@ -616,7 +616,7 @@
   display: inline-flex;
   align-items: center;
   padding: 0.625rem 1.25rem;
-  background: #2563eb;
+  background: var(--theme-success-500, #2563eb);
   color: white;
   border: none;
   border-radius: 6px;
@@ -627,7 +627,7 @@
 }
 
 .btnSubmit:hover:not(:disabled) {
-  background: #1d4ed8;
+  background: var(--theme-success-600, #1d4ed8);
 }
 
 .btnSubmit:disabled {
@@ -636,8 +636,8 @@
 }
 
 .errorMessage {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--theme-error-50, #fee2e2);
+  color: var(--theme-error-600, #991b1b);
   padding: 0.75rem;
   border-radius: 6px;
   margin-bottom: 1rem;

--- a/src/hooks/mutations/useApproveWriteOff.ts
+++ b/src/hooks/mutations/useApproveWriteOff.ts
@@ -46,9 +46,7 @@ export interface ApproveWriteOffResult {
 /**
  * Publish approve command via the command API.
  */
-async function publishApproveCommand(
-  params: ApproveWriteOffParams
-): Promise<PublishEventResponse> {
+async function publishApproveCommand(params: ApproveWriteOffParams): Promise<PublishEventResponse> {
   const command: WriteOffApproveCommand = {
     requestId: params.requestId,
     requestNumber: params.requestNumber,
@@ -62,7 +60,9 @@ async function publishApproveCommand(
   })
 
   if (!res.ok) {
-    const error = await res.json().catch(() => ({ error: { message: 'Failed to approve request' } }))
+    const error = await res
+      .json()
+      .catch(() => ({ error: { message: 'Failed to approve request' } }))
     throw new Error(error.error?.message || 'Failed to approve write-off request')
   }
 
@@ -72,9 +72,7 @@ async function publishApproveCommand(
 /**
  * Approve write-off request and poll for the status change.
  */
-async function approveWriteOff(
-  params: ApproveWriteOffParams
-): Promise<ApproveWriteOffResult> {
+async function approveWriteOff(params: ApproveWriteOffParams): Promise<ApproveWriteOffResult> {
   // Validate comment length
   if (!params.comment || params.comment.trim().length < MIN_APPROVAL_COMMENT_LENGTH) {
     throw new Error(`Approval comment must be at least ${MIN_APPROVAL_COMMENT_LENGTH} characters`)
@@ -91,7 +89,7 @@ async function approveWriteOff(
       maxAttempts: 10,
       intervalMs: 500,
       initialDelayMs: 100,
-    }
+    },
   )
 
   return projection
@@ -125,7 +123,8 @@ export function useApproveWriteOff() {
       // Handle polling timeout specifically
       if (error instanceof PollTimeoutError) {
         toast.warning('Approval submitted but confirmation delayed', {
-          description: 'Your approval was accepted but is taking longer than expected. Please refresh to see the status.',
+          description:
+            'Your approval was accepted but is taking longer than expected. Please refresh to see the status.',
         })
         queryClient.invalidateQueries({ queryKey: ['write-off-requests'] })
         return

--- a/src/hooks/mutations/useCancelWriteOff.ts
+++ b/src/hooks/mutations/useCancelWriteOff.ts
@@ -44,9 +44,7 @@ export interface CancelWriteOffResult {
 /**
  * Publish cancel command via the command API.
  */
-async function publishCancelCommand(
-  params: CancelWriteOffParams
-): Promise<PublishEventResponse> {
+async function publishCancelCommand(params: CancelWriteOffParams): Promise<PublishEventResponse> {
   const command: WriteOffCancelCommand = {
     requestId: params.requestId,
     requestNumber: params.requestNumber,
@@ -69,9 +67,7 @@ async function publishCancelCommand(
 /**
  * Cancel write-off request and poll for the status change.
  */
-async function cancelWriteOff(
-  params: CancelWriteOffParams
-): Promise<CancelWriteOffResult> {
+async function cancelWriteOff(params: CancelWriteOffParams): Promise<CancelWriteOffResult> {
   // 1. Publish the command event
   await publishCancelCommand(params)
 
@@ -83,7 +79,7 @@ async function cancelWriteOff(
       maxAttempts: 10,
       intervalMs: 500,
       initialDelayMs: 100,
-    }
+    },
   )
 
   return projection
@@ -118,7 +114,8 @@ export function useCancelWriteOff() {
       // Handle polling timeout specifically
       if (error instanceof PollTimeoutError) {
         toast.warning('Cancellation submitted but confirmation delayed', {
-          description: 'Your cancellation was accepted but is taking longer than expected. Please refresh to see the status.',
+          description:
+            'Your cancellation was accepted but is taking longer than expected. Please refresh to see the status.',
         })
         queryClient.invalidateQueries({ queryKey: ['write-off-requests'] })
         queryClient.invalidateQueries({ queryKey: ['pending-approvals'] })

--- a/src/hooks/mutations/useCreateExportJob.ts
+++ b/src/hooks/mutations/useCreateExportJob.ts
@@ -1,6 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
-import { exportJobsQueryKey, type ExportJobType, type ExportFormat } from '@/hooks/queries/useExportJobs'
+import {
+  exportJobsQueryKey,
+  type ExportJobType,
+  type ExportFormat,
+} from '@/hooks/queries/useExportJobs'
 
 export interface CreateExportJobRequest {
   type: ExportJobType
@@ -85,7 +89,12 @@ export function useCreateExportJob() {
       })
 
       const data = await res.json().catch(() => ({}))
-      console.log('[ExportJob] Response status:', res.status, 'body:', JSON.stringify(data, null, 2))
+      console.log(
+        '[ExportJob] Response status:',
+        res.status,
+        'body:',
+        JSON.stringify(data, null, 2),
+      )
 
       if (!res.ok) {
         console.error('[ExportJob] Create failed:', res.status, data)

--- a/src/hooks/mutations/useCreateNote.ts
+++ b/src/hooks/mutations/useCreateNote.ts
@@ -36,9 +36,7 @@ async function createNote(params: CreateNoteParams): Promise<CreateNoteResult> {
     const body = await res.json().catch(() => ({}))
     const message =
       // Payload wraps validation errors in errors array
-      body?.errors?.[0]?.message ||
-      body?.message ||
-      'Failed to create note'
+      body?.errors?.[0]?.message || body?.message || 'Failed to create note'
     throw new Error(message)
   }
 

--- a/src/hooks/mutations/useMarketingCommands.ts
+++ b/src/hooks/mutations/useMarketingCommands.ts
@@ -139,6 +139,29 @@ export function useUnlinkContact() {
   })
 }
 
+export interface SetReviewFlagVars {
+  contactId: string
+  needsReview: boolean
+  reason?: string
+}
+
+/** A2: park/unpark a contact for review (excluded from sends while set). */
+export function useSetReviewFlag() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: SetReviewFlagVars) =>
+      postCommand(`/api/marketing/contacts/${encodeURIComponent(vars.contactId)}/review-flag`, {
+        needs_review: vars.needsReview,
+        ...(vars.reason ? { reason: vars.reason } : {}),
+      }),
+    onSuccess: (_res, vars) => {
+      toast.success(vars.needsReview ? 'Contact flagged for review' : 'Review flag cleared')
+      qc.invalidateQueries({ queryKey: ['marketing-contacts'] })
+    },
+    onError: (e: Error) => toast.error('Failed to update review flag', { description: e.message }),
+  })
+}
+
 export interface CreateContactVars {
   first_name?: string
   email?: string

--- a/src/hooks/mutations/useMarketingCommands.ts
+++ b/src/hooks/mutations/useMarketingCommands.ts
@@ -8,8 +8,25 @@
  * list/detail queries.
  */
 
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useEffect } from 'react'
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
+import { useFailedActionsStore } from '@/stores/failed-actions'
+
+/**
+ * Marketing commands are 202-accepted (command → event → projection), so a
+ * refetch fired at success time frequently races the projection and returns
+ * pre-change data — the UI looks like it reverted. Invalidate now AND again
+ * after the typical projection lag so the view self-heals without a manual
+ * refresh.
+ */
+const LAG_RETRIES_MS = [1500, 4000]
+
+function invalidateWithLag(qc: QueryClient, keys: string[][]) {
+  const run = () => keys.forEach((queryKey) => qc.invalidateQueries({ queryKey }))
+  run()
+  LAG_RETRIES_MS.forEach((ms) => setTimeout(run, ms))
+}
 
 async function postCommand<T = unknown>(url: string, body?: unknown): Promise<T> {
   const res = await fetch(url, {
@@ -37,9 +54,18 @@ export function useCreateBatch() {
       postCommand<{ batchId: string; eventId: string }>('/api/marketing/batches', vars),
     onSuccess: () => {
       toast.success('Batch created')
-      qc.invalidateQueries({ queryKey: ['marketing-batches'] })
+      invalidateWithLag(qc, [['marketing-batches']])
     },
-    onError: (e: Error) => toast.error('Failed to create batch', { description: e.message }),
+    onError: (e: Error, vars) => {
+      toast.error('Failed to create batch', { description: e.message })
+      recordMarketingFailure(
+        `Create batch "${vars.name}"`,
+        vars.name,
+        '/api/marketing/batches',
+        vars,
+        e,
+      )
+    },
   })
 }
 
@@ -58,26 +84,49 @@ export function useAssignBatch() {
       ),
     onSuccess: (res) => {
       toast.success(`Assigned ${res.assignedCount} contact(s) to the batch`)
-      qc.invalidateQueries({ queryKey: ['marketing-batches'] })
-      qc.invalidateQueries({ queryKey: ['marketing-contacts'] })
+      invalidateWithLag(qc, [['marketing-batches'], ['marketing-contacts']])
     },
-    onError: (e: Error) => toast.error('Failed to assign contacts', { description: e.message }),
+    onError: (e: Error, vars) => {
+      toast.error('Failed to assign contacts', { description: e.message })
+      recordMarketingFailure(
+        `Assign ${vars.contactIds.length} contact(s) to batch`,
+        vars.batchId,
+        `/api/marketing/batches/${encodeURIComponent(vars.batchId)}/assign`,
+        { contact_ids: vars.contactIds },
+        e,
+      )
+    },
   })
 }
 
 export function useTriggerInvitations() {
   return useMutation({
     mutationFn: (batchId: string) =>
-      postCommand<{ invitedCount: number; skippedUnconsented: number }>(
-        `/api/marketing/batches/${encodeURIComponent(batchId)}/invite`,
-      ),
+      postCommand<{
+        invitedCount: number
+        skippedUnconsented: number
+        skippedNeedsReview?: number
+      }>(`/api/marketing/batches/${encodeURIComponent(batchId)}/invite`),
     onSuccess: (res) => {
+      const skipped = [
+        res.skippedUnconsented ? `${res.skippedUnconsented} unconsented` : null,
+        res.skippedNeedsReview ? `${res.skippedNeedsReview} needing review` : null,
+      ].filter(Boolean)
       toast.success(
         `Invited ${res.invitedCount} member(s)` +
-          (res.skippedUnconsented ? `, skipped ${res.skippedUnconsented} unconsented` : ''),
+          (skipped.length ? ` — skipped ${skipped.join(', ')}` : ''),
       )
     },
-    onError: (e: Error) => toast.error('Failed to trigger invitations', { description: e.message }),
+    onError: (e: Error, batchId) => {
+      toast.error('Failed to trigger invitations', { description: e.message })
+      recordMarketingFailure(
+        'Send batch invitations',
+        batchId,
+        `/api/marketing/batches/${encodeURIComponent(batchId)}/invite`,
+        undefined,
+        e,
+      )
+    },
   })
 }
 
@@ -98,7 +147,7 @@ export function useSetFeedbackStatus() {
       }),
     onSuccess: () => {
       toast.success('Feedback status updated')
-      qc.invalidateQueries({ queryKey: ['marketing-feedback'] })
+      invalidateWithLag(qc, [['marketing-feedback']])
     },
     onError: (e: Error) => toast.error('Failed to update status', { description: e.message }),
   })
@@ -119,9 +168,18 @@ export function useLinkContact() {
       }),
     onSuccess: () => {
       toast.success('Contact linked')
-      qc.invalidateQueries({ queryKey: ['marketing-contacts'] })
+      invalidateWithLag(qc, [['marketing-contacts']])
     },
-    onError: (e: Error) => toast.error('Failed to link contact', { description: e.message }),
+    onError: (e: Error, vars) => {
+      toast.error('Failed to link contact', { description: e.message })
+      recordMarketingFailure(
+        'Link contact to customer',
+        vars.contactId,
+        `/api/marketing/contacts/${encodeURIComponent(vars.contactId)}/link`,
+        { customer_id: vars.customerId },
+        e,
+      )
+    },
   })
 }
 
@@ -133,9 +191,50 @@ export function useUnlinkContact() {
       postCommand(`/api/marketing/contacts/${encodeURIComponent(contactId)}/unlink`),
     onSuccess: () => {
       toast.success('Contact unlinked')
-      qc.invalidateQueries({ queryKey: ['marketing-contacts'] })
+      invalidateWithLag(qc, [['marketing-contacts']])
     },
     onError: (e: Error) => toast.error('Failed to unlink contact', { description: e.message }),
+  })
+}
+
+export interface RecordConsentVars {
+  contactId: string
+  granted: boolean
+  channels: Array<'sms' | 'whatsapp' | 'email'>
+  method: string
+  evidence?: string
+}
+
+/** Staff consent capture/withdrawal (offline contacts, verbal opt-outs). */
+export function useRecordConsent() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: RecordConsentVars) =>
+      postCommand(`/api/marketing/contacts/${encodeURIComponent(vars.contactId)}/consent`, {
+        granted: vars.granted,
+        channels: vars.channels,
+        method: vars.method,
+        ...(vars.evidence ? { evidence: vars.evidence } : {}),
+      }),
+    onSuccess: (_res, vars) => {
+      toast.success(vars.granted ? 'Consent recorded' : 'Consent withdrawal recorded')
+      invalidateWithLag(qc, [['marketing-contacts']])
+    },
+    onError: (e: Error, vars) => {
+      toast.error('Failed to record consent', { description: e.message })
+      recordMarketingFailure(
+        vars.granted ? 'Record consent' : 'Record consent withdrawal',
+        vars.contactId,
+        `/api/marketing/contacts/${encodeURIComponent(vars.contactId)}/consent`,
+        {
+          granted: vars.granted,
+          channels: vars.channels,
+          method: vars.method,
+          evidence: vars.evidence,
+        },
+        e,
+      )
+    },
   })
 }
 
@@ -156,7 +255,7 @@ export function useSetReviewFlag() {
       }),
     onSuccess: (_res, vars) => {
       toast.success(vars.needsReview ? 'Contact flagged for review' : 'Review flag cleared')
-      qc.invalidateQueries({ queryKey: ['marketing-contacts'] })
+      invalidateWithLag(qc, [['marketing-contacts']])
     },
     onError: (e: Error) => toast.error('Failed to update review flag', { description: e.message }),
   })
@@ -178,9 +277,74 @@ export function useCreateContact() {
     mutationFn: (vars: CreateContactVars) =>
       postCommand<{ contactId: string; eventId: string }>('/api/marketing/contacts', vars),
     onSuccess: () => {
-      toast.success('Contact created')
-      qc.invalidateQueries({ queryKey: ['marketing-contacts'] })
+      toast.success('Contact created — appearing in the grid shortly')
+      invalidateWithLag(qc, [['marketing-contacts']])
     },
     onError: (e: Error) => toast.error('Failed to create contact', { description: e.message }),
   })
+}
+
+// ── Failed-actions integration ──────────────────────────────────────────────
+//
+// Marketing commands are idempotent platform-side, so a generic replay is
+// safe: every command is a postCommand(url, body). Failures land in the
+// shared failed-actions queue with enough context to replay verbatim.
+
+export interface MarketingCommandFailureParams {
+  url: string
+  body?: unknown
+  label: string
+  [key: string]: unknown
+}
+
+export function recordMarketingFailure(
+  label: string,
+  subjectId: string,
+  url: string,
+  body: unknown,
+  error: Error,
+): void {
+  useFailedActionsStore
+    .getState()
+    .addFailedAction(
+      'marketing-command',
+      subjectId,
+      { url, body, label } satisfies MarketingCommandFailureParams,
+      error.message,
+      label,
+    )
+}
+
+/**
+ * Mount once inside the marketing views: replays failed marketing commands
+ * when the Failed Actions panel dispatches a retry event.
+ */
+export function useMarketingCommandRetryListener() {
+  const qc = useQueryClient()
+  const removeAction = useFailedActionsStore((state) => state.removeAction)
+
+  useEffect(() => {
+    const onRetry = async (event: Event) => {
+      const detail = (event as CustomEvent).detail as
+        | { id: string; type: string; params: MarketingCommandFailureParams }
+        | undefined
+      if (!detail || detail.type !== 'marketing-command') return
+      try {
+        await postCommand(detail.params.url, detail.params.body)
+        removeAction(detail.id)
+        toast.success(`Retried: ${detail.params.label}`)
+        invalidateWithLag(qc, [
+          ['marketing-contacts'],
+          ['marketing-batches'],
+          ['marketing-feedback'],
+        ])
+      } catch (e) {
+        toast.error(`Retry failed: ${detail.params.label}`, {
+          description: e instanceof Error ? e.message : undefined,
+        })
+      }
+    }
+    window.addEventListener('billie-retry-action', onRetry)
+    return () => window.removeEventListener('billie-retry-action', onRetry)
+  }, [qc, removeAction])
 }

--- a/src/hooks/mutations/useRecordRepayment.ts
+++ b/src/hooks/mutations/useRecordRepayment.ts
@@ -93,7 +93,7 @@ async function recordRepayment(params: RecordRepaymentParams): Promise<RecordRep
  * 3. Submit API request
  * 4a. On success: update stage to 'confirmed', show toast, invalidate queries
  * 4b. On error: update stage to 'failed', show error toast
- * 
+ *
  * Also listens for `billie-retry-action` custom events to retry failed actions
  * from the Failed Actions Notification Center.
  */
@@ -104,7 +104,9 @@ export function useRecordRepayment(loanAccountId?: string, accountLabel?: string
   const addFailedAction = useFailedActionsStore((state) => state.addFailedAction)
   const removeAction = useFailedActionsStore((state) => state.removeAction)
   const getExpectedVersion = useVersionStore((state) => state.getExpectedVersion)
-  const hasPendingRepayment = loanAccountId ? hasPendingAction(loanAccountId, 'record-repayment') : false
+  const hasPendingRepayment = loanAccountId
+    ? hasPendingAction(loanAccountId, 'record-repayment')
+    : false
 
   const mutation = useMutation({
     mutationFn: recordRepayment,
@@ -148,7 +150,8 @@ export function useRecordRepayment(loanAccountId?: string, accountLabel?: string
 
       // Show success toast
       toast.success('Repayment recorded', {
-        description: allocDesc.length > 0 ? allocDesc.join(', ') : `$${params.amount.toFixed(2)} applied`,
+        description:
+          allocDesc.length > 0 ? allocDesc.join(', ') : `$${params.amount.toFixed(2)} applied`,
       })
 
       // Invalidate transactions query to refresh list
@@ -198,15 +201,16 @@ export function useRecordRepayment(loanAccountId?: string, accountLabel?: string
             notes: params.notes,
           },
           appError.message,
-          accountLabel
+          accountLabel,
         )
       }
 
       // Show error toast with retry option and copy details
       toast.error('Failed to record repayment', {
-        description: appError.code === ERROR_CODES.UNKNOWN_ERROR
-          ? `${appError.message} (${appError.errorId})`
-          : appError.message,
+        description:
+          appError.code === ERROR_CODES.UNKNOWN_ERROR
+            ? `${appError.message} (${appError.errorId})`
+            : appError.message,
         action: appError.isRetryable()
           ? {
               label: 'Retry',
@@ -217,10 +221,11 @@ export function useRecordRepayment(loanAccountId?: string, accountLabel?: string
             }
           : {
               label: '📋 Copy details',
-              onClick: () => copyErrorDetails(appError, {
-                action: 'record-repayment',
-                accountId: params.loanAccountId,
-              }),
+              onClick: () =>
+                copyErrorDetails(appError, {
+                  action: 'record-repayment',
+                  accountId: params.loanAccountId,
+                }),
             },
       })
     },
@@ -250,7 +255,8 @@ export function useRecordRepayment(loanAccountId?: string, accountLabel?: string
       }
 
       // Execute the mutation and remove from failed actions on success
-      mutation.mutateAsync(repaymentParams)
+      mutation
+        .mutateAsync(repaymentParams)
         .then(() => {
           // Successfully retried - remove from failed actions
           removeAction(id)
@@ -260,7 +266,7 @@ export function useRecordRepayment(loanAccountId?: string, accountLabel?: string
           // The action stays in the queue for another retry attempt
         })
     },
-    [mutation, removeAction, getExpectedVersion]
+    [mutation, removeAction, getExpectedVersion],
   )
 
   // Listen for retry events
@@ -279,7 +285,7 @@ export function useRecordRepayment(loanAccountId?: string, accountLabel?: string
       const expectedVersion = getExpectedVersion(params.loanAccountId)
       mutation.mutate({ ...params, expectedVersion })
     },
-    [mutation, getExpectedVersion]
+    [mutation, getExpectedVersion],
   )
 
   const recordRepaymentAsyncWithVersion = useCallback(
@@ -287,7 +293,7 @@ export function useRecordRepayment(loanAccountId?: string, accountLabel?: string
       const expectedVersion = getExpectedVersion(params.loanAccountId)
       return mutation.mutateAsync({ ...params, expectedVersion })
     },
-    [mutation, getExpectedVersion]
+    [mutation, getExpectedVersion],
   )
 
   return {

--- a/src/hooks/mutations/useRejectWriteOff.ts
+++ b/src/hooks/mutations/useRejectWriteOff.ts
@@ -46,9 +46,7 @@ export interface RejectWriteOffResult {
 /**
  * Publish reject command via the command API.
  */
-async function publishRejectCommand(
-  params: RejectWriteOffParams
-): Promise<PublishEventResponse> {
+async function publishRejectCommand(params: RejectWriteOffParams): Promise<PublishEventResponse> {
   const command: WriteOffRejectCommand = {
     requestId: params.requestId,
     requestNumber: params.requestNumber,
@@ -72,9 +70,7 @@ async function publishRejectCommand(
 /**
  * Reject write-off request and poll for the status change.
  */
-async function rejectWriteOff(
-  params: RejectWriteOffParams
-): Promise<RejectWriteOffResult> {
+async function rejectWriteOff(params: RejectWriteOffParams): Promise<RejectWriteOffResult> {
   // Validate reason length
   if (!params.reason || params.reason.trim().length < MIN_APPROVAL_COMMENT_LENGTH) {
     throw new Error(`Rejection reason must be at least ${MIN_APPROVAL_COMMENT_LENGTH} characters`)
@@ -91,7 +87,7 @@ async function rejectWriteOff(
       maxAttempts: 10,
       intervalMs: 500,
       initialDelayMs: 100,
-    }
+    },
   )
 
   return projection
@@ -125,7 +121,8 @@ export function useRejectWriteOff() {
       // Handle polling timeout specifically
       if (error instanceof PollTimeoutError) {
         toast.warning('Rejection submitted but confirmation delayed', {
-          description: 'Your rejection was accepted but is taking longer than expected. Please refresh to see the status.',
+          description:
+            'Your rejection was accepted but is taking longer than expected. Please refresh to see the status.',
         })
         queryClient.invalidateQueries({ queryKey: ['write-off-requests'] })
         return

--- a/src/hooks/mutations/useScheduleConfigChange.ts
+++ b/src/hooks/mutations/useScheduleConfigChange.ts
@@ -46,7 +46,11 @@ export function useScheduleConfigChange() {
       })
       if (!res.ok) {
         const error = await res.json().catch(() => ({}))
-        const errorMessage = error.error || error.message || error.details || `HTTP ${res.status}: Failed to schedule config change`
+        const errorMessage =
+          error.error ||
+          error.message ||
+          error.details ||
+          `HTTP ${res.status}: Failed to schedule config change`
         throw new Error(errorMessage)
       }
       return res.json()

--- a/src/hooks/mutations/useTriggerPortfolioRecalc.ts
+++ b/src/hooks/mutations/useTriggerPortfolioRecalc.ts
@@ -47,7 +47,11 @@ export function useTriggerPortfolioRecalc() {
       })
       if (!res.ok) {
         const error = await res.json().catch(() => ({}))
-        const errorMessage = error.error || error.message || error.details || `HTTP ${res.status}: Failed to trigger recalculation`
+        const errorMessage =
+          error.error ||
+          error.message ||
+          error.details ||
+          `HTTP ${res.status}: Failed to trigger recalculation`
         throw new Error(errorMessage)
       }
       return res.json()
@@ -55,7 +59,7 @@ export function useTriggerPortfolioRecalc() {
     onSuccess: (data) => {
       // Invalidate portfolio ECL data after recalc starts
       queryClient.invalidateQueries({ queryKey: ['portfolio-ecl'] })
-      
+
       // Show success toast
       toast.success('ECL recalculation started', {
         description: `Processing ${data.accountCount} accounts`,
@@ -63,7 +67,8 @@ export function useTriggerPortfolioRecalc() {
     },
     onError: (error) => {
       // Show error toast
-      const errorMessage = error instanceof Error ? error.message : 'Failed to trigger recalculation'
+      const errorMessage =
+        error instanceof Error ? error.message : 'Failed to trigger recalculation'
       toast.error('Failed to trigger recalculation', {
         description: errorMessage,
       })

--- a/src/hooks/mutations/useUpdateOverlay.ts
+++ b/src/hooks/mutations/useUpdateOverlay.ts
@@ -43,7 +43,11 @@ export function useUpdateOverlay() {
       })
       if (!res.ok) {
         const error = await res.json().catch(() => ({}))
-        const errorMessage = error.error || error.message || error.details || `HTTP ${res.status}: Failed to update overlay multiplier`
+        const errorMessage =
+          error.error ||
+          error.message ||
+          error.details ||
+          `HTTP ${res.status}: Failed to update overlay multiplier`
         throw new Error(errorMessage)
       }
       return res.json()
@@ -52,7 +56,7 @@ export function useUpdateOverlay() {
       // Invalidate ECL config to refresh data
       queryClient.invalidateQueries({ queryKey: eclConfigQueryKey })
       queryClient.invalidateQueries({ queryKey: ['ecl-config', 'history'] })
-      
+
       // Show success toast
       toast.success('Overlay multiplier updated', {
         description: `Overlay multiplier updated to ${data.newValue.toFixed(2)}x`,
@@ -60,7 +64,8 @@ export function useUpdateOverlay() {
     },
     onError: (error) => {
       // Show error toast
-      const errorMessage = error instanceof Error ? error.message : 'Failed to update overlay multiplier'
+      const errorMessage =
+        error instanceof Error ? error.message : 'Failed to update overlay multiplier'
       toast.error('Failed to update overlay multiplier', {
         description: errorMessage,
       })

--- a/src/hooks/mutations/useUpdatePDRate.ts
+++ b/src/hooks/mutations/useUpdatePDRate.ts
@@ -54,7 +54,7 @@ export function useUpdatePDRate() {
       // Invalidate ECL config to refresh data
       queryClient.invalidateQueries({ queryKey: eclConfigQueryKey })
       queryClient.invalidateQueries({ queryKey: ['ecl-config', 'history'] })
-      
+
       // Show success toast
       toast.success('PD rate updated', {
         description: `Bucket "${data.bucket}" rate updated to ${(data.newRate * 100).toFixed(2)}%`,

--- a/src/hooks/mutations/useWaiveFee.ts
+++ b/src/hooks/mutations/useWaiveFee.ts
@@ -71,14 +71,14 @@ async function waiveFee(params: WaiveFeeParams): Promise<WaiveFeeResponse> {
 
 /**
  * Mutation hook for waiving fees with optimistic UI updates.
- * 
+ *
  * Flow:
  * 1. Generate idempotency key
  * 2. Add to optimistic store (stage: 'optimistic')
  * 3. Submit API request
  * 4a. On success: update stage to 'confirmed', show toast, invalidate queries
  * 4b. On error: update stage to 'failed', show error toast
- * 
+ *
  * Also listens for `billie-retry-action` custom events to retry failed actions
  * from the Failed Actions Notification Center.
  */
@@ -96,10 +96,7 @@ export function useWaiveFee(loanAccountId?: string, accountLabel?: string) {
 
     onMutate: async (params) => {
       // Generate idempotency key
-      const mutationId = generateIdempotencyKey(
-        params.loanAccountId,
-        'waive-fee'
-      )
+      const mutationId = generateIdempotencyKey(params.loanAccountId, 'waive-fee')
 
       // Create pending mutation
       const pendingMutation: PendingMutation = {
@@ -176,15 +173,16 @@ export function useWaiveFee(loanAccountId?: string, accountLabel?: string) {
             approvedBy: params.approvedBy,
           },
           appError.message,
-          accountLabel
+          accountLabel,
         )
       }
 
       // Show error toast with retry option and copy details
       toast.error('Failed to waive fee', {
-        description: appError.code === ERROR_CODES.UNKNOWN_ERROR
-          ? `${appError.message} (${appError.errorId})`
-          : appError.message,
+        description:
+          appError.code === ERROR_CODES.UNKNOWN_ERROR
+            ? `${appError.message} (${appError.errorId})`
+            : appError.message,
         action: appError.isRetryable()
           ? {
               label: 'Retry',
@@ -195,10 +193,11 @@ export function useWaiveFee(loanAccountId?: string, accountLabel?: string) {
             }
           : {
               label: '📋 Copy details',
-              onClick: () => copyErrorDetails(appError, {
-                action: 'waive-fee',
-                accountId: params.loanAccountId,
-              }),
+              onClick: () =>
+                copyErrorDetails(appError, {
+                  action: 'waive-fee',
+                  accountId: params.loanAccountId,
+                }),
             },
       })
     },
@@ -227,7 +226,8 @@ export function useWaiveFee(loanAccountId?: string, accountLabel?: string) {
       }
 
       // Execute the mutation and remove from failed actions on success
-      mutation.mutateAsync(waiveParams)
+      mutation
+        .mutateAsync(waiveParams)
         .then(() => {
           // Successfully retried - remove from failed actions
           removeAction(id)
@@ -237,7 +237,7 @@ export function useWaiveFee(loanAccountId?: string, accountLabel?: string) {
           // The action stays in the queue for another retry attempt
         })
     },
-    [mutation, removeAction, getExpectedVersion]
+    [mutation, removeAction, getExpectedVersion],
   )
 
   // Listen for retry events
@@ -256,7 +256,7 @@ export function useWaiveFee(loanAccountId?: string, accountLabel?: string) {
       const expectedVersion = getExpectedVersion(params.loanAccountId)
       mutation.mutate({ ...params, expectedVersion })
     },
-    [mutation, getExpectedVersion]
+    [mutation, getExpectedVersion],
   )
 
   const waiveFeeAsyncWithVersion = useCallback(
@@ -264,7 +264,7 @@ export function useWaiveFee(loanAccountId?: string, accountLabel?: string) {
       const expectedVersion = getExpectedVersion(params.loanAccountId)
       return mutation.mutateAsync({ ...params, expectedVersion })
     },
-    [mutation, getExpectedVersion]
+    [mutation, getExpectedVersion],
   )
 
   return {

--- a/src/hooks/mutations/useWriteOffRequest.ts
+++ b/src/hooks/mutations/useWriteOffRequest.ts
@@ -66,7 +66,7 @@ export const writeOffRequestsQueryKey = (loanAccountId: string) =>
  * Returns 202 Accepted with eventId for polling.
  */
 async function publishWriteOffCommand(
-  params: WriteOffRequestParams
+  params: WriteOffRequestParams,
 ): Promise<PublishEventResponse> {
   const command: WriteOffRequestCommand = {
     loanAccountId: params.loanAccountId,
@@ -98,7 +98,7 @@ async function publishWriteOffCommand(
  * Submit write-off request and poll for the resulting projection.
  */
 async function submitWriteOffRequest(
-  params: WriteOffRequestParams
+  params: WriteOffRequestParams,
 ): Promise<WriteOffRequestResult> {
   // 1. Publish the command event
   const { eventId } = await publishWriteOffCommand(params)
@@ -148,7 +148,8 @@ export function useWriteOffRequest() {
       // Handle polling timeout specifically
       if (error instanceof PollTimeoutError) {
         toast.error('Request submitted but confirmation delayed', {
-          description: 'Your request was accepted but is taking longer than expected to process. Please refresh to see the status.',
+          description:
+            'Your request was accepted but is taking longer than expected to process. Please refresh to see the status.',
         })
         // Still invalidate queries so a manual refresh shows the request
         queryClient.invalidateQueries({ queryKey: ['write-off-requests'] })

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -37,7 +37,12 @@ export type {
   UseAccountAgingOptions,
 } from './useAccountAging'
 
-export { useAccruedYield, useAccrualHistory, accruedYieldQueryKey, accrualHistoryQueryKey } from './useAccruedYield'
+export {
+  useAccruedYield,
+  useAccrualHistory,
+  accruedYieldQueryKey,
+  accrualHistoryQueryKey,
+} from './useAccruedYield'
 export type {
   AccruedYieldResponse,
   AccrualCalculationBreakdown,
@@ -66,7 +71,10 @@ export type {
 } from './useScheduleWithStatus'
 
 // Carrying amount breakdown hook (E2-S9)
-export { useCarryingAmountBreakdown, carryingAmountBreakdownQueryKey } from './useCarryingAmountBreakdown'
+export {
+  useCarryingAmountBreakdown,
+  carryingAmountBreakdownQueryKey,
+} from './useCarryingAmountBreakdown'
 export type {
   CarryingAmountBreakdownResponse,
   UseCarryingAmountBreakdownOptions,
@@ -80,13 +88,24 @@ export type { ClosedPeriod } from './useClosedPeriods'
 export { useECLConfig, eclConfigQueryKey } from './useECLConfig'
 export type { ECLConfig, PDRateConfig } from './useECLConfig'
 export { useECLConfigHistory, eclConfigHistoryQueryKey } from './useECLConfigHistory'
-export type { ECLConfigHistoryEntry, ECLConfigHistoryResponse, UseECLConfigHistoryOptions } from './useECLConfigHistory'
+export type {
+  ECLConfigHistoryEntry,
+  ECLConfigHistoryResponse,
+  UseECLConfigHistoryOptions,
+} from './useECLConfigHistory'
 export { usePendingConfigChanges, pendingConfigChangesQueryKey } from './usePendingConfigChanges'
 export type { PendingConfigChange, PendingConfigChangesResponse } from './usePendingConfigChanges'
 
 // Export Center hooks (E5)
 export { useExportJobs, exportJobsQueryKey } from './useExportJobs'
-export type { ExportJob, ExportJobStatus, ExportJobType, ExportFormat, ExportJobsResponse, UseExportJobsOptions } from './useExportJobs'
+export type {
+  ExportJob,
+  ExportJobStatus,
+  ExportJobType,
+  ExportFormat,
+  ExportJobsResponse,
+  UseExportJobsOptions,
+} from './useExportJobs'
 
 // Investigation hooks (E6)
 export { useEventHistory, eventHistoryQueryKey } from './useEventHistory'

--- a/src/hooks/queries/useAccountAging.ts
+++ b/src/hooks/queries/useAccountAging.ts
@@ -61,8 +61,7 @@ async function fetchAccountAging(accountId: string): Promise<AccountAgingRespons
 /**
  * Query key for account aging
  */
-export const accountAgingQueryKey = (accountId: string) =>
-  ['account-aging', accountId] as const
+export const accountAgingQueryKey = (accountId: string) => ['account-aging', accountId] as const
 
 /**
  * Hook to fetch account aging status (DPD, bucket, overdue amounts).

--- a/src/hooks/queries/useAccruedYield.ts
+++ b/src/hooks/queries/useAccruedYield.ts
@@ -130,8 +130,7 @@ async function fetchAccrualHistory(
 /**
  * Query key for accrued yield
  */
-export const accruedYieldQueryKey = (accountId: string) =>
-  ['accrued-yield', accountId] as const
+export const accruedYieldQueryKey = (accountId: string) => ['accrued-yield', accountId] as const
 
 /**
  * Query key for accrual history

--- a/src/hooks/queries/useApprovalHistory.ts
+++ b/src/hooks/queries/useApprovalHistory.ts
@@ -72,7 +72,7 @@ export interface ApprovalHistoryOptions {
  * Only returns approved and rejected requests (completed workflow).
  */
 async function fetchApprovalHistory(
-  options: ApprovalHistoryOptions = {}
+  options: ApprovalHistoryOptions = {},
 ): Promise<ApprovalHistoryResponse> {
   const { page = 1, limit = DEFAULT_PAGE_SIZE, sort = 'newest', filters = {} } = options
 
@@ -93,13 +93,13 @@ async function fetchApprovalHistory(
   // To filter by decision date, use approvalDetails.decidedAt field (future enhancement).
   if (filters.startDate) {
     where.createdAt = {
-      ...(where.createdAt as Record<string, unknown> || {}),
+      ...((where.createdAt as Record<string, unknown>) || {}),
       greater_than_equal: filters.startDate,
     }
   }
   if (filters.endDate) {
     where.createdAt = {
-      ...(where.createdAt as Record<string, unknown> || {}),
+      ...((where.createdAt as Record<string, unknown>) || {}),
       less_than_equal: filters.endDate,
     }
   }
@@ -124,7 +124,7 @@ async function fetchApprovalHistory(
       page,
       sort: sortMap[sort] || '-updatedAt',
     },
-    { addQueryPrefix: true }
+    { addQueryPrefix: true },
   )
 
   const res = await fetch(`/api/write-off-requests${queryString}`)

--- a/src/hooks/queries/useApprovalNotifications.ts
+++ b/src/hooks/queries/useApprovalNotifications.ts
@@ -62,7 +62,7 @@ async function fetchApprovalNotifications(): Promise<PendingApprovalsResponse> {
  */
 function getSeenNotifications(): Set<string> {
   if (typeof window === 'undefined') return new Set()
-  
+
   try {
     const stored = localStorage.getItem(SEEN_NOTIFICATIONS_KEY)
     if (stored) {
@@ -79,7 +79,7 @@ function getSeenNotifications(): Set<string> {
  */
 function markNotificationsAsSeen(ids: string[]): void {
   if (typeof window === 'undefined') return
-  
+
   try {
     const seen = getSeenNotifications()
     ids.forEach((id) => seen.add(id))
@@ -100,20 +100,17 @@ export const approvalNotificationsQueryKey = ['write-off-requests', 'notificatio
 
 /**
  * Hook for fetching and managing approval notifications.
- * 
+ *
  * Features:
  * - Polls every 30 seconds for new pending approvals
  * - Detects new notifications and shows toast
  * - Tracks seen notifications in localStorage
  * - Returns unread count and notification list
- * 
+ *
  * @param options.enabled - Whether to enable polling (default: true)
  * @param options.showToasts - Whether to show toast for new items (default: true)
  */
-export function useApprovalNotifications(options?: {
-  enabled?: boolean
-  showToasts?: boolean
-}) {
+export function useApprovalNotifications(options?: { enabled?: boolean; showToasts?: boolean }) {
   const { enabled = true, showToasts = true } = options ?? {}
   const queryClient = useQueryClient()
   const previousIdsRef = useRef<Set<string>>(new Set())
@@ -143,7 +140,7 @@ export function useApprovalNotifications(options?: {
 
     // Find new notifications that weren't in the previous set and haven't been seen
     const newNotifications = query.data.docs.filter(
-      (n) => !previousIdsRef.current.has(n.id) && !seenIds.has(n.id)
+      (n) => !previousIdsRef.current.has(n.id) && !seenIds.has(n.id),
     )
 
     if (newNotifications.length > 0) {
@@ -197,7 +194,7 @@ export function useApprovalNotifications(options?: {
       markNotificationsAsSeen([id])
       queryClient.invalidateQueries({ queryKey: approvalNotificationsQueryKey })
     },
-    [queryClient]
+    [queryClient],
   )
 
   return {

--- a/src/hooks/queries/useBatches.ts
+++ b/src/hooks/queries/useBatches.ts
@@ -7,8 +7,11 @@ export interface BatchesFilters {
   page?: number
 }
 
+/** Batch enriched server-side with its contact member count. */
+export type BatchWithCount = Batch & { memberCount?: number }
+
 export interface BatchesResponse {
-  docs: Batch[]
+  docs: BatchWithCount[]
   totalDocs: number
   totalPages: number
   page: number

--- a/src/hooks/queries/useCarryingAmountBreakdown.ts
+++ b/src/hooks/queries/useCarryingAmountBreakdown.ts
@@ -48,7 +48,9 @@ export const carryingAmountBreakdownQueryKey = (accountId: string) => [
 async function fetchCarryingAmountBreakdown(
   accountId: string,
 ): Promise<CarryingAmountBreakdownResponse | null> {
-  const response = await fetch(`/api/investigation/carrying-amount/${encodeURIComponent(accountId)}`)
+  const response = await fetch(
+    `/api/investigation/carrying-amount/${encodeURIComponent(accountId)}`,
+  )
 
   if (!response.ok) {
     if (response.status === 503) {

--- a/src/hooks/queries/useContactNotes.ts
+++ b/src/hooks/queries/useContactNotes.ts
@@ -20,7 +20,9 @@ export interface ContactNoteData {
   amendsNote?: string | null | { id: string }
   customer: string | { id: string; fullName?: string | null }
   loanAccount?: string | null | { id: string; loanAccountId: string; accountNumber: string }
-  createdBy: string | { id: string; firstName?: string | null; lastName?: string | null; email?: string | null }
+  createdBy:
+    | string
+    | { id: string; firstName?: string | null; lastName?: string | null; email?: string | null }
   createdAt: string
   updatedAt: string
 }
@@ -50,9 +52,7 @@ async function fetchContactNotes(
   filters: ContactNotesFilters,
   page: number,
 ): Promise<ContactNotesResult> {
-  const andClauses: Record<string, unknown>[] = [
-    { 'customer': { equals: customerId } },
-  ]
+  const andClauses: Record<string, unknown>[] = [{ customer: { equals: customerId } }]
 
   if (filters.topic) {
     andClauses.push({ topic: { equals: filters.topic } })

--- a/src/hooks/queries/useConversations.ts
+++ b/src/hooks/queries/useConversations.ts
@@ -59,8 +59,7 @@ export function useConversations({
 }: UseConversationsOptions = {}): UseConversationsResult {
   const query = useInfiniteQuery({
     queryKey: ['conversations', filters],
-    queryFn: ({ pageParam }) =>
-      fetchConversations({ ...filters, cursor: pageParam ?? undefined }),
+    queryFn: ({ pageParam }) => fetchConversations({ ...filters, cursor: pageParam ?? undefined }),
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.cursor : undefined),
     enabled,

--- a/src/hooks/queries/useECLAllowance.ts
+++ b/src/hooks/queries/useECLAllowance.ts
@@ -96,8 +96,7 @@ async function fetchECLAllowance(accountId: string): Promise<ECLAllowanceRespons
 /**
  * Query key for ECL allowance
  */
-export const eclAllowanceQueryKey = (accountId: string) =>
-  ['ecl-allowance', accountId] as const
+export const eclAllowanceQueryKey = (accountId: string) => ['ecl-allowance', accountId] as const
 
 /**
  * Hook to fetch ECL (Expected Credit Loss) allowance for an account.

--- a/src/hooks/queries/useEventHistory.ts
+++ b/src/hooks/queries/useEventHistory.ts
@@ -29,8 +29,10 @@ export interface UseEventHistoryOptions {
   enabled?: boolean
 }
 
-export const eventHistoryQueryKey = (accountId: string, options?: Partial<UseEventHistoryOptions>) =>
-  ['event-history', accountId, options] as const
+export const eventHistoryQueryKey = (
+  accountId: string,
+  options?: Partial<UseEventHistoryOptions>,
+) => ['event-history', accountId, options] as const
 
 /**
  * Hook to fetch event history for an account.

--- a/src/hooks/queries/useExportJobs.ts
+++ b/src/hooks/queries/useExportJobs.ts
@@ -48,7 +48,10 @@ export interface ExportJobsResponse {
 export interface UseExportJobsOptions {
   userId?: string
   enabled?: boolean
-  refetchInterval?: number | false | ((query: { state: { data?: ExportJobsResponse } }) => number | false)
+  refetchInterval?:
+    | number
+    | false
+    | ((query: { state: { data?: ExportJobsResponse } }) => number | false)
 }
 
 export const exportJobsQueryKey = ['export-jobs'] as const

--- a/src/hooks/queries/useFeesCount.ts
+++ b/src/hooks/queries/useFeesCount.ts
@@ -19,8 +19,7 @@ export function useFeesCount(loanAccountId: string | null): number {
     return transactions.filter((tx) => {
       const feeAmount = parseFloat(tx.feeDelta || '0')
       return (
-        WAIVABLE_FEE_TYPES.includes(tx.type as (typeof WAIVABLE_FEE_TYPES)[number]) &&
-        feeAmount > 0
+        WAIVABLE_FEE_TYPES.includes(tx.type as (typeof WAIVABLE_FEE_TYPES)[number]) && feeAmount > 0
       )
     }).length
   }, [data?.transactions])

--- a/src/hooks/queries/useMarketingContacts.ts
+++ b/src/hooks/queries/useMarketingContacts.ts
@@ -10,6 +10,7 @@ export interface MarketingContactsFilters {
   city?: string
   batch?: string
   needs_review?: string
+  loan_status?: string
   page?: number
 }
 
@@ -31,6 +32,7 @@ function buildQueryString(filters: MarketingContactsFilters): string {
   if (filters.city) params.set('city', filters.city)
   if (filters.batch) params.set('batch', filters.batch)
   if (filters.needs_review) params.set('needs_review', filters.needs_review)
+  if (filters.loan_status) params.set('loan_status', filters.loan_status)
   if (filters.page) params.set('page', String(filters.page))
   const qs = params.toString()
   return qs ? `?${qs}` : ''

--- a/src/hooks/queries/useMarketingContacts.ts
+++ b/src/hooks/queries/useMarketingContacts.ts
@@ -9,6 +9,7 @@ export interface MarketingContactsFilters {
   source?: string
   city?: string
   batch?: string
+  needs_review?: string
   page?: number
 }
 
@@ -29,6 +30,7 @@ function buildQueryString(filters: MarketingContactsFilters): string {
   if (filters.source) params.set('source', filters.source)
   if (filters.city) params.set('city', filters.city)
   if (filters.batch) params.set('batch', filters.batch)
+  if (filters.needs_review) params.set('needs_review', filters.needs_review)
   if (filters.page) params.set('page', String(filters.page))
   const qs = params.toString()
   return qs ? `?${qs}` : ''

--- a/src/hooks/queries/useNotificationSuppression.ts
+++ b/src/hooks/queries/useNotificationSuppression.ts
@@ -17,7 +17,9 @@ interface SuppressionResponse {
 }
 
 async function fetchSuppression(customerId: string): Promise<SuppressionData | null> {
-  const res = await fetch(`/api/notifications/suppression?customerId=${encodeURIComponent(customerId)}`)
+  const res = await fetch(
+    `/api/notifications/suppression?customerId=${encodeURIComponent(customerId)}`,
+  )
   if (!res.ok) {
     throw new Error('Failed to fetch notification suppression state')
   }
@@ -39,9 +41,7 @@ export interface UseNotificationSuppressionResult {
   isExpired: boolean
 }
 
-export function useNotificationSuppression(
-  customerId: string,
-): UseNotificationSuppressionResult {
+export function useNotificationSuppression(customerId: string): UseNotificationSuppressionResult {
   const query = useQuery({
     queryKey: suppressionQueryKey(customerId),
     queryFn: () => fetchSuppression(customerId),

--- a/src/hooks/queries/useNotifications.ts
+++ b/src/hooks/queries/useNotifications.ts
@@ -1,12 +1,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { stringify } from 'qs-esm'
 
-export type NotificationStatus =
-  | 'sent'
-  | 'failed'
-  | 'blocked'
-  | 'statement'
-  | 'suppression_change'
+export type NotificationStatus = 'sent' | 'failed' | 'blocked' | 'statement' | 'suppression_change'
 
 export interface NotificationData {
   id: string

--- a/src/hooks/queries/useOverdueAccounts.ts
+++ b/src/hooks/queries/useOverdueAccounts.ts
@@ -57,9 +57,11 @@ export interface UseOverdueAccountsOptions extends OverdueAccountsFilters {
 /**
  * Fetch overdue accounts from the API
  */
-async function fetchOverdueAccounts(filters: OverdueAccountsFilters): Promise<OverdueAccountsResponse> {
+async function fetchOverdueAccounts(
+  filters: OverdueAccountsFilters,
+): Promise<OverdueAccountsResponse> {
   const params = new URLSearchParams()
-  
+
   if (filters.bucket) params.set('bucket', filters.bucket)
   if (filters.minDpd !== undefined) params.set('minDpd', filters.minDpd.toString())
   if (filters.maxDpd !== undefined) params.set('maxDpd', filters.maxDpd.toString())

--- a/src/hooks/queries/usePendingApprovals.ts
+++ b/src/hooks/queries/usePendingApprovals.ts
@@ -21,7 +21,9 @@ export interface WriteOffApproval {
   requiresSeniorApproval: boolean
   requestedAt: string
   /** User who requested - can be a string ID or populated user object */
-  requestedBy?: string | { id: string | number; email?: string; firstName?: string; lastName?: string }
+  requestedBy?:
+    | string
+    | { id: string | number; email?: string; firstName?: string; lastName?: string }
   requestedByName?: string
   createdAt: string
   updatedAt: string
@@ -46,7 +48,7 @@ export interface PendingApprovalsOptions {
 }
 
 async function fetchPendingApprovals(
-  options: PendingApprovalsOptions = {}
+  options: PendingApprovalsOptions = {},
 ): Promise<PendingApprovalsResponse> {
   const { page = 1, limit = 20, sort = 'oldest' } = options
 
@@ -67,7 +69,7 @@ async function fetchPendingApprovals(
       page,
       sort: sortMap[sort] || 'createdAt',
     },
-    { addQueryPrefix: true }
+    { addQueryPrefix: true },
   )
 
   const res = await fetch(`/api/write-off-requests${queryString}`)

--- a/src/hooks/queries/usePendingWriteOff.ts
+++ b/src/hooks/queries/usePendingWriteOff.ts
@@ -19,22 +19,17 @@ interface WriteOffRequestsResponse {
   hasPrevPage: boolean
 }
 
-async function fetchPendingWriteOff(
-  loanAccountId: string
-): Promise<PendingWriteOffData | null> {
+async function fetchPendingWriteOff(loanAccountId: string): Promise<PendingWriteOffData | null> {
   // Use qs-esm to properly serialize Payload REST API where queries
   const queryString = stringify(
     {
       where: {
-        and: [
-          { loanAccountId: { equals: loanAccountId } },
-          { status: { equals: 'pending' } },
-        ],
+        and: [{ loanAccountId: { equals: loanAccountId } }, { status: { equals: 'pending' } }],
       },
       limit: 1,
       sort: '-createdAt',
     },
-    { addQueryPrefix: true }
+    { addQueryPrefix: true },
   )
 
   const res = await fetch(`/api/write-off-requests${queryString}`)

--- a/src/hooks/queries/useScheduleWithStatus.ts
+++ b/src/hooks/queries/useScheduleWithStatus.ts
@@ -62,7 +62,9 @@ export const scheduleWithStatusQueryKey = (accountId: string) => ['schedule-with
 // Fetcher
 // =============================================================================
 
-async function fetchScheduleWithStatus(accountId: string): Promise<ScheduleWithStatusResponse | null> {
+async function fetchScheduleWithStatus(
+  accountId: string,
+): Promise<ScheduleWithStatusResponse | null> {
   const response = await fetch(`/api/ledger/schedule/${encodeURIComponent(accountId)}`)
 
   if (!response.ok) {

--- a/src/hooks/queries/useTransactions.ts
+++ b/src/hooks/queries/useTransactions.ts
@@ -61,11 +61,11 @@ export const TRANSACTION_TYPES = [
 
 async function fetchTransactions(
   loanAccountId: string,
-  filters: TransactionFilters
+  filters: TransactionFilters,
 ): Promise<TransactionsResponse> {
   const params = new URLSearchParams()
   params.set('loanAccountId', loanAccountId)
-  
+
   if (filters.limit) params.set('limit', filters.limit.toString())
   if (filters.type) params.set('type', filters.type)
   if (filters.fromDate) params.set('fromDate', filters.fromDate)
@@ -99,4 +99,3 @@ export function useTransactions(loanAccountId: string | null, filters: Transacti
     placeholderData: keepPreviousData,
   })
 }
-

--- a/src/hooks/useGlobalHotkeys.ts
+++ b/src/hooks/useGlobalHotkeys.ts
@@ -25,9 +25,7 @@ export function useGlobalHotkeys(hotkeys: HotkeyConfig[]): void {
       // Check if we're in an input/textarea/contenteditable
       const target = e.target as HTMLElement
       const isInput =
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.isContentEditable
+        target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
 
       for (const hotkey of hotkeys) {
         // Skip if in input and not allowed
@@ -71,7 +69,7 @@ export function useGlobalHotkeys(hotkeys: HotkeyConfig[]): void {
  */
 export function useCommandPaletteHotkeys(
   isOpen: boolean,
-  onOpenChange: (open: boolean) => void
+  onOpenChange: (open: boolean) => void,
 ): void {
   // Memoize callbacks to prevent effect re-runs
   const handleToggle = useCallback(() => onOpenChange(!isOpen), [isOpen, onOpenChange])
@@ -83,24 +81,27 @@ export function useCommandPaletteHotkeys(
   }, [isOpen, onOpenChange])
 
   // Memoize hotkeys array to prevent effect re-runs on every render
-  const hotkeys = useMemo<HotkeyConfig[]>(() => [
-    {
-      key: 'k',
-      cmdOrCtrl: true,
-      onPress: handleToggle,
-      allowInInput: true,
-    },
-    {
-      key: 'F7',
-      onPress: handleOpen,
-      allowInInput: true,
-    },
-    {
-      key: 'Escape',
-      onPress: handleClose,
-      allowInInput: true,
-    },
-  ], [handleToggle, handleOpen, handleClose])
+  const hotkeys = useMemo<HotkeyConfig[]>(
+    () => [
+      {
+        key: 'k',
+        cmdOrCtrl: true,
+        onPress: handleToggle,
+        allowInInput: true,
+      },
+      {
+        key: 'F7',
+        onPress: handleOpen,
+        allowInInput: true,
+      },
+      {
+        key: 'Escape',
+        onPress: handleClose,
+        allowInInput: true,
+      },
+    ],
+    [handleToggle, handleOpen, handleClose],
+  )
 
   useGlobalHotkeys(hotkeys)
 }

--- a/src/hooks/useListKeyboardNav.ts
+++ b/src/hooks/useListKeyboardNav.ts
@@ -57,9 +57,7 @@ export function useListKeyboardNav(options: UseListKeyboardNavOptions): {
       const target = e.target as HTMLElement | null
       const inInput =
         !!target &&
-        (target.tagName === 'INPUT' ||
-          target.tagName === 'TEXTAREA' ||
-          target.isContentEditable)
+        (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
       if (inInput) return
 
       // Skip modifier-laden combos so we don't conflict with browser/system

--- a/src/hooks/useModalA11y.ts
+++ b/src/hooks/useModalA11y.ts
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Minimal modal accessibility: close on Escape while mounted. Pair with
+ * role="dialog" aria-modal="true" on the overlay's dialog element (see
+ * CommandPalette for the full in-repo pattern).
+ */
+export function useEscapeClose(onClose: () => void): void {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+}

--- a/src/hooks/useVersionConflictModal.ts
+++ b/src/hooks/useVersionConflictModal.ts
@@ -51,16 +51,13 @@ export function useVersionConflictModal() {
   /**
    * Show the version conflict modal.
    */
-  const showConflict = useCallback(
-    (loanAccountId: string, preservedChanges?: PreservedChanges) => {
-      setState({
-        isOpen: true,
-        loanAccountId,
-        preservedChanges: preservedChanges ?? null,
-      })
-    },
-    []
-  )
+  const showConflict = useCallback((loanAccountId: string, preservedChanges?: PreservedChanges) => {
+    setState({
+      isOpen: true,
+      loanAccountId,
+      preservedChanges: preservedChanges ?? null,
+    })
+  }, [])
 
   /**
    * Close the modal without refreshing.

--- a/src/migrations/20260707_141505.json
+++ b/src/migrations/20260707_141505.json
@@ -1,0 +1,7744 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_users_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'readonly'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_id": {
+          "name": "avatar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "enable_a_p_i_key": {
+          "name": "enable_a_p_i_key",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_index": {
+          "name": "api_key_index",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_avatar_idx": {
+          "name": "users_avatar_idx",
+          "columns": [
+            {
+              "expression": "avatar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_avatar_id_media_id_fk": {
+          "name": "users_avatar_id_media_id_fk",
+          "tableFrom": "users",
+          "tableTo": "media",
+          "columnsFrom": [
+            "avatar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers_identity_documents": {
+      "name": "customers_identity_documents",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "enum_customers_identity_documents_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_subtype": {
+          "name": "document_subtype",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_of_issue": {
+          "name": "state_of_issue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_issue": {
+          "name": "country_of_issue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "additional_info": {
+          "name": "additional_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_identity_documents_order_idx": {
+          "name": "customers_identity_documents_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_identity_documents_parent_id_idx": {
+          "name": "customers_identity_documents_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_identity_documents_parent_id_fk": {
+          "name": "customers_identity_documents_parent_id_fk",
+          "tableFrom": "customers_identity_documents",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into": {
+          "name": "merged_into",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "middle_name": {
+          "name": "middle_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_phone_number": {
+          "name": "mobile_phone_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verified": {
+          "name": "identity_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_number": {
+          "name": "residential_address_street_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_name": {
+          "name": "residential_address_street_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_type": {
+          "name": "residential_address_street_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_unit_number": {
+          "name": "residential_address_unit_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street": {
+          "name": "residential_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_suburb": {
+          "name": "residential_address_suburb",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_city": {
+          "name": "residential_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_state": {
+          "name": "residential_address_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_postcode": {
+          "name": "residential_address_postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_country": {
+          "name": "residential_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "residential_address_full_address": {
+          "name": "residential_address_full_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_street": {
+          "name": "mailing_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_city": {
+          "name": "mailing_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_state": {
+          "name": "mailing_address_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_postcode": {
+          "name": "mailing_address_postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_country": {
+          "name": "mailing_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "staff_flag": {
+          "name": "staff_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "investor_flag": {
+          "name": "investor_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founder_flag": {
+          "name": "founder_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerable_flag": {
+          "name": "vulnerable_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ekyc_entity_id": {
+          "name": "ekyc_entity_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ekyc_status": {
+          "name": "ekyc_status",
+          "type": "enum_customers_ekyc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "individual_status": {
+          "name": "individual_status",
+          "type": "enum_customers_individual_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_reason": {
+          "name": "reapplication_block_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_until": {
+          "name": "reapplication_block_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_at": {
+          "name": "reapplication_block_blocked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_application_number": {
+          "name": "reapplication_block_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_status": {
+          "name": "reapplication_block_clear_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_cleared_at": {
+          "name": "reapplication_block_cleared_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_overall_result": {
+          "name": "identity_verification_overall_result",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_provider": {
+          "name": "identity_verification_provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_provider_reference": {
+          "name": "identity_verification_provider_reference",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_lab_request_id": {
+          "name": "identity_verification_lab_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_checked_at": {
+          "name": "identity_verification_checked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_archived": {
+          "name": "identity_verification_report_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_archived_at": {
+          "name": "identity_verification_archived_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "customers_customer_id_idx": {
+          "name": "customers_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_merged_into_idx": {
+          "name": "customers_merged_into_idx",
+          "columns": [
+            {
+              "expression": "merged_into",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_updated_at_idx": {
+          "name": "customers_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_created_at_idx": {
+          "name": "customers_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers_rels": {
+      "name": "customers_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applications_id": {
+          "name": "applications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_accounts_id": {
+          "name": "loan_accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_rels_order_idx": {
+          "name": "customers_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_parent_idx": {
+          "name": "customers_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_path_idx": {
+          "name": "customers_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_applications_id_idx": {
+          "name": "customers_rels_applications_id_idx",
+          "columns": [
+            {
+              "expression": "applications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_conversations_id_idx": {
+          "name": "customers_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_loan_accounts_id_idx": {
+          "name": "customers_rels_loan_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "loan_accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_rels_parent_fk": {
+          "name": "customers_rels_parent_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_applications_fk": {
+          "name": "customers_rels_applications_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "applications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_conversations_fk": {
+          "name": "customers_rels_conversations_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_loan_accounts_fk": {
+          "name": "customers_rels_loan_accounts_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_utterances": {
+      "name": "conversations_utterances",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utterance": {
+          "name": "utterance",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_input_type": {
+          "name": "answer_input_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_seq": {
+          "name": "prev_seq",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_conversation": {
+          "name": "end_conversation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_utterances_order_idx": {
+          "name": "conversations_utterances_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_utterances_parent_id_idx": {
+          "name": "conversations_utterances_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_utterances_parent_id_fk": {
+          "name": "conversations_utterances_parent_id_fk",
+          "tableFrom": "conversations_utterances",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_facts": {
+      "name": "conversations_facts",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fact": {
+          "name": "fact",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_facts_order_idx": {
+          "name": "conversations_facts_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_facts_parent_id_idx": {
+          "name": "conversations_facts_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_facts_parent_id_fk": {
+          "name": "conversations_facts_parent_id_fk",
+          "tableFrom": "conversations_facts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_noticeboard": {
+      "name": "conversations_noticeboard",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_noticeboard_order_idx": {
+          "name": "conversations_noticeboard_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_noticeboard_parent_id_idx": {
+          "name": "conversations_noticeboard_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_noticeboard_parent_id_fk": {
+          "name": "conversations_noticeboard_parent_id_fk",
+          "tableFrom": "conversations_noticeboard",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_number": {
+          "name": "application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id_string": {
+          "name": "customer_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id_id": {
+          "name": "application_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_conversations_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "last_utterance_time": {
+          "name": "last_utterance_time",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_decision": {
+          "name": "final_decision",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_reason": {
+          "name": "decision_detail_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_retry_eligible": {
+          "name": "decision_detail_retry_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_source_application_number": {
+          "name": "decision_detail_source_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_blocked_until": {
+          "name": "decision_detail_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_reason": {
+          "name": "reapplication_block_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_message_variant": {
+          "name": "reapplication_block_message_variant",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_stop_message": {
+          "name": "reapplication_block_stop_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_application_number": {
+          "name": "reapplication_block_source_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_account_id": {
+          "name": "reapplication_block_source_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_decided_at": {
+          "name": "reapplication_block_source_decided_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_until": {
+          "name": "reapplication_block_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_at": {
+          "name": "reapplication_block_blocked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_canonical_customer_id": {
+          "name": "reapplication_block_canonical_customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_disposition_kind": {
+          "name": "reapplication_block_disposition_kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_manual_review_candidate": {
+          "name": "reapplication_block_manual_review_candidate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_recognition": {
+          "name": "reapplication_block_recognition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_status": {
+          "name": "reapplication_block_clear_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_cleared_at": {
+          "name": "reapplication_block_cleared_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_cleared_by": {
+          "name": "reapplication_block_cleared_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_justification": {
+          "name": "reapplication_block_clear_justification",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_request_id": {
+          "name": "reapplication_block_clear_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_lab_request_id": {
+          "name": "identity_verification_report_lab_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_provider_reference": {
+          "name": "identity_verification_report_provider_reference",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_report_file_location": {
+          "name": "identity_verification_report_report_file_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_report_file_name": {
+          "name": "identity_verification_report_report_file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_raw_response_file_location": {
+          "name": "identity_verification_report_raw_response_file_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_raw_response_file_name": {
+          "name": "identity_verification_report_raw_response_file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_archived_at": {
+          "name": "identity_verification_report_archived_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_identity_risk": {
+          "name": "assessments_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_serviceability": {
+          "name": "assessments_serviceability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_fraud_check": {
+          "name": "assessments_fraud_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_account_conduct": {
+          "name": "assessments_account_conduct",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_post_identity_risk": {
+          "name": "assessments_post_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_credit_assessment_complete": {
+          "name": "assessments_credit_assessment_complete",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture": {
+          "name": "statement_capture",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_status": {
+          "name": "decision_status",
+          "type": "enum_conversations_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_data": {
+          "name": "application_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_conversation_id_idx": {
+          "name": "conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_application_number_idx": {
+          "name": "conversations_application_number_idx",
+          "columns": [
+            {
+              "expression": "application_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_customer_id_idx": {
+          "name": "conversations_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_customer_id_string_idx": {
+          "name": "conversations_customer_id_string_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_application_id_idx": {
+          "name": "conversations_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_status_idx": {
+          "name": "conversations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_decision_status_idx": {
+          "name": "conversations_decision_status_idx",
+          "columns": [
+            {
+              "expression": "decision_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_created_at_idx": {
+          "name": "conversations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_monitor_grid_idx": {
+          "name": "conversations_monitor_grid_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_by_customer_idx": {
+          "name": "conversations_by_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_customer_id_id_customers_id_fk": {
+          "name": "conversations_customer_id_id_customers_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_application_id_id_applications_id_fk": {
+          "name": "conversations_application_id_id_applications_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_proc_state_steps": {
+      "name": "app_proc_state_steps",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "step_name": {
+          "name": "step_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_app_proc_state_steps_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        },
+        "completion_event_name": {
+          "name": "completion_event_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_input_type": {
+          "name": "answer_input_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_main": {
+          "name": "prompts_main",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_completeness_check": {
+          "name": "prompts_completeness_check",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_confirmation": {
+          "name": "prompts_confirmation",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_output_json": {
+          "name": "prompts_output_json",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_mapping_out": {
+          "name": "prompts_mapping_out",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_module_name": {
+          "name": "business_logic_module_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_method_name": {
+          "name": "business_logic_method_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_mapping_in": {
+          "name": "business_logic_mapping_in",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_mapping_out": {
+          "name": "business_logic_mapping_out",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_proc_state_steps_order_idx": {
+          "name": "app_proc_state_steps_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_proc_state_steps_parent_id_idx": {
+          "name": "app_proc_state_steps_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_proc_state_steps_parent_id_fk": {
+          "name": "app_proc_state_steps_parent_id_fk",
+          "tableFrom": "app_proc_state_steps",
+          "tableTo": "app_proc_state",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_proc_state": {
+      "name": "app_proc_state",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stage_name": {
+          "name": "stage_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_proc_state_order_idx": {
+          "name": "app_proc_state_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_proc_state_parent_id_idx": {
+          "name": "app_proc_state_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_proc_state_parent_id_fk": {
+          "name": "app_proc_state_parent_id_fk",
+          "tableFrom": "app_proc_state",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_application_process_conversation": {
+      "name": "applications_application_process_conversation",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_applications_application_process_conversation_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_application_process_conversation_order_idx": {
+          "name": "applications_application_process_conversation_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_application_process_conversation_parent_id_idx": {
+          "name": "applications_application_process_conversation_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_application_process_conversation_parent_id_fk": {
+          "name": "applications_application_process_conversation_parent_id_fk",
+          "tableFrom": "applications_application_process_conversation",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_noticeboard_versions": {
+      "name": "applications_noticeboard_versions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_noticeboard_versions_order_idx": {
+          "name": "applications_noticeboard_versions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_noticeboard_versions_parent_id_idx": {
+          "name": "applications_noticeboard_versions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_noticeboard_versions_parent_id_fk": {
+          "name": "applications_noticeboard_versions_parent_id_fk",
+          "tableFrom": "applications_noticeboard_versions",
+          "tableTo": "applications_noticeboard",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_noticeboard": {
+      "name": "applications_noticeboard",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "applications_noticeboard_order_idx": {
+          "name": "applications_noticeboard_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_noticeboard_parent_id_idx": {
+          "name": "applications_noticeboard_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_noticeboard_parent_id_fk": {
+          "name": "applications_noticeboard_parent_id_fk",
+          "tableFrom": "applications_noticeboard",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_number": {
+          "name": "application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_purpose": {
+          "name": "loan_purpose",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_amount": {
+          "name": "loan_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_fee": {
+          "name": "loan_fee",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_total_payable": {
+          "name": "loan_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_term": {
+          "name": "loan_term",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_attestation_acceptance": {
+          "name": "customer_attestation_acceptance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture_consent_provided": {
+          "name": "statement_capture_consent_provided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture_completed": {
+          "name": "statement_capture_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_offer_acceptance": {
+          "name": "product_offer_acceptance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_outcome": {
+          "name": "application_outcome",
+          "type": "enum_applications_application_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_current_process_stage": {
+          "name": "application_process_current_process_stage",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_current_process_step": {
+          "name": "application_process_current_process_step",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_started_at": {
+          "name": "application_process_started_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_updated_at": {
+          "name": "application_process_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_identity_risk": {
+          "name": "assessments_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_serviceability": {
+          "name": "assessments_serviceability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_fraud_check": {
+          "name": "assessments_fraud_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applications_application_number_idx": {
+          "name": "applications_application_number_idx",
+          "columns": [
+            {
+              "expression": "application_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_customer_id_idx": {
+          "name": "applications_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_application_outcome_idx": {
+          "name": "applications_application_outcome_idx",
+          "columns": [
+            {
+              "expression": "application_outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_updated_at_idx": {
+          "name": "applications_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_created_at_idx": {
+          "name": "applications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_customer_id_id_customers_id_fk": {
+          "name": "applications_customer_id_id_customers_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_rels": {
+      "name": "applications_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_rels_order_idx": {
+          "name": "applications_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_parent_idx": {
+          "name": "applications_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_path_idx": {
+          "name": "applications_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_conversations_id_idx": {
+          "name": "applications_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_rels_parent_fk": {
+          "name": "applications_rels_parent_fk",
+          "tableFrom": "applications_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_rels_conversations_fk": {
+          "name": "applications_rels_conversations_fk",
+          "tableFrom": "applications_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_accounts_repayment_schedule_payments": {
+      "name": "loan_accounts_repayment_schedule_payments",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payment_number": {
+          "name": "payment_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_loan_accounts_repayment_schedule_payments_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'scheduled'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_remaining": {
+          "name": "amount_remaining",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_transaction_ids": {
+          "name": "linked_transaction_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "loan_accounts_repayment_schedule_payments_order_idx": {
+          "name": "loan_accounts_repayment_schedule_payments_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_repayment_schedule_payments_parent_id_idx": {
+          "name": "loan_accounts_repayment_schedule_payments_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accts_repay_sched_payments_natural_key_idx": {
+          "name": "loan_accts_repay_sched_payments_natural_key_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_accounts_repayment_schedule_payments_parent_id_fk": {
+          "name": "loan_accounts_repayment_schedule_payments_parent_id_fk",
+          "tableFrom": "loan_accounts_repayment_schedule_payments",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_accounts": {
+      "name": "loan_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id_string": {
+          "name": "customer_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_loan_amount": {
+          "name": "loan_terms_loan_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_loan_fee": {
+          "name": "loan_terms_loan_fee",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_total_payable": {
+          "name": "loan_terms_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_opened_date": {
+          "name": "loan_terms_opened_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_disbursed_date": {
+          "name": "loan_terms_disbursed_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_current_balance": {
+          "name": "balances_current_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_total_outstanding": {
+          "name": "balances_total_outstanding",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_total_paid": {
+          "name": "balances_total_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_payment_date": {
+          "name": "last_payment_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_payment_amount": {
+          "name": "last_payment_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_is_in_arrears": {
+          "name": "aging_is_in_arrears",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "aging_bucket": {
+          "name": "aging_bucket",
+          "type": "enum_loan_accounts_aging_bucket",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_current_d_p_d": {
+          "name": "aging_current_d_p_d",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_last_updated": {
+          "name": "aging_last_updated",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_status": {
+          "name": "account_status",
+          "type": "enum_loan_accounts_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "sdk_status": {
+          "name": "sdk_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commencement_date": {
+          "name": "commencement_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_loan_agreement_url": {
+          "name": "signed_loan_agreement_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "enum_loan_accounts_closure_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_previous_status": {
+          "name": "closure_previous_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_closed_date": {
+          "name": "closure_closed_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_final_balance": {
+          "name": "closure_final_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_total_paid": {
+          "name": "closure_total_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_loan_total_payable": {
+          "name": "closure_loan_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_triggered_by_transaction_id": {
+          "name": "closure_triggered_by_transaction_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_schedule_id": {
+          "name": "repayment_schedule_schedule_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_number_of_payments": {
+          "name": "repayment_schedule_number_of_payments",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_payment_frequency": {
+          "name": "repayment_schedule_payment_frequency",
+          "type": "enum_loan_accounts_repayment_schedule_payment_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_created_date": {
+          "name": "repayment_schedule_created_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "loan_accounts_loan_account_id_idx": {
+          "name": "loan_accounts_loan_account_id_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_account_number_idx": {
+          "name": "loan_accounts_account_number_idx",
+          "columns": [
+            {
+              "expression": "account_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_customer_id_idx": {
+          "name": "loan_accounts_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_customer_id_string_idx": {
+          "name": "loan_accounts_customer_id_string_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_loan_terms_loan_terms_disbursed_date_idx": {
+          "name": "loan_accounts_loan_terms_loan_terms_disbursed_date_idx",
+          "columns": [
+            {
+              "expression": "loan_terms_disbursed_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_aging_aging_is_in_arrears_idx": {
+          "name": "loan_accounts_aging_aging_is_in_arrears_idx",
+          "columns": [
+            {
+              "expression": "aging_is_in_arrears",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_aging_aging_bucket_idx": {
+          "name": "loan_accounts_aging_aging_bucket_idx",
+          "columns": [
+            {
+              "expression": "aging_bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_account_status_idx": {
+          "name": "loan_accounts_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_commencement_date_idx": {
+          "name": "loan_accounts_commencement_date_idx",
+          "columns": [
+            {
+              "expression": "commencement_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_updated_at_idx": {
+          "name": "loan_accounts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_created_at_idx": {
+          "name": "loan_accounts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_accounts_customer_id_id_customers_id_fk": {
+          "name": "loan_accounts_customer_id_id_customers_id_fk",
+          "tableFrom": "loan_accounts",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.write_off_requests_supporting_documents": {
+      "name": "write_off_requests_supporting_documents",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "write_off_requests_supporting_documents_order_idx": {
+          "name": "write_off_requests_supporting_documents_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_supporting_documents_parent_id_idx": {
+          "name": "write_off_requests_supporting_documents_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_supporting_documents_document_idx": {
+          "name": "write_off_requests_supporting_documents_document_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "write_off_requests_supporting_documents_document_id_media_id_fk": {
+          "name": "write_off_requests_supporting_documents_document_id_media_id_fk",
+          "tableFrom": "write_off_requests_supporting_documents",
+          "tableTo": "media",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "write_off_requests_supporting_documents_parent_id_fk": {
+          "name": "write_off_requests_supporting_documents_parent_id_fk",
+          "tableFrom": "write_off_requests_supporting_documents",
+          "tableTo": "write_off_requests",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.write_off_requests": {
+      "name": "write_off_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_number": {
+          "name": "request_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_balance": {
+          "name": "original_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "enum_write_off_requests_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_write_off_requests_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum_write_off_requests_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "requires_senior_approval": {
+          "name": "requires_senior_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_by_id": {
+          "name": "approval_details_decided_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_by_name": {
+          "name": "approval_details_decided_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_at": {
+          "name": "approval_details_decided_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_comment": {
+          "name": "approval_details_comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by": {
+          "name": "approval_details_approved_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by_name": {
+          "name": "approval_details_approved_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_at": {
+          "name": "approval_details_approved_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by": {
+          "name": "approval_details_rejected_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by_name": {
+          "name": "approval_details_rejected_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_at": {
+          "name": "approval_details_rejected_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_reason": {
+          "name": "approval_details_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by": {
+          "name": "cancellation_details_cancelled_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by_name": {
+          "name": "cancellation_details_cancelled_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_at": {
+          "name": "cancellation_details_cancelled_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "write_off_requests_request_id_idx": {
+          "name": "write_off_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_event_id_idx": {
+          "name": "write_off_requests_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_request_number_idx": {
+          "name": "write_off_requests_request_number_idx",
+          "columns": [
+            {
+              "expression": "request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_loan_account_id_idx": {
+          "name": "write_off_requests_loan_account_id_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_customer_id_idx": {
+          "name": "write_off_requests_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_status_idx": {
+          "name": "write_off_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_requested_by_idx": {
+          "name": "write_off_requests_requested_by_idx",
+          "columns": [
+            {
+              "expression": "requested_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_approval_details_approval_details_dec_idx": {
+          "name": "write_off_requests_approval_details_approval_details_dec_idx",
+          "columns": [
+            {
+              "expression": "approval_details_decided_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_updated_at_idx": {
+          "name": "write_off_requests_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_created_at_idx": {
+          "name": "write_off_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "write_off_requests_requested_by_id_users_id_fk": {
+          "name": "write_off_requests_requested_by_id_users_id_fk",
+          "tableFrom": "write_off_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "write_off_requests_approval_details_decided_by_id_users_id_fk": {
+          "name": "write_off_requests_approval_details_decided_by_id_users_id_fk",
+          "tableFrom": "write_off_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approval_details_decided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reapplication_block_clear_requests": {
+      "name": "reapplication_block_clear_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_number": {
+          "name": "request_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_customer_id": {
+          "name": "canonical_customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "justification": {
+          "name": "justification",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_reapplication_block_clear_requests_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by": {
+          "name": "approval_details_approved_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by_name": {
+          "name": "approval_details_approved_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_at": {
+          "name": "approval_details_approved_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_comment": {
+          "name": "approval_details_comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by": {
+          "name": "approval_details_rejected_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by_name": {
+          "name": "approval_details_rejected_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_at": {
+          "name": "approval_details_rejected_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_reason": {
+          "name": "approval_details_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by": {
+          "name": "cancellation_details_cancelled_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by_name": {
+          "name": "cancellation_details_cancelled_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_at": {
+          "name": "cancellation_details_cancelled_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reapplication_block_clear_requests_request_id_idx": {
+          "name": "reapplication_block_clear_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_event_id_idx": {
+          "name": "reapplication_block_clear_requests_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_request_number_idx": {
+          "name": "reapplication_block_clear_requests_request_number_idx",
+          "columns": [
+            {
+              "expression": "request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_canonical_customer_id_idx": {
+          "name": "reapplication_block_clear_requests_canonical_customer_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_status_idx": {
+          "name": "reapplication_block_clear_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_requested_by_idx": {
+          "name": "reapplication_block_clear_requests_requested_by_idx",
+          "columns": [
+            {
+              "expression": "requested_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_updated_at_idx": {
+          "name": "reapplication_block_clear_requests_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_created_at_idx": {
+          "name": "reapplication_block_clear_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reapplication_block_clear_requests_requested_by_id_users_id_fk": {
+          "name": "reapplication_block_clear_requests_requested_by_id_users_id_fk",
+          "tableFrom": "reapplication_block_clear_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_notes": {
+      "name": "contact_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "enum_contact_notes_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "enum_contact_notes_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_direction": {
+          "name": "contact_direction",
+          "type": "enum_contact_notes_contact_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum_contact_notes_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "enum_contact_notes_sentiment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'neutral'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amends_note_id": {
+          "name": "amends_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_contact_notes_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_notes_customer_idx": {
+          "name": "contact_notes_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_loan_account_idx": {
+          "name": "contact_notes_loan_account_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_application_idx": {
+          "name": "contact_notes_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_conversation_idx": {
+          "name": "contact_notes_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_created_by_idx": {
+          "name": "contact_notes_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_amends_note_idx": {
+          "name": "contact_notes_amends_note_idx",
+          "columns": [
+            {
+              "expression": "amends_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_status_idx": {
+          "name": "contact_notes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_created_at_idx": {
+          "name": "contact_notes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_updated_at_idx": {
+          "name": "contact_notes_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_notes_customer_id_customers_id_fk": {
+          "name": "contact_notes_customer_id_customers_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_loan_account_id_loan_accounts_id_fk": {
+          "name": "contact_notes_loan_account_id_loan_accounts_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_application_id_applications_id_fk": {
+          "name": "contact_notes_application_id_applications_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_conversation_id_conversations_id_fk": {
+          "name": "contact_notes_conversation_id_conversations_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_created_by_id_users_id_fk": {
+          "name": "contact_notes_created_by_id_users_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_amends_note_id_contact_notes_id_fk": {
+          "name": "contact_notes_amends_note_id_contact_notes_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "contact_notes",
+          "columnsFrom": [
+            "amends_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_ref_id": {
+          "name": "customer_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_notifications_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "enum_notifications_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_content_hash": {
+          "name": "template_content_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_git_sha": {
+          "name": "template_git_sha",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_hash": {
+          "name": "recipient_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_category": {
+          "name": "tags_category",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_reason": {
+          "name": "tags_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_step": {
+          "name": "tags_step",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_failed_at": {
+          "name": "failure_failed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_error_type": {
+          "name": "failure_error_type",
+          "type": "enum_notifications_failure_error_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_error_message": {
+          "name": "failure_error_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_attempt": {
+          "name": "failure_attempt",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_fallback_suggested": {
+          "name": "failure_fallback_suggested",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_account_id": {
+          "name": "statement_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_start": {
+          "name": "statement_period_start",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_end": {
+          "name": "statement_period_end",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_dispatched_at": {
+          "name": "statement_dispatched_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_mode": {
+          "name": "suppression_mode",
+          "type": "enum_notifications_suppression_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_reason": {
+          "name": "suppression_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_set_by": {
+          "name": "suppression_set_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_set_at": {
+          "name": "suppression_set_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_expires_at": {
+          "name": "suppression_expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_notification_id_idx": {
+          "name": "notifications_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_idempotency_key_idx": {
+          "name": "notifications_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_customer_ref_idx": {
+          "name": "notifications_customer_ref_idx",
+          "columns": [
+            {
+              "expression": "customer_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_customer_id_idx": {
+          "name": "notifications_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_status_idx": {
+          "name": "notifications_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_event_at_idx": {
+          "name": "notifications_event_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_customer_ref_id_customers_id_fk": {
+          "name": "notifications_customer_ref_id_customers_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_cases": {
+      "name": "collection_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_ref_id": {
+          "name": "customer_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum_collection_cases_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rung": {
+          "name": "rung",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardship_paused": {
+          "name": "hardship_paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_contact": {
+          "name": "stopped_contact",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overdue_amount": {
+          "name": "overdue_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_overdue": {
+          "name": "days_overdue",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_step": {
+          "name": "last_step",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cured_at": {
+          "name": "cured_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhausted_at": {
+          "name": "exhausted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_at": {
+          "name": "resumed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_contact_at": {
+          "name": "stop_contact_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_cases_account_id_idx": {
+          "name": "collection_cases_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_customer_ref_idx": {
+          "name": "collection_cases_customer_ref_idx",
+          "columns": [
+            {
+              "expression": "customer_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_customer_id_idx": {
+          "name": "collection_cases_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_state_idx": {
+          "name": "collection_cases_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_rung_idx": {
+          "name": "collection_cases_rung_idx",
+          "columns": [
+            {
+              "expression": "rung",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_hardship_paused_idx": {
+          "name": "collection_cases_hardship_paused_idx",
+          "columns": [
+            {
+              "expression": "hardship_paused",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_stopped_contact_idx": {
+          "name": "collection_cases_stopped_contact_idx",
+          "columns": [
+            {
+              "expression": "stopped_contact",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_opened_at_idx": {
+          "name": "collection_cases_opened_at_idx",
+          "columns": [
+            {
+              "expression": "opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_worklist_idx": {
+          "name": "collection_cases_worklist_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rung",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_by_customer_idx": {
+          "name": "collection_cases_by_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_cases_customer_ref_id_customers_id_fk": {
+          "name": "collection_cases_customer_ref_id_customers_id_fk",
+          "tableFrom": "collection_cases",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_e164": {
+          "name": "mobile_e164",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postcode": {
+          "name": "postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "enum_contacts_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm": {
+          "name": "utm",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_preference": {
+          "name": "channel_preference",
+          "type": "enum_contacts_channel_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_code": {
+          "name": "referral_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_contact_id": {
+          "name": "referred_by_contact_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitlist_joined_at": {
+          "name": "waitlist_joined_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitlist_position": {
+          "name": "waitlist_position",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "panel_member": {
+          "name": "panel_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_basis": {
+          "name": "link_basis",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derived_stage": {
+          "name": "derived_stage",
+          "type": "enum_contacts_derived_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_status": {
+          "name": "loan_status",
+          "type": "enum_contacts_loan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "erased": {
+          "name": "erased",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_contact_id_idx": {
+          "name": "contacts_contact_id_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_email_idx": {
+          "name": "contacts_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_mobile_e164_idx": {
+          "name": "contacts_mobile_e164_idx",
+          "columns": [
+            {
+              "expression": "mobile_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_referral_code_idx": {
+          "name": "contacts_referral_code_idx",
+          "columns": [
+            {
+              "expression": "referral_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_referred_by_contact_id_idx": {
+          "name": "contacts_referred_by_contact_id_idx",
+          "columns": [
+            {
+              "expression": "referred_by_contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_needs_review_idx": {
+          "name": "contacts_needs_review_idx",
+          "columns": [
+            {
+              "expression": "needs_review",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_customer_id_idx": {
+          "name": "contacts_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_derived_stage_idx": {
+          "name": "contacts_derived_stage_idx",
+          "columns": [
+            {
+              "expression": "derived_stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_updated_at_idx": {
+          "name": "contacts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_created_at_idx": {
+          "name": "contacts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interactions": {
+      "name": "interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id_string": {
+          "name": "contact_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "enum_interactions_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "enum_interactions_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_system": {
+          "name": "source_system",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interactions_interaction_id_idx": {
+          "name": "interactions_interaction_id_idx",
+          "columns": [
+            {
+              "expression": "interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_contact_id_string_idx": {
+          "name": "interactions_contact_id_string_idx",
+          "columns": [
+            {
+              "expression": "contact_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_contact_idx": {
+          "name": "interactions_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_occurred_at_idx": {
+          "name": "interactions_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_updated_at_idx": {
+          "name": "interactions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_created_at_idx": {
+          "name": "interactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interactions_contact_id_contacts_id_fk": {
+          "name": "interactions_contact_id_contacts_id_fk",
+          "tableFrom": "interactions",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_audit_log": {
+      "name": "contact_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contact_id_string": {
+          "name": "contact_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_audit_log_contact_id_string_idx": {
+          "name": "contact_audit_log_contact_id_string_idx",
+          "columns": [
+            {
+              "expression": "contact_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_audit_log_occurred_at_idx": {
+          "name": "contact_audit_log_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_audit_log_updated_at_idx": {
+          "name": "contact_audit_log_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_audit_log_created_at_idx": {
+          "name": "contact_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_actor": {
+          "name": "created_by_actor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_created_at": {
+          "name": "batch_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "batches_batch_id_idx": {
+          "name": "batches_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_updated_at_idx": {
+          "name": "batches_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_created_at_idx": {
+          "name": "batches_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id_string": {
+          "name": "contact_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_type": {
+          "name": "feedback_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_area": {
+          "name": "product_area",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_actor": {
+          "name": "status_actor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_note": {
+          "name": "status_note",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_feedback_id_idx": {
+          "name": "feedback_feedback_id_idx",
+          "columns": [
+            {
+              "expression": "feedback_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_contact_id_string_idx": {
+          "name": "feedback_contact_id_string_idx",
+          "columns": [
+            {
+              "expression": "contact_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_customer_id_idx": {
+          "name": "feedback_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_product_area_idx": {
+          "name": "feedback_product_area_idx",
+          "columns": [
+            {
+              "expression": "product_area",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_status_idx": {
+          "name": "feedback_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_updated_at_idx": {
+          "name": "feedback_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_created_at_idx": {
+          "name": "feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customers_id": {
+          "name": "customers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applications_id": {
+          "name": "applications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_accounts_id": {
+          "name": "loan_accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_off_requests_id": {
+          "name": "write_off_requests_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_requests_id": {
+          "name": "reapplication_block_clear_requests_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_notes_id": {
+          "name": "contact_notes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notifications_id": {
+          "name": "notifications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cases_id": {
+          "name": "collection_cases_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts_id": {
+          "name": "contacts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interactions_id": {
+          "name": "interactions_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_audit_log_id": {
+          "name": "contact_audit_log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batches_id": {
+          "name": "batches_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_customers_id_idx": {
+          "name": "payload_locked_documents_rels_customers_id_idx",
+          "columns": [
+            {
+              "expression": "customers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_conversations_id_idx": {
+          "name": "payload_locked_documents_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_applications_id_idx": {
+          "name": "payload_locked_documents_rels_applications_id_idx",
+          "columns": [
+            {
+              "expression": "applications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_loan_accounts_id_idx": {
+          "name": "payload_locked_documents_rels_loan_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "loan_accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_write_off_requests_id_idx": {
+          "name": "payload_locked_documents_rels_write_off_requests_id_idx",
+          "columns": [
+            {
+              "expression": "write_off_requests_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_reapplication_block_clear__idx": {
+          "name": "payload_locked_documents_rels_reapplication_block_clear__idx",
+          "columns": [
+            {
+              "expression": "reapplication_block_clear_requests_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contact_notes_id_idx": {
+          "name": "payload_locked_documents_rels_contact_notes_id_idx",
+          "columns": [
+            {
+              "expression": "contact_notes_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_notifications_id_idx": {
+          "name": "payload_locked_documents_rels_notifications_id_idx",
+          "columns": [
+            {
+              "expression": "notifications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_collection_cases_id_idx": {
+          "name": "payload_locked_documents_rels_collection_cases_id_idx",
+          "columns": [
+            {
+              "expression": "collection_cases_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contacts_id_idx": {
+          "name": "payload_locked_documents_rels_contacts_id_idx",
+          "columns": [
+            {
+              "expression": "contacts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_interactions_id_idx": {
+          "name": "payload_locked_documents_rels_interactions_id_idx",
+          "columns": [
+            {
+              "expression": "interactions_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contact_audit_log_id_idx": {
+          "name": "payload_locked_documents_rels_contact_audit_log_id_idx",
+          "columns": [
+            {
+              "expression": "contact_audit_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_batches_id_idx": {
+          "name": "payload_locked_documents_rels_batches_id_idx",
+          "columns": [
+            {
+              "expression": "batches_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_feedback_id_idx": {
+          "name": "payload_locked_documents_rels_feedback_id_idx",
+          "columns": [
+            {
+              "expression": "feedback_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_customers_fk": {
+          "name": "payload_locked_documents_rels_customers_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_conversations_fk": {
+          "name": "payload_locked_documents_rels_conversations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_applications_fk": {
+          "name": "payload_locked_documents_rels_applications_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "applications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_loan_accounts_fk": {
+          "name": "payload_locked_documents_rels_loan_accounts_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_write_off_requests_fk": {
+          "name": "payload_locked_documents_rels_write_off_requests_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "write_off_requests",
+          "columnsFrom": [
+            "write_off_requests_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_reapplication_block_clear_r_fk": {
+          "name": "payload_locked_documents_rels_reapplication_block_clear_r_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "reapplication_block_clear_requests",
+          "columnsFrom": [
+            "reapplication_block_clear_requests_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contact_notes_fk": {
+          "name": "payload_locked_documents_rels_contact_notes_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contact_notes",
+          "columnsFrom": [
+            "contact_notes_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_notifications_fk": {
+          "name": "payload_locked_documents_rels_notifications_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notifications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_collection_cases_fk": {
+          "name": "payload_locked_documents_rels_collection_cases_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "collection_cases",
+          "columnsFrom": [
+            "collection_cases_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contacts_fk": {
+          "name": "payload_locked_documents_rels_contacts_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contacts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_interactions_fk": {
+          "name": "payload_locked_documents_rels_interactions_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interactions_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contact_audit_log_fk": {
+          "name": "payload_locked_documents_rels_contact_audit_log_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contact_audit_log",
+          "columnsFrom": [
+            "contact_audit_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_batches_fk": {
+          "name": "payload_locked_documents_rels_batches_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batches_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_feedback_fk": {
+          "name": "payload_locked_documents_rels_feedback_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "feedback",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_users_role": {
+      "name": "enum_users_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "supervisor",
+        "operations",
+        "readonly",
+        "service",
+        "marketing"
+      ]
+    },
+    "public.enum_customers_identity_documents_document_type": {
+      "name": "enum_customers_identity_documents_document_type",
+      "schema": "public",
+      "values": [
+        "DRIVERS_LICENCE",
+        "PASSPORT",
+        "MEDICARE"
+      ]
+    },
+    "public.enum_customers_ekyc_status": {
+      "name": "enum_customers_ekyc_status",
+      "schema": "public",
+      "values": [
+        "successful",
+        "failed",
+        "pending"
+      ]
+    },
+    "public.enum_customers_individual_status": {
+      "name": "enum_customers_individual_status",
+      "schema": "public",
+      "values": [
+        "LIVING",
+        "DECEASED",
+        "MISSING"
+      ]
+    },
+    "public.enum_conversations_status": {
+      "name": "enum_conversations_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "soft_end",
+        "hard_end",
+        "approved",
+        "declined"
+      ]
+    },
+    "public.enum_conversations_decision_status": {
+      "name": "enum_conversations_decision_status",
+      "schema": "public",
+      "values": [
+        "approved",
+        "declined",
+        "referred",
+        "no_decision"
+      ]
+    },
+    "public.enum_app_proc_state_steps_type": {
+      "name": "enum_app_proc_state_steps_type",
+      "schema": "public",
+      "values": [
+        "llm",
+        "business_logic",
+        "user_input"
+      ]
+    },
+    "public.enum_applications_application_process_conversation_role": {
+      "name": "enum_applications_application_process_conversation_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ]
+    },
+    "public.enum_applications_application_outcome": {
+      "name": "enum_applications_application_outcome",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "declined",
+        "withdrawn"
+      ]
+    },
+    "public.enum_loan_accounts_repayment_schedule_payments_status": {
+      "name": "enum_loan_accounts_repayment_schedule_payments_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "paid",
+        "missed",
+        "partial"
+      ]
+    },
+    "public.enum_loan_accounts_aging_bucket": {
+      "name": "enum_loan_accounts_aging_bucket",
+      "schema": "public",
+      "values": [
+        "current",
+        "early_arrears",
+        "late_arrears",
+        "default",
+        "closed"
+      ]
+    },
+    "public.enum_loan_accounts_account_status": {
+      "name": "enum_loan_accounts_account_status",
+      "schema": "public",
+      "values": [
+        "pending_disbursement",
+        "active",
+        "paid_off",
+        "in_arrears",
+        "written_off"
+      ]
+    },
+    "public.enum_loan_accounts_closure_reason": {
+      "name": "enum_loan_accounts_closure_reason",
+      "schema": "public",
+      "values": [
+        "PAID_OFF",
+        "WRITTEN_OFF",
+        "ADMIN_CLOSED"
+      ]
+    },
+    "public.enum_loan_accounts_repayment_schedule_payment_frequency": {
+      "name": "enum_loan_accounts_repayment_schedule_payment_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "fortnightly",
+        "monthly"
+      ]
+    },
+    "public.enum_write_off_requests_reason": {
+      "name": "enum_write_off_requests_reason",
+      "schema": "public",
+      "values": [
+        "hardship",
+        "bankruptcy",
+        "deceased",
+        "unable_to_locate",
+        "fraud_victim",
+        "disputed",
+        "aged_debt",
+        "other"
+      ]
+    },
+    "public.enum_write_off_requests_status": {
+      "name": "enum_write_off_requests_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.enum_write_off_requests_priority": {
+      "name": "enum_write_off_requests_priority",
+      "schema": "public",
+      "values": [
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.enum_reapplication_block_clear_requests_status": {
+      "name": "enum_reapplication_block_clear_requests_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.enum_contact_notes_channel": {
+      "name": "enum_contact_notes_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "internal",
+        "system"
+      ]
+    },
+    "public.enum_contact_notes_topic": {
+      "name": "enum_contact_notes_topic",
+      "schema": "public",
+      "values": [
+        "general_enquiry",
+        "complaint",
+        "escalation",
+        "internal_note",
+        "account_update",
+        "collections"
+      ]
+    },
+    "public.enum_contact_notes_contact_direction": {
+      "name": "enum_contact_notes_contact_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.enum_contact_notes_priority": {
+      "name": "enum_contact_notes_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.enum_contact_notes_sentiment": {
+      "name": "enum_contact_notes_sentiment",
+      "schema": "public",
+      "values": [
+        "positive",
+        "neutral",
+        "negative",
+        "escalation"
+      ]
+    },
+    "public.enum_contact_notes_status": {
+      "name": "enum_contact_notes_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "amended"
+      ]
+    },
+    "public.enum_notifications_status": {
+      "name": "enum_notifications_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "blocked",
+        "statement",
+        "suppression_change"
+      ]
+    },
+    "public.enum_notifications_channel": {
+      "name": "enum_notifications_channel",
+      "schema": "public",
+      "values": [
+        "email",
+        "sms"
+      ]
+    },
+    "public.enum_notifications_failure_error_type": {
+      "name": "enum_notifications_failure_error_type",
+      "schema": "public",
+      "values": [
+        "transient",
+        "permanent",
+        "auth",
+        "template",
+        "contact_missing",
+        "opt_out",
+        "suppressed"
+      ]
+    },
+    "public.enum_notifications_suppression_mode": {
+      "name": "enum_notifications_suppression_mode",
+      "schema": "public",
+      "values": [
+        "all",
+        "non_essential",
+        "marketing_only",
+        "panic_button",
+        "off"
+      ]
+    },
+    "public.enum_collection_cases_state": {
+      "name": "enum_collection_cases_state",
+      "schema": "public",
+      "values": [
+        "open",
+        "awaiting_human",
+        "cured"
+      ]
+    },
+    "public.enum_contacts_source": {
+      "name": "enum_contacts_source",
+      "schema": "public",
+      "values": [
+        "meta",
+        "google",
+        "campus",
+        "referral",
+        "social_dm",
+        "ai_search",
+        "organic",
+        "other"
+      ]
+    },
+    "public.enum_contacts_channel_preference": {
+      "name": "enum_contacts_channel_preference",
+      "schema": "public",
+      "values": [
+        "whatsapp",
+        "sms"
+      ]
+    },
+    "public.enum_contacts_derived_stage": {
+      "name": "enum_contacts_derived_stage",
+      "schema": "public",
+      "values": [
+        "lead",
+        "waitlist",
+        "invited",
+        "applicant",
+        "customer",
+        "former_customer"
+      ]
+    },
+    "public.enum_contacts_loan_status": {
+      "name": "enum_contacts_loan_status",
+      "schema": "public",
+      "values": [
+        "approved",
+        "disbursed",
+        "repaid"
+      ]
+    },
+    "public.enum_interactions_kind": {
+      "name": "enum_interactions_kind",
+      "schema": "public",
+      "values": [
+        "signup",
+        "message_out",
+        "message_in",
+        "feedback_prompt",
+        "referral",
+        "stage_change",
+        "note",
+        "import"
+      ]
+    },
+    "public.enum_interactions_direction": {
+      "name": "enum_interactions_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "94f89066-813d-4804-9b36-cd692bc73ca0",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/src/migrations/20260707_141505.ts
+++ b/src/migrations/20260707_141505.ts
@@ -1,0 +1,13 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "contacts" ADD COLUMN "needs_review" boolean;
+  CREATE INDEX "contacts_needs_review_idx" ON "contacts" USING btree ("needs_review");`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   DROP INDEX "contacts_needs_review_idx";
+  ALTER TABLE "contacts" DROP COLUMN "needs_review";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -11,6 +11,7 @@ import * as migration_20260702_052932 from './20260702_052932';
 import * as migration_20260702_223751_marketing_module from './20260702_223751_marketing_module';
 import * as migration_20260704_043533_marketing_phase2 from './20260704_043533_marketing_phase2';
 import * as migration_20260707_121002 from './20260707_121002';
+import * as migration_20260707_141505 from './20260707_141505';
 
 export const migrations = [
   {
@@ -76,6 +77,11 @@ export const migrations = [
   {
     up: migration_20260707_121002.up,
     down: migration_20260707_121002.down,
-    name: '20260707_121002'
+    name: '20260707_121002',
+  },
+  {
+    up: migration_20260707_141505.up,
+    down: migration_20260707_141505.down,
+    name: '20260707_141505'
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1580,6 +1580,10 @@ export interface Contact {
   batchId?: string | null;
   panelMember?: boolean | null;
   /**
+   * A2 flag (attributes.needs_review mirror) — parked for staff review; excluded from invitation sends
+   */
+  needsReview?: boolean | null;
+  /**
    * Canonical platform customer id once linked (one-way)
    */
   customerId?: string | null;
@@ -2494,6 +2498,7 @@ export interface ContactsSelect<T extends boolean = true> {
   waitlistPosition?: T;
   batchId?: T;
   panelMember?: T;
+  needsReview?: T;
   customerId?: T;
   linkBasis?: T;
   linkedAt?: T;

--- a/src/stores/failed-actions.ts
+++ b/src/stores/failed-actions.ts
@@ -28,6 +28,7 @@ export type FailedActionType =
   | 'resume-hardship'
   | 'stop-contact'
   | 'advance-step'
+  | 'marketing-command'
 
 /**
  * A failed action that can be retried later.
@@ -54,28 +55,28 @@ export interface FailedAction {
 interface FailedActionsState {
   /** List of failed actions */
   actions: FailedAction[]
-  
+
   /** Add a failed action to the queue */
   addFailedAction: (
     type: FailedActionType,
     accountId: string,
     params: Record<string, unknown>,
     errorMessage: string,
-    accountLabel?: string
+    accountLabel?: string,
   ) => string
-  
+
   /** Remove a failed action (on success or dismiss) */
   removeAction: (id: string) => void
-  
+
   /** Increment retry count for an action */
   incrementRetryCount: (id: string) => void
-  
+
   /** Clear all failed actions */
   clearAll: () => void
-  
+
   /** Get count of non-expired actions */
   getActiveCount: () => number
-  
+
   /** Load actions from localStorage (call on mount) */
   loadFromStorage: () => void
 }
@@ -93,11 +94,11 @@ function isExpired(action: FailedAction): boolean {
  */
 function loadFromLocalStorage(): FailedAction[] {
   if (typeof window === 'undefined') return []
-  
+
   try {
     const stored = localStorage.getItem(FAILED_ACTIONS_STORAGE_KEY)
     if (!stored) return []
-    
+
     const actions: FailedAction[] = JSON.parse(stored)
     // Filter out expired actions
     return actions.filter((action) => !isExpired(action))
@@ -112,13 +113,11 @@ function loadFromLocalStorage(): FailedAction[] {
  */
 function saveToLocalStorage(actions: FailedAction[]): void {
   if (typeof window === 'undefined') return
-  
+
   try {
     // Only save non-expired actions, limited to max count
-    const validActions = actions
-      .filter((action) => !isExpired(action))
-      .slice(-MAX_FAILED_ACTIONS)
-    
+    const validActions = actions.filter((action) => !isExpired(action)).slice(-MAX_FAILED_ACTIONS)
+
     localStorage.setItem(FAILED_ACTIONS_STORAGE_KEY, JSON.stringify(validActions))
   } catch {
     // Ignore localStorage errors
@@ -127,55 +126,53 @@ function saveToLocalStorage(actions: FailedAction[]): void {
 
 /**
  * Zustand store for managing failed actions that can be retried.
- * 
+ *
  * Features:
  * - Persists to localStorage with TTL (24h)
  * - Limits storage to MAX_FAILED_ACTIONS items
  * - Filters expired actions on load
  * - Supports retry count tracking
- * 
+ *
  * SECURITY:
  * - Data is CLEARED when a different user logs in (see UserSessionGuard)
  * - This prevents User B from seeing User A's failed action queue
- * 
+ *
  * @see src/components/UserSessionGuard - clears this store on user change
- * 
+ *
  * @example
  * ```tsx
  * const { actions, addFailedAction, removeAction } = useFailedActionsStore()
- * 
+ *
  * // Add a failed action
  * addFailedAction('waive-fee', 'ACC-123', { amount: 10 }, 'Network error')
- * 
+ *
  * // Remove on success or dismiss
  * removeAction(actionId)
  * ```
  */
 export const useFailedActionsStore = create<FailedActionsState>((set, get) => ({
   actions: [],
-  
+
   addFailedAction: (type, accountId, params, errorMessage, accountLabel) => {
     // Check for existing action with same type and accountId to prevent duplicates
     const existingActions = get().actions
     const existingIndex = existingActions.findIndex(
-      (a) => a.type === type && a.accountId === accountId && !isExpired(a)
+      (a) => a.type === type && a.accountId === accountId && !isExpired(a),
     )
-    
+
     // If duplicate exists, update it instead of adding new
     if (existingIndex >= 0) {
       const existingAction = existingActions[existingIndex]
       set((state) => {
         const newActions = state.actions.map((a, i) =>
-          i === existingIndex
-            ? { ...a, errorMessage, timestamp: new Date().toISOString() }
-            : a
+          i === existingIndex ? { ...a, errorMessage, timestamp: new Date().toISOString() } : a,
         )
         saveToLocalStorage(newActions)
         return { actions: newActions }
       })
       return existingAction.id
     }
-    
+
     const id = nanoid()
     const action: FailedAction = {
       id,
@@ -187,16 +184,16 @@ export const useFailedActionsStore = create<FailedActionsState>((set, get) => ({
       timestamp: new Date().toISOString(),
       retryCount: 0,
     }
-    
+
     set((state) => {
       const newActions = [...state.actions, action].slice(-MAX_FAILED_ACTIONS)
       saveToLocalStorage(newActions)
       return { actions: newActions }
     })
-    
+
     return id
   },
-  
+
   removeAction: (id) => {
     set((state) => {
       const newActions = state.actions.filter((a) => a.id !== id)
@@ -204,26 +201,26 @@ export const useFailedActionsStore = create<FailedActionsState>((set, get) => ({
       return { actions: newActions }
     })
   },
-  
+
   incrementRetryCount: (id) => {
     set((state) => {
       const newActions = state.actions.map((a) =>
-        a.id === id ? { ...a, retryCount: a.retryCount + 1 } : a
+        a.id === id ? { ...a, retryCount: a.retryCount + 1 } : a,
       )
       saveToLocalStorage(newActions)
       return { actions: newActions }
     })
   },
-  
+
   clearAll: () => {
     set({ actions: [] })
     saveToLocalStorage([])
   },
-  
+
   getActiveCount: () => {
     return get().actions.filter((a) => !isExpired(a)).length
   },
-  
+
   loadFromStorage: () => {
     const storedActions = loadFromLocalStorage()
     set({ actions: storedActions })


### PR DESCRIPTION
## Summary

Third leg of the Stream B rollout (with platform #57/#58 + billieChat #134), plus the A2 sign-off decision implemented end-to-end and the C1 cutover tooling.

### Stream B consumption
- `contact.stage.changed.v1` now mirrors **loan_status** into the projection when carried (the Loan status panel finally populates).
- **Latent bug fixed**: `handle_contact_updated` overwrote the `attributes` jsonb with each event's delta — advocate and needs-review overlays would have wiped each other. Now merged via `merge_jsonb` (matching the platform's semantics), with attributes still audited.

### A2 — needs-review flag (no stage override)
```
Grid:  [Review ▾ All contacts | ⚑ Needs review]     │ FLAGS      │
                                                     │ ⚑ Review   │
Detail: ┌─ Review ────────────────────────┐
        │ Status   ⚑ Needs review         │  Flag modal: optional reason,
        │ Reason   Possible duplicate…    │  "excluded from every invitation
        │ [Flag for review…] [Clear flag] │   send" warning, audited
        └─────────────────────────────────┘
```
- `needs_review` column (migration `20260707_141505`) mirrored from `attributes.needs_review` — the D16 attribute mechanism, set via the existing `UpdateContact` command (platform #58 enforces the send gate + reports `skipped_needs_review`).

### C1 cutover
- `scripts/backfill_sendlog.py` — idempotent Apps Script send-log importer (row-hash keys; unmatched rows go to a review CSV, never dropped silently).
- Cutover runbook: freeze → export → backfill → verify → retire, with rollback notes and the **B1 decision** (WhatsApp stays phase 3; start Meta template approval in parallel).

### Docs
Design spec §3/§4/§13: A2 + A4 built, flagged decision #1 resolved (billieChat already emitted the OTP event — now routed), B1 decided.

## Tests
22 pytest + **459 vitest** green; eslint/tsc clean on touched files.

## Deploy order
billieChat #134 → platform #57 + #58 (alembic 0011) → this PR (payload migration auto-applies on deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi