### PR TITLE
chore(event-processor): marketing SDK pin → 0.3.2

### DIFF
--- a/event-processor/requirements.txt
+++ b/event-processor/requirements.txt
@@ -26,4 +26,4 @@ git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-s
 # Collection case events (BTB-199 consumer side).
 git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@collection-v0.3.0#subdirectory=packages/collection
 # Marketing (contact.*/batch.*/feedback.*/referral.*) events (Phase-1 C3 + Phase-2 B5 consumer side).
-git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@marketing-v0.3.1#subdirectory=packages/marketing
+git+https://x-access-token:${GITHUB_TOKEN}@github.com/BillieLoans/billie-event-sdks.git@marketing-v0.3.2#subdirectory=packages/marketing


### PR DESCRIPTION
Pin bump to the py3.9-safe marketing SDK release (billie-event-sdks #4). No behavioural change for the CRM (runs 3.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi