### PR TITLE
fix(event-processor): normalise interaction direction onto the pg enum

### DIFF
--- a/event-processor/src/billie_servicing/handlers/marketing.py
+++ b/event-processor/src/billie_servicing/handlers/marketing.py
@@ -227,6 +227,23 @@ async def handle_contact_consent_withdrawn(pool: asyncpg.Pool, event: Any) -> No
     )
 
 
+# The interactions.direction column is a Postgres enum (inbound/outbound).
+# The SDK field is a free string, so normalise here: a non-canonical value in
+# one event must degrade to NULL, not DLQ-loop the whole stream partition.
+_DIRECTION_ALIASES = {
+    "in": "inbound",
+    "inbound": "inbound",
+    "out": "outbound",
+    "outbound": "outbound",
+}
+
+
+def _normalise_direction(raw: Any) -> str | None:
+    if not raw:
+        return None
+    return _DIRECTION_ALIASES.get(str(raw).strip().lower())
+
+
 async def handle_contact_interaction_logged(pool: asyncpg.Pool, event: Any) -> None:
     """Handle ``contact.interaction.logged.v1`` — append-only interaction row.
 
@@ -248,7 +265,7 @@ async def handle_contact_interaction_logged(pool: asyncpg.Pool, event: Any) -> N
         "occurred_at": coerce_date(p.occurred_at),
         "kind": p.kind,
         "channel": p.channel,
-        "direction": p.direction,
+        "direction": _normalise_direction(p.direction),
         "subject": p.subject,
         "body": p.body,
         "source_system": p.source_system,

--- a/event-processor/tests/test_marketing_handlers.py
+++ b/event-processor/tests/test_marketing_handlers.py
@@ -71,6 +71,22 @@ async def test_interaction_logged_inserts_row():
     assert any("interactions" in s for s, _ in pool.executed)
 
 
+async def test_interaction_direction_normalised_to_enum_values(mock_pool):
+    # The platform's notification echo shipped direction="out" for a while;
+    # the projection must map short forms onto the pg enum, and degrade
+    # unknown values to NULL rather than DLQ-loop the event.
+    for raw, stored in [("out", "outbound"), ("in", "inbound"),
+                        ("outbound", "outbound"), ("sideways", None), (None, None)]:
+        await handle_contact_interaction_logged(mock_pool, _parsed(
+            "contact.interaction.logged.v1", {
+                "interaction_id": f"i-{raw}", "contact_id": "c-1",
+                "kind": "message_out", "direction": raw,
+                "occurred_at": "2026-07-02T00:00:00+00:00",
+                "source_system": "notification"}))
+        row = mock_pool.last_upsert("interactions")
+        assert row["direction"] == stored, f"direction {raw!r} stored as {row['direction']!r}"
+
+
 async def test_erased_redacts_pi():
     pool = FakePool()
     await handle_contact_erased(pool, _parsed("contact.erased.v1", {


### PR DESCRIPTION
## Summary
Demo fly logs show `contact.interaction.logged.v1` events DLQ-looping with `invalid input value for enum enum_interactions_direction: "out"`. Root cause: the platform's notification-outcome echo (marketingService `_log_notification_outcome`) emits `direction="out"`, while `interactions.direction` is a pg enum accepting only `inbound`/`outbound`.

- `handle_contact_interaction_logged` now normalises direction (`out`→`outbound`, `in`→`inbound`, case-insensitive) and degrades unknown values to NULL instead of letting one malformed event wedge redelivery.
- Producer-side fix (emit `outbound` + validate direction at the LogInteraction gRPC surface) is in the companion platform-services PR.
- Stuck demo messages will project successfully on redelivery once this deploys — no data was lost.

## Test plan
- [x] New handler test covering `out`/`in`/`outbound`/unknown/None → stored value
- [x] Full event-processor suite: 275 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi