### PR TITLE
fix(admin): gate lending chrome behind the lending wall roles

### DIFF
--- a/src/components/LedgerStatus/LedgerStatusIndicator.tsx
+++ b/src/components/LedgerStatus/LedgerStatusIndicator.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react'
 import { useLedgerHealth } from '@/hooks/queries/useLedgerHealth'
+import { useLendingAccess } from '@/hooks/useLendingAccess'
 import type { LedgerHealthStatus } from '@/types/ledger-health'
 import { LATENCY_DISPLAY_THRESHOLD_MS } from '@/lib/constants'
 import styles from './styles.module.css'
@@ -72,14 +73,19 @@ export const LedgerStatusIndicator: React.FC<LedgerStatusIndicatorProps> = ({
   showLatency = true,
 }) => {
   const [mounted, setMounted] = useState(false)
-  const { status, latencyMs, message, isLoading, isFetching, refetch } = useLedgerHealth()
+  // The ledger is lending chrome — marketing/service roles can't call
+  // /api/ledger/health (hasAnyRole), so don't poll or render for them.
+  const hasLendingAccess = useLendingAccess()
+  const { status, latencyMs, message, isLoading, isFetching, refetch } = useLedgerHealth({
+    enabled: hasLendingAccess,
+  })
 
   // Only render on client side
   useEffect(() => {
     setMounted(true)
   }, [])
 
-  if (!mounted) return null
+  if (!mounted || !hasLendingAccess) return null
 
   const isMinimized = minimizeWhenConnected && status === 'connected' && !isLoading
   const shouldShowLatency = showLatency && (status !== 'connected' || latencyMs > LATENCY_DISPLAY_THRESHOLD_MS)

--- a/src/components/Notifications/NotificationBadge.tsx
+++ b/src/components/Notifications/NotificationBadge.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback, useEffect } from 'react'
 import { useApprovalNotifications } from '@/hooks/queries/useApprovalNotifications'
+import { useLendingAccess } from '@/hooks/useLendingAccess'
 import { NotificationPanel } from './NotificationPanel'
 import styles from './styles.module.css'
 
@@ -18,7 +19,12 @@ export const NotificationBadge: React.FC<NotificationBadgeProps> = ({
   visible = true,
 }) => {
   const [panelOpen, setPanelOpen] = useState(false)
-  
+
+  // write_off_requests is behind the lending wall (hasAnyRole) — polling it
+  // as a marketing/service user just 403s on every cycle and floods the logs.
+  const hasLendingAccess = useLendingAccess()
+  const canSee = visible && hasLendingAccess
+
   const {
     notifications,
     totalPending,
@@ -26,7 +32,7 @@ export const NotificationBadge: React.FC<NotificationBadgeProps> = ({
     isLoading,
     markAllAsRead,
     markAsRead,
-  } = useApprovalNotifications({ enabled: visible })
+  } = useApprovalNotifications({ enabled: canSee })
 
   const handleTogglePanel = useCallback(() => {
     setPanelOpen((prev) => !prev)
@@ -50,7 +56,7 @@ export const NotificationBadge: React.FC<NotificationBadgeProps> = ({
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [panelOpen])
 
-  if (!visible) return null
+  if (!canSee) return null
 
   // Format count for display
   const displayCount = totalPending > 99 ? '99+' : totalPending.toString()

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -115,6 +115,8 @@ export type {
 export { usePendingBlockClears } from './queries/usePendingBlockClears'
 export type { BlockClearRequest, PendingBlockClearsOptions } from './queries/usePendingBlockClears'
 
+export { useLendingAccess } from './useLendingAccess'
+
 // Re-export types from canonical location
 export type {
   CustomerSearchResult,

--- a/src/hooks/useLendingAccess.ts
+++ b/src/hooks/useLendingAccess.ts
@@ -1,0 +1,16 @@
+'use client'
+
+import { useAuth } from '@payloadcms/ui'
+import { hasAnyRole } from '@/lib/access'
+
+/**
+ * Whether the current admin user is on the lending side of the wall
+ * (admin/supervisor/operations/readonly — `hasAnyRole`). The `marketing`
+ * and `service` roles are deliberately excluded: global lending chrome
+ * (approvals bell, ledger status, read-only sync) must not render or poll
+ * for them — their requests would only 403 against the lending collections.
+ */
+export function useLendingAccess(): boolean {
+  const { user } = useAuth()
+  return hasAnyRole(user)
+}

--- a/src/hooks/useReadOnlyMode.ts
+++ b/src/hooks/useReadOnlyMode.ts
@@ -15,6 +15,12 @@ export interface UseReadOnlyModeOptions {
   showRecoveryToast?: boolean
   /** Treat 'degraded' as offline (default: false) */
   treatDegradedAsOffline?: boolean
+  /**
+   * Poll ledger health and sync the store (default: true). Disable for
+   * roles behind the lending wall — with the query off, the health status
+   * defaults to 'offline', which must NOT be synced into read-only mode.
+   */
+  enabled?: boolean
 }
 
 /**
@@ -36,9 +42,9 @@ export interface UseReadOnlyModeOptions {
  * ```
  */
 export function useReadOnlyMode(options: UseReadOnlyModeOptions = {}) {
-  const { showRecoveryToast = true, treatDegradedAsOffline = false } = options
+  const { showRecoveryToast = true, treatDegradedAsOffline = false, enabled = true } = options
 
-  const { status, isLoading } = useLedgerHealth()
+  const { status, isLoading } = useLedgerHealth({ enabled })
   const setReadOnlyMode = useUIStore((state) => state.setReadOnlyMode)
   const readOnlyMode = useUIStore((state) => state.readOnlyMode)
 
@@ -47,8 +53,9 @@ export function useReadOnlyMode(options: UseReadOnlyModeOptions = {}) {
   const hasInitializedRef = useRef(false)
 
   useEffect(() => {
-    // Don't update during initial load
-    if (isLoading) return
+    // Not polling (lending-walled role) or still on initial load — the
+    // 'offline' default from a disabled query must not flip read-only mode.
+    if (!enabled || isLoading) return
 
     // Determine if current status should trigger read-only mode
     const shouldBeReadOnly =
@@ -74,7 +81,7 @@ export function useReadOnlyMode(options: UseReadOnlyModeOptions = {}) {
     // Update previous status ref
     previousStatusRef.current = status
     hasInitializedRef.current = true
-  }, [status, isLoading, setReadOnlyMode, showRecoveryToast, treatDegradedAsOffline])
+  }, [status, isLoading, enabled, setReadOnlyMode, showRecoveryToast, treatDegradedAsOffline])
 
   return {
     /** Whether read-only mode is active */

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -18,6 +18,7 @@ import { UserSessionGuard } from '@/components/UserSessionGuard'
 // Note: NotificationIndicator is now rendered through Payload's actions slot
 import { useUIStore } from '@/stores/ui'
 import { useCommandPaletteHotkeys } from '@/hooks/useGlobalHotkeys'
+import { useLendingAccess } from '@/hooks/useLendingAccess'
 import { useReadOnlyMode } from '@/hooks/useReadOnlyMode'
 import { useCustomerSearch } from '@/hooks/queries/useCustomerSearch'
 import { useLoanAccountSearch } from '@/hooks/queries/useLoanAccountSearch'
@@ -28,7 +29,10 @@ import { SMART_VIEWS } from '@/lib/smart-views'
  * Must be inside QueryClientProvider.
  */
 const ReadOnlyModeSync: React.FC = () => {
-  useReadOnlyMode()
+  // Ledger health is lending chrome — marketing/service roles can't read it
+  // (hasAnyRole), so don't poll on their behalf.
+  const hasLendingAccess = useLendingAccess()
+  useReadOnlyMode({ enabled: hasLendingAccess })
   return null
 }
 

--- a/tests/unit/hooks/useReadOnlyMode.test.ts
+++ b/tests/unit/hooks/useReadOnlyMode.test.ts
@@ -54,6 +54,26 @@ describe('useReadOnlyMode', () => {
     vi.restoreAllMocks()
   })
 
+  describe('Lending wall (enabled: false)', () => {
+    it('does not poll and never flips readOnlyMode when disabled', async () => {
+      ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockOfflineResponse),
+      })
+
+      const { result } = renderHook(() => useReadOnlyMode({ enabled: false }), {
+        wrapper: createWrapper(),
+      })
+
+      // The disabled query defaults status to 'offline' — that must NOT be
+      // synced into the store as read-only mode.
+      await new Promise((r) => setTimeout(r, 50))
+      expect(global.fetch).not.toHaveBeenCalled()
+      expect(result.current.isReadOnly).toBe(false)
+      expect(useUIStore.getState().readOnlyMode).toBe(false)
+    })
+  })
+
   describe('Status Sync', () => {
     it('should set readOnlyMode to false when ledger is connected', async () => {
       ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/tests/unit/ui/ledger-status-indicator.test.tsx
+++ b/tests/unit/ui/ledger-status-indicator.test.tsx
@@ -4,6 +4,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import React from 'react'
 import { LedgerStatusIndicator } from '@/components/LedgerStatus'
 
+// Mock useAuth — lending-side role by default; individual tests flip it
+const mockUseAuth = vi.fn(() => ({ user: { id: 'u-1', role: 'operations' } }))
+vi.mock('@payloadcms/ui', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
 // Create query client wrapper
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -70,6 +76,21 @@ describe('LedgerStatusIndicator', () => {
 
       // Initial state shows "Checking..."
       expect(screen.getByText('Checking...')).toBeInTheDocument()
+    })
+  })
+
+  describe('Lending wall', () => {
+    it('does not render or poll for lending-walled roles (marketing)', async () => {
+      setupMockFetch()
+      mockUseAuth.mockReturnValue({ user: { id: 'u-2', role: 'marketing' } })
+      render(<LedgerStatusIndicator />, { wrapper: createWrapper() })
+
+      // Give the mount effect + any (wrong) query a tick to fire.
+      await new Promise((r) => setTimeout(r, 50))
+      expect(screen.queryByTestId('ledger-status-indicator')).not.toBeInTheDocument()
+      expect(global.fetch).not.toHaveBeenCalled()
+
+      mockUseAuth.mockReturnValue({ user: { id: 'u-1', role: 'operations' } })
     })
   })
 

--- a/tests/unit/ui/notification-badge.test.tsx
+++ b/tests/unit/ui/notification-badge.test.tsx
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { NotificationBadge } from '@/components/Notifications'
 
+// Mock useAuth — lending-side role by default; individual tests flip it
+const mockUseAuth = vi.fn(() => ({ user: { id: 'u-1', role: 'operations' } }))
+vi.mock('@payloadcms/ui', () => ({
+  useAuth: () => mockUseAuth(),
+}))
+
 // Mock the useApprovalNotifications hook
 const mockRefetch = vi.fn()
 const mockMarkAllAsRead = vi.fn()
@@ -37,6 +43,13 @@ describe('NotificationBadge', () => {
   it('should render badge button', () => {
     render(<NotificationBadge />)
     expect(screen.getByTestId('notification-badge-button')).toBeInTheDocument()
+  })
+
+  it('does not render or poll for lending-walled roles (marketing)', () => {
+    mockUseAuth.mockReturnValueOnce({ user: { id: 'u-2', role: 'marketing' } })
+    render(<NotificationBadge />)
+    expect(screen.queryByTestId('notification-badge-button')).not.toBeInTheDocument()
+    expect(mockUseApprovalNotifications).toHaveBeenCalledWith({ enabled: false })
   })
 
   it('should not render when visible is false', () => {

--- a/tests/unit/ui/notification-panel.test.tsx
+++ b/tests/unit/ui/notification-panel.test.tsx
@@ -3,6 +3,12 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { NotificationPanel } from '@/components/Notifications'
 import type { ApprovalNotification } from '@/hooks/queries/useApprovalNotifications'
 
+// The Notifications barrel pulls in NotificationBadge → useLendingAccess →
+// @payloadcms/ui; mock it so the real package (and its CSS) never loads.
+vi.mock('@payloadcms/ui', () => ({
+  useAuth: () => ({ user: { id: 'u-1', role: 'operations' } }),
+}))
+
 const mockNotifications: ApprovalNotification[] = [
   {
     id: '1',


### PR DESCRIPTION
## Summary
Demo fly logs showed repeating `ERROR: You are not allowed to perform this action` (Payload `Forbidden`, 403) bursts. Root cause: the approvals bell (`NotificationAction` header component) polls Payload REST `/api/write-off-requests` every 30s for **every** logged-in user, but that collection's read access is `hasAnyRole` — which deliberately excludes the `marketing` role (the lending wall). A marketing-role session 403s on every poll, ×4 with React Query retry backoff — exactly the 2–4s error cadence in the logs. Access control held throughout; this was log spam + wasted requests.

Fix — a shared `useLendingAccess()` gate (`useAuth` + `hasAnyRole`) applied to all global lending chrome:
- **NotificationBadge** — doesn't render or poll for walled roles
- **LedgerStatusIndicator** — doesn't render or poll `/api/ledger/health` (that route is also `hasAnyRole`-gated; previously it silently 403'd every 30s and showed a misleading "Offline" dot to marketing users)
- **ReadOnlyModeSync** — polling disabled, and the sync effect explicitly no-ops when disabled: a disabled health query defaults its status to `'offline'`, which must not flip read-only mode on for walled roles

## Test plan
- [x] New tests: badge hidden + `enabled: false` for marketing role; indicator not rendered and no fetch for marketing role; `useReadOnlyMode({ enabled: false })` never fetches and never sets `readOnlyMode` despite the offline default
- [x] All notification/ledger/read-only suites green (722 tests across `tests/unit/ui` + affected hooks; the 3 pre-existing `.css`-import suite failures are identical on main)
- [x] eslint 0 errors; tsc clean for touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi