### PR TITLE
feat(marketing): admin erase-contact button with type-to-confirm verification

### DIFF
--- a/src/components/MarketingView/ContactDetail.tsx
+++ b/src/components/MarketingView/ContactDetail.tsx
@@ -7,9 +7,12 @@ import { toast } from 'sonner'
 import { useMarketingContact, marketingContactQueryKey } from '@/hooks/queries/useMarketingContact'
 import { useContactReferrals } from '@/hooks/queries/useContactReferrals'
 import { useFeedbackQueue } from '@/hooks/queries/useFeedbackQueue'
+import { useAuth } from '@payloadcms/ui'
 import { useSetReviewFlag, useUnlinkContact } from '@/hooks/mutations/useMarketingCommands'
+import { isAdmin } from '@/lib/access'
 import { LinkCustomerModal } from './LinkCustomerModal'
 import { RecordConsentModal } from './RecordConsentModal'
+import { EraseContactModal } from './EraseContactModal'
 import type { ContactAuditLog, Interaction } from '@/payload-types'
 import { formatDateMedium } from '@/lib/formatters'
 import { getMarketingConsentGranted } from '@/lib/marketing'
@@ -128,7 +131,10 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
   const [showUnlinkConfirm, setShowUnlinkConfirm] = useState(false)
   const [showFlagModal, setShowFlagModal] = useState(false)
   const [showConsentModal, setShowConsentModal] = useState(false)
+  const [showEraseModal, setShowEraseModal] = useState(false)
   const [flagReason, setFlagReason] = useState('')
+  const { user } = useAuth()
+  const userIsAdmin = isAdmin(user)
   const unlink = useUnlinkContact()
   const reviewFlag = useSetReviewFlag()
 
@@ -426,6 +432,28 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
                 </a>
               </span>
             </div>
+            <div className={styles.panelRow}>
+              <span className={styles.panelRowLabel}>Erasure</span>
+              <span className={styles.panelRowValue}>
+                {contact.erased ? (
+                  <span className={styles.panelRowMeta}>Erased</span>
+                ) : (
+                  <button
+                    type="button"
+                    className={styles.dangerLink}
+                    disabled={!userIsAdmin}
+                    title={
+                      userIsAdmin
+                        ? 'Permanently erase this contact (right to be forgotten)'
+                        : 'Admin only'
+                    }
+                    onClick={() => setShowEraseModal(true)}
+                  >
+                    Erase contact…
+                  </button>
+                )}
+              </span>
+            </div>
           </Panel>
 
           <Panel title="Audit (last 10)">
@@ -445,6 +473,14 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
           </Panel>
         </div>
       </div>
+
+      {showEraseModal && (
+        <EraseContactModal
+          contactId={contactId}
+          contactName={contact.firstName ?? null}
+          onClose={() => setShowEraseModal(false)}
+        />
+      )}
 
       {showLinkModal && (
         <LinkCustomerModal

--- a/src/components/MarketingView/ContactDetail.tsx
+++ b/src/components/MarketingView/ContactDetail.tsx
@@ -421,38 +421,35 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
 
           <Panel title="Data & privacy">
             <div className={styles.panelRow}>
-              <span className={styles.panelRowLabel}>Subject access</span>
+              <span className={styles.panelRowLabel}>Status</span>
               <span className={styles.panelRowValue}>
-                <a
-                  className={styles.nameLink}
-                  href={`/api/marketing/contacts/${contactId}/export`}
-                  title="Download everything held about this contact (admin only)"
-                >
-                  Download export
-                </a>
+                {contact.erased ? 'Erased' : '—'}
               </span>
             </div>
-            <div className={styles.panelRow}>
-              <span className={styles.panelRowLabel}>Erasure</span>
-              <span className={styles.panelRowValue}>
-                {contact.erased ? (
-                  <span className={styles.panelRowMeta}>Erased</span>
-                ) : (
-                  <button
-                    type="button"
-                    className={styles.dangerLink}
-                    disabled={!userIsAdmin}
-                    title={
-                      userIsAdmin
-                        ? 'Permanently erase this contact (right to be forgotten)'
-                        : 'Admin only'
-                    }
-                    onClick={() => setShowEraseModal(true)}
-                  >
-                    Erase contact…
-                  </button>
-                )}
-              </span>
+            <div className={styles.panelButtonRow}>
+              <button
+                type="button"
+                className={styles.pageButton}
+                title="Download everything held about this contact (admin only)"
+                onClick={() => {
+                  window.location.href = `/api/marketing/contacts/${contactId}/export`
+                }}
+              >
+                Download export
+              </button>
+              <button
+                type="button"
+                className={styles.pageButtonDanger}
+                disabled={!userIsAdmin || !!contact.erased}
+                title={
+                  userIsAdmin
+                    ? 'Permanently erase this contact (right to be forgotten)'
+                    : 'Admin only'
+                }
+                onClick={() => setShowEraseModal(true)}
+              >
+                Erase contact…
+              </button>
             </div>
           </Panel>
 

--- a/src/components/MarketingView/EraseContactModal.tsx
+++ b/src/components/MarketingView/EraseContactModal.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useEraseContact } from '@/hooks/mutations/useMarketingCommands'
+import { useEscapeClose } from '@/hooks/useModalA11y'
+import styles from './styles.module.css'
+
+interface EraseContactModalProps {
+  contactId: string
+  /** Display name used as the typed confirmation phrase. */
+  contactName: string | null
+  onClose: () => void
+}
+
+/**
+ * Privacy erasure (right to be forgotten) — irreversible, admin-only (the
+ * route enforces isAdmin; the button is also gated in the UI). Requires
+ * typing the confirmation phrase exactly, mirroring the friction of the
+ * approval flows: an erase must never be a slip of the mouse.
+ */
+export const EraseContactModal: React.FC<EraseContactModalProps> = ({
+  contactId,
+  contactName,
+  onClose,
+}) => {
+  const [confirmation, setConfirmation] = useState('')
+  const erase = useEraseContact()
+  useEscapeClose(onClose)
+
+  const phrase = contactName?.trim() || 'ERASE'
+  const canSubmit = confirmation.trim() === phrase && !erase.isPending
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    erase.mutate(contactId, { onSuccess: () => onClose() })
+  }
+
+  return (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className={styles.modalHeader}>
+          <h2 className={styles.modalTitle}>Erase contact — irreversible</h2>
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className={styles.modalBody}>
+            {erase.isError && (
+              <div className={styles.errorMessage}>
+                {erase.error instanceof Error ? erase.error.message : 'Erasure failed'}
+              </div>
+            )}
+
+            <div className={styles.errorMessage}>
+              This permanently removes the person&apos;s data everywhere: personal details,
+              message contents, feedback text, consent evidence, and their entries in the
+              underlying event history. A tombstone remains so the record cannot silently
+              reappear. <strong>This cannot be undone.</strong>
+            </div>
+
+            <div className={styles.formGroup}>
+              <label className={styles.formLabel} htmlFor="erase-confirmation">
+                Type <strong>{phrase}</strong> to confirm
+              </label>
+              <input
+                id="erase-confirmation"
+                autoFocus
+                type="text"
+                className={styles.formInput}
+                value={confirmation}
+                onChange={(e) => setConfirmation(e.target.value)}
+                placeholder={phrase}
+                autoComplete="off"
+              />
+            </div>
+          </div>
+
+          <div className={styles.modalFooter}>
+            <button type="button" className={styles.btnCancel} onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className={styles.btnDanger}
+              disabled={!canSubmit}
+              title={!canSubmit ? `Type "${phrase}" exactly to enable` : undefined}
+            >
+              {erase.isPending ? 'Erasing…' : 'Erase permanently'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default EraseContactModal

--- a/src/components/MarketingView/styles.module.css
+++ b/src/components/MarketingView/styles.module.css
@@ -642,6 +642,48 @@
   cursor: not-allowed;
 }
 
+.btnDanger {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.625rem 1.25rem;
+  background: var(--theme-error-500, #dc2626);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btnDanger:hover:not(:disabled) {
+  background: var(--theme-error-600, #b91c1c);
+}
+
+.btnDanger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dangerLink {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+  color: var(--theme-error-500, #dc2626);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.dangerLink:hover:not(:disabled) {
+  color: var(--theme-error-600, #b91c1c);
+}
+
+.dangerLink:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
 .errorMessage {
   background: var(--theme-error-50, #fee2e2);
   color: var(--theme-error-600, #991b1b);

--- a/src/components/MarketingView/styles.module.css
+++ b/src/components/MarketingView/styles.module.css
@@ -202,6 +202,25 @@
   cursor: not-allowed;
 }
 
+.pageButtonDanger {
+  padding: 8px 16px;
+  border: 1px solid var(--theme-error-500, #dc2626);
+  border-radius: 6px;
+  background: var(--theme-elevation-0, #fff);
+  color: var(--theme-error-500, #dc2626);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.pageButtonDanger:hover:not(:disabled) {
+  background: var(--theme-error-50, #fee2e2);
+}
+
+.pageButtonDanger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .pageStatus {
   font-size: 13px;
   color: var(--theme-elevation-500, #666);
@@ -662,26 +681,6 @@
 .btnDanger:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-.dangerLink {
-  background: none;
-  border: none;
-  padding: 0;
-  font-size: inherit;
-  color: var(--theme-error-500, #dc2626);
-  cursor: pointer;
-  text-decoration: underline;
-}
-
-.dangerLink:hover:not(:disabled) {
-  color: var(--theme-error-600, #b91c1c);
-}
-
-.dangerLink:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  text-decoration: none;
 }
 
 .errorMessage {

--- a/src/hooks/mutations/useMarketingCommands.ts
+++ b/src/hooks/mutations/useMarketingCommands.ts
@@ -238,6 +238,22 @@ export function useRecordConsent() {
   })
 }
 
+/** Admin-only privacy erasure — irreversible; UI must verify first. */
+export function useEraseContact() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (contactId: string) =>
+      postCommand(`/api/marketing/contacts/${encodeURIComponent(contactId)}/erase`),
+    onSuccess: () => {
+      toast.success('Contact erased', {
+        description: 'Personal information is being redacted across all records.',
+      })
+      invalidateWithLag(qc, [['marketing-contacts']])
+    },
+    onError: (e: Error) => toast.error('Erasure failed', { description: e.message }),
+  })
+}
+
 export interface SetReviewFlagVars {
   contactId: string
   needsReview: boolean

--- a/tests/unit/components/EraseContactModal.test.tsx
+++ b/tests/unit/components/EraseContactModal.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { EraseContactModal } from '@/components/MarketingView/EraseContactModal'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const renderModal = (contactName: string | null = 'Rohan', onClose = vi.fn()) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <EraseContactModal contactId="c-1" contactName={contactName} onClose={onClose} />
+    </QueryClientProvider>,
+  )
+  return onClose
+}
+
+beforeEach(() => {
+  cleanup()
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ contactId: 'c-1', eventId: 'e-1' }),
+  })) as unknown as typeof fetch
+})
+
+describe('EraseContactModal', () => {
+  it('disables Erase until the confirmation phrase matches exactly', () => {
+    renderModal('Rohan')
+    const submit = screen.getByRole('button', { name: 'Erase permanently' })
+    expect(submit).toBeDisabled()
+
+    const input = screen.getByLabelText(/to confirm/)
+    fireEvent.change(input, { target: { value: 'rohan' } }) // wrong case
+    expect(submit).toBeDisabled()
+
+    fireEvent.change(input, { target: { value: 'Rohan' } })
+    expect(submit).not.toBeDisabled()
+  })
+
+  it('falls back to the literal ERASE phrase when the contact has no name', () => {
+    renderModal(null)
+    const submit = screen.getByRole('button', { name: 'Erase permanently' })
+
+    fireEvent.change(screen.getByLabelText(/to confirm/), { target: { value: 'ERASE' } })
+    expect(submit).not.toBeDisabled()
+  })
+
+  it('POSTs to the erase route and closes on success', async () => {
+    const onClose = renderModal('Rohan')
+    fireEvent.change(screen.getByLabelText(/to confirm/), { target: { value: 'Rohan' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Erase permanently' }))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(String(url)).toBe('/api/marketing/contacts/c-1/erase')
+    expect(init.method).toBe('POST')
+  })
+
+  it('does not submit on Enter while the phrase is wrong', () => {
+    renderModal('Rohan')
+    const input = screen.getByLabelText(/to confirm/)
+    fireEvent.change(input, { target: { value: 'Roha' } })
+    fireEvent.submit(input.closest('form')!)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the API error and stays open', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        error: { code: 'COMMAND_FAILED', message: 'Erasure failed. Please retry.' },
+      }),
+    })) as unknown as typeof fetch
+
+    const onClose = renderModal('Rohan')
+    fireEvent.change(screen.getByLabelText(/to confirm/), { target: { value: 'Rohan' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Erase permanently' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Erasure failed. Please retry.')).toBeInTheDocument(),
+    )
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- The DSR erasure route (`POST /api/marketing/contacts/[contactId]/erase`) previously had **no UI trigger** — admins had to call the API directly. This adds the button.
- New **Erase contact…** action in the *Data & privacy* panel on the contact detail page, admin-only (disabled with an "Admin only" tooltip for other roles; the route's `isAdmin` gate remains the enforcement point).
- Verification step: a modal spells out exactly what erasure removes (PI, message contents, feedback text, consent evidence, event-history entries; tombstone retained) and requires typing the contact's name (or `ERASE` when unnamed) exactly before the danger button enables.
- Once erased, the row shows a fixed-position **Erased** marker instead of the button.

## Test plan
- [x] `tests/unit/components/EraseContactModal.test.tsx` — 5 tests: phrase gating (case-exact), ERASE fallback for unnamed contacts, POST + close on success, no submit on Enter with wrong phrase, API error surfaced and modal stays open
- [x] Full `tests/unit/components/` suite green (76 tests)
- [x] `tsc` clean for touched files; lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi