### PR TITLE
feat(marketing): warn-and-confirm before staff contact-create updates an existing identity

### DIFF
--- a/src/app/api/marketing/contacts/match/route.ts
+++ b/src/app/api/marketing/contacts/match/route.ts
@@ -1,0 +1,66 @@
+/**
+ * API Route: GET /api/marketing/contacts/match?mobile=…&email=…
+ *
+ * Natural-key duplicate pre-check for the staff New-contact flow. Mirrors the
+ * platform's UpsertContact resolution exactly — normalised AU mobile first,
+ * then case-insensitive email, non-erased contacts only — so the UI can warn
+ * "this will update an existing contact" BEFORE the upsert silently takes
+ * over that identity. Read-only; gated like contact creation (canMarketing).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { requireAuth } from '@/lib/auth'
+import { canMarketing } from '@/lib/access'
+import { normaliseAuMobile, normaliseEmail } from '@/lib/marketing'
+import type { Contact } from '@/payload-types'
+
+function summarise(contact: Contact, matchedOn: 'mobile' | 'email') {
+  return {
+    contactId: contact.contactId,
+    firstName: contact.firstName ?? null,
+    mobileE164: contact.mobileE164 ?? null,
+    email: contact.email ?? null,
+    derivedStage: contact.derivedStage ?? null,
+    matchedOn,
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(canMarketing)
+  if ('error' in auth) return auth.error
+  const { payload } = auth
+
+  const sp = request.nextUrl.searchParams
+  const mobile = normaliseAuMobile(sp.get('mobile'))
+  const email = normaliseEmail(sp.get('email'))
+
+  if (!mobile && !email) return NextResponse.json({ match: null })
+
+  if (mobile) {
+    const byMobile = await payload.find({
+      collection: 'contacts',
+      where: { mobileE164: { equals: mobile }, erased: { not_equals: true } } as never,
+      limit: 1,
+      overrideAccess: false,
+      user: auth.user,
+    })
+    if (byMobile.docs[0]) {
+      return NextResponse.json({ match: summarise(byMobile.docs[0], 'mobile') })
+    }
+  }
+
+  if (email) {
+    const byEmail = await payload.find({
+      collection: 'contacts',
+      where: { email: { equals: email }, erased: { not_equals: true } } as never,
+      limit: 1,
+      overrideAccess: false,
+      user: auth.user,
+    })
+    if (byEmail.docs[0]) {
+      return NextResponse.json({ match: summarise(byEmail.docs[0], 'email') })
+    }
+  }
+
+  return NextResponse.json({ match: null })
+}

--- a/src/app/api/marketing/contacts/route.ts
+++ b/src/app/api/marketing/contacts/route.ts
@@ -100,7 +100,7 @@ export async function POST(request: NextRequest) {
       actor: String(user.id),
     })
     return NextResponse.json(
-      { contactId: result.contactId, eventId: result.eventId },
+      { contactId: result.contactId, eventId: result.eventId, created: result.created },
       { status: 202 },
     )
   } catch (e) {

--- a/src/components/MarketingView/NewContactModal.tsx
+++ b/src/components/MarketingView/NewContactModal.tsx
@@ -1,7 +1,13 @@
 'use client'
 
 import React, { useState } from 'react'
-import { useCreateContact, type CreateContactVars } from '@/hooks/mutations/useMarketingCommands'
+import Link from 'next/link'
+import {
+  checkContactMatch,
+  useCreateContact,
+  type ContactMatch,
+  type CreateContactVars,
+} from '@/hooks/mutations/useMarketingCommands'
 import { useEscapeClose } from '@/hooks/useModalA11y'
 import styles from './styles.module.css'
 
@@ -26,6 +32,12 @@ const SOURCE_OPTIONS = [
  * /api/marketing/contacts (waitlist:false) — the contact is created in the
  * marketing system of record and projects back into the grid. Mobile or email
  * is required (the natural key); everything else is optional.
+ *
+ * Warn-and-confirm: UpsertContact resolves identity by natural key, so a
+ * mobile/email that matches an existing contact would silently UPDATE that
+ * record (including renaming it). Submit therefore pre-checks the natural
+ * keys and, on a match, requires a second, explicit "Update existing
+ * contact" submission. Editing either key clears the pending confirmation.
  */
 export const NewContactModal: React.FC<NewContactModalProps> = ({ onClose, onSuccess }) => {
   const [firstName, setFirstName] = useState('')
@@ -36,12 +48,42 @@ export const NewContactModal: React.FC<NewContactModalProps> = ({ onClose, onSuc
   const [city, setCity] = useState('')
   const [postcode, setPostcode] = useState('')
 
-  const create = useCreateContact()
-  const canSubmit = (!!mobile.trim() || !!email.trim()) && !create.isPending
+  const [match, setMatch] = useState<ContactMatch | null>(null)
+  const [checking, setChecking] = useState(false)
+  const [checkError, setCheckError] = useState<string | null>(null)
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const create = useCreateContact()
+  const canSubmit = (!!mobile.trim() || !!email.trim()) && !create.isPending && !checking
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!canSubmit) return
+
+    // First pass: duplicate pre-check. A match switches the modal into
+    // confirm mode; only the second submit actually posts. Fail closed —
+    // if we can't verify, we must not risk silently renaming someone.
+    if (!match) {
+      setChecking(true)
+      setCheckError(null)
+      let found: ContactMatch | null = null
+      try {
+        found = await checkContactMatch({
+          mobile: mobile.trim() || undefined,
+          email: email.trim() || undefined,
+        })
+      } catch (err) {
+        setCheckError(
+          err instanceof Error ? err.message : 'Duplicate check failed. Please retry.',
+        )
+        return
+      } finally {
+        setChecking(false)
+      }
+      if (found) {
+        setMatch(found)
+        return
+      }
+    }
 
     const vars: CreateContactVars = { source }
     if (firstName.trim()) vars.first_name = firstName.trim()
@@ -54,6 +96,16 @@ export const NewContactModal: React.FC<NewContactModalProps> = ({ onClose, onSuc
     }
 
     create.mutate(vars, { onSuccess: () => onSuccess() })
+  }
+
+  // Editing a natural key invalidates a pending confirmation.
+  const handleMobileChange = (value: string) => {
+    setMobile(value)
+    setMatch(null)
+  }
+  const handleEmailChange = (value: string) => {
+    setEmail(value)
+    setMatch(null)
   }
 
   useEscapeClose(onClose)
@@ -80,6 +132,21 @@ export const NewContactModal: React.FC<NewContactModalProps> = ({ onClose, onSuc
                 {create.error instanceof Error ? create.error.message : 'Failed to create contact'}
               </div>
             )}
+            {checkError && <div className={styles.errorMessage}>{checkError}</div>}
+            {match && (
+              <div className={styles.warningMessage} data-testid="duplicate-warning">
+                This {match.matchedOn} already belongs to{' '}
+                <strong>{match.firstName ?? 'an unnamed contact'}</strong>
+                {match.derivedStage ? ` (${match.derivedStage})` : ''}. Saving will{' '}
+                <strong>update that contact</strong> — it will not create a new person.{' '}
+                <Link
+                  href={`/admin/marketing/contacts/${match.contactId}`}
+                  className={styles.nameLink}
+                >
+                  View contact
+                </Link>
+              </div>
+            )}
 
             <div className={styles.formGroup}>
               <label className={styles.formLabel} htmlFor="new-contact-first-name">
@@ -104,7 +171,7 @@ export const NewContactModal: React.FC<NewContactModalProps> = ({ onClose, onSuc
                 type="tel"
                 className={styles.formInput}
                 value={mobile}
-                onChange={(e) => setMobile(e.target.value)}
+                onChange={(e) => handleMobileChange(e.target.value)}
                 placeholder="+61…"
               />
               <p className={styles.formHint}>Mobile or email is required.</p>
@@ -119,7 +186,7 @@ export const NewContactModal: React.FC<NewContactModalProps> = ({ onClose, onSuc
                 type="email"
                 className={styles.formInput}
                 value={email}
-                onChange={(e) => setEmail(e.target.value)}
+                onChange={(e) => handleEmailChange(e.target.value)}
               />
             </div>
 
@@ -189,7 +256,13 @@ export const NewContactModal: React.FC<NewContactModalProps> = ({ onClose, onSuc
               Cancel
             </button>
             <button type="submit" className={styles.btnSubmit} disabled={!canSubmit}>
-              {create.isPending ? 'Creating…' : 'Create contact'}
+              {checking
+                ? 'Checking…'
+                : create.isPending
+                  ? 'Saving…'
+                  : match
+                    ? 'Update existing contact'
+                    : 'Create contact'}
             </button>
           </div>
         </form>

--- a/src/components/MarketingView/styles.module.css
+++ b/src/components/MarketingView/styles.module.css
@@ -691,3 +691,13 @@
   margin-bottom: 1rem;
   font-size: 0.875rem;
 }
+
+.warningMessage {
+  background: var(--theme-warning-50, #fef3c7);
+  color: var(--theme-warning-800, #92400e);
+  border: 1px solid var(--theme-warning-200, #fde68a);
+  padding: 0.75rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+}

--- a/src/hooks/mutations/useMarketingCommands.ts
+++ b/src/hooks/mutations/useMarketingCommands.ts
@@ -287,13 +287,51 @@ export interface CreateContactVars {
   source: string
 }
 
+export interface ContactMatch {
+  contactId: string
+  firstName: string | null
+  mobileE164: string | null
+  email: string | null
+  derivedStage: string | null
+  matchedOn: 'mobile' | 'email'
+}
+
+/**
+ * Natural-key duplicate pre-check for the New-contact flow. Returns the
+ * existing contact the platform's UpsertContact would resolve to (mobile
+ * first, then email), or null. Imperative on purpose — it runs on submit,
+ * not while typing.
+ */
+export async function checkContactMatch(vars: {
+  mobile?: string
+  email?: string
+}): Promise<ContactMatch | null> {
+  const params = new URLSearchParams()
+  if (vars.mobile) params.set('mobile', vars.mobile)
+  if (vars.email) params.set('email', vars.email)
+  const res = await fetch(`/api/marketing/contacts/match?${params}`, { credentials: 'include' })
+  if (!res.ok) {
+    const err = await res.json().catch(() => null)
+    throw new Error(err?.error?.message ?? `Duplicate check failed: ${res.status}`)
+  }
+  const data = (await res.json()) as { match: ContactMatch | null }
+  return data.match
+}
+
 export function useCreateContact() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (vars: CreateContactVars) =>
-      postCommand<{ contactId: string; eventId: string }>('/api/marketing/contacts', vars),
-    onSuccess: () => {
-      toast.success('Contact created — appearing in the grid shortly')
+      postCommand<{ contactId: string; eventId: string; created?: boolean }>(
+        '/api/marketing/contacts',
+        vars,
+      ),
+    onSuccess: (res) => {
+      toast.success(
+        res.created === false
+          ? 'Existing contact updated — changes appearing shortly'
+          : 'Contact created — appearing in the grid shortly',
+      )
       invalidateWithLag(qc, [['marketing-contacts']])
     },
     onError: (e: Error) => toast.error('Failed to create contact', { description: e.message }),

--- a/src/lib/marketing.ts
+++ b/src/lib/marketing.ts
@@ -11,3 +11,27 @@ export function getMarketingConsentGranted(consent: Contact['consent']): boolean
   }
   return null
 }
+
+/**
+ * Natural-key normalisation — exact TS mirror of the platform's
+ * marketingService `normalise_mobile`/`normalise_email` (commands.py). The
+ * duplicate pre-check in the New-contact flow must agree with the platform's
+ * UpsertContact resolution, or the warning and the actual upsert diverge.
+ */
+const AU_MOBILE = /^\+61\d{9}$/
+
+export function normaliseAuMobile(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  const digits = String(raw).replace(/[^\d+]/g, '')
+  let candidate: string
+  if (digits.startsWith('+')) candidate = digits
+  else if (digits.startsWith('61')) candidate = `+${digits}`
+  else if (digits.startsWith('0') && digits.length === 10) candidate = `+61${digits.slice(1)}`
+  else return null
+  return AU_MOBILE.test(candidate) ? candidate : null
+}
+
+export function normaliseEmail(raw: string | null | undefined): string | null {
+  const trimmed = raw?.trim()
+  return trimmed ? trimmed.toLowerCase() : null
+}

--- a/tests/unit/components/NewContactModal.test.tsx
+++ b/tests/unit/components/NewContactModal.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { NewContactModal } from '@/components/MarketingView/NewContactModal'
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const renderModal = () => {
+  const onClose = vi.fn()
+  const onSuccess = vi.fn()
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <NewContactModal onClose={onClose} onSuccess={onSuccess} />
+    </QueryClientProvider>,
+  )
+  return { onClose, onSuccess }
+}
+
+const matchResponse = {
+  match: {
+    contactId: 'c-rohan',
+    firstName: 'Rohan Sharp',
+    mobileE164: '+61403320117',
+    email: 'rohan@billie.loans',
+    derivedStage: 'customer',
+    matchedOn: 'mobile',
+  },
+}
+
+/** fetch stub routing by URL: match pre-check vs create POST. */
+function stubFetch({ match }: { match: unknown }) {
+  return vi.fn(async (url: RequestInfo | URL) => {
+    if (String(url).includes('/api/marketing/contacts/match')) {
+      return { ok: true, json: async () => ({ match }) }
+    }
+    return {
+      ok: true,
+      json: async () => ({ contactId: 'c-new', eventId: 'e-1', created: match === null }),
+    }
+  }) as unknown as typeof fetch
+}
+
+const fillAndSubmit = (label: string) => {
+  fireEvent.change(screen.getByLabelText('First name'), { target: { value: 'Gary Smith' } })
+  fireEvent.change(screen.getByLabelText('Mobile'), { target: { value: '0403 320 117' } })
+  fireEvent.click(screen.getByRole('button', { name: label }))
+}
+
+beforeEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('NewContactModal warn-and-confirm', () => {
+  it('creates directly when the natural keys match nothing', async () => {
+    global.fetch = stubFetch({ match: null })
+    const { onSuccess } = renderModal()
+    fillAndSubmit('Create contact')
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled())
+
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]))
+    expect(calls[0]).toContain('/api/marketing/contacts/match?')
+    expect(calls[1]).toBe('/api/marketing/contacts')
+    expect(screen.queryByTestId('duplicate-warning')).not.toBeInTheDocument()
+  })
+
+  it('shows the warning instead of creating when a contact matches', async () => {
+    global.fetch = stubFetch({ match: matchResponse.match })
+    const { onSuccess } = renderModal()
+    fillAndSubmit('Create contact')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('duplicate-warning')).toBeInTheDocument(),
+    )
+    expect(screen.getByText('Rohan Sharp')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Update existing contact' })).toBeInTheDocument()
+
+    // Only the pre-check has fired — no create POST.
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]))
+    expect(calls).toHaveLength(1)
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('second submit confirms and posts the update', async () => {
+    global.fetch = stubFetch({ match: matchResponse.match })
+    const { onSuccess } = renderModal()
+    fillAndSubmit('Create contact')
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Update existing contact' })).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Update existing contact' }))
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled())
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]))
+    expect(calls[1]).toBe('/api/marketing/contacts')
+  })
+
+  it('editing a natural key clears the pending confirmation', async () => {
+    global.fetch = stubFetch({ match: matchResponse.match })
+    renderModal()
+    fillAndSubmit('Create contact')
+
+    await waitFor(() =>
+      expect(screen.getByTestId('duplicate-warning')).toBeInTheDocument(),
+    )
+    fireEvent.change(screen.getByLabelText('Mobile'), { target: { value: '0403 320 118' } })
+
+    expect(screen.queryByTestId('duplicate-warning')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Create contact' })).toBeInTheDocument()
+  })
+
+  it('fails closed when the duplicate check errors', async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes('/match')) {
+        return {
+          ok: false,
+          status: 503,
+          json: async () => ({ error: { message: 'Duplicate check failed. Please retry.' } }),
+        }
+      }
+      throw new Error('create must not be called')
+    }) as unknown as typeof fetch
+
+    const { onSuccess } = renderModal()
+    fillAndSubmit('Create contact')
+
+    await waitFor(() =>
+      expect(screen.getByText('Duplicate check failed. Please retry.')).toBeInTheDocument(),
+    )
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1)
+  })
+})

--- a/tests/unit/lib/marketing-normalise.test.ts
+++ b/tests/unit/lib/marketing-normalise.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { normaliseAuMobile, normaliseEmail } from '@/lib/marketing'
+
+// Parity cases mirroring the platform's normalise_mobile/normalise_email
+// (marketingService commands.py) — the duplicate pre-check must resolve the
+// same way the UpsertContact command does.
+describe('normaliseAuMobile', () => {
+  it.each([
+    ['0403 320 117', '+61403320117'],
+    ['0403-320-117', '+61403320117'],
+    ['61403320117', '+61403320117'],
+    ['+61403320117', '+61403320117'],
+    ['+61 403 320 117', '+61403320117'],
+  ])('normalises %s to %s', (raw, expected) => {
+    expect(normaliseAuMobile(raw)).toBe(expected)
+  })
+
+  it.each([
+    ['', null],
+    [null, null],
+    [undefined, null],
+    ['12345', null], // not an AU shape
+    ['0403 320 11', null], // too short
+    ['+6140332011789', null], // too long
+    ['+64211234567', null], // NZ number
+  ])('rejects %s', (raw, expected) => {
+    expect(normaliseAuMobile(raw as string | null | undefined)).toBe(expected)
+  })
+})
+
+describe('normaliseEmail', () => {
+  it('lowercases and trims', () => {
+    expect(normaliseEmail('  Rohan@Billie.LOANS ')).toBe('rohan@billie.loans')
+  })
+  it('returns null for empty/blank', () => {
+    expect(normaliseEmail('')).toBeNull()
+    expect(normaliseEmail('   ')).toBeNull()
+    expect(normaliseEmail(null)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
Follow-up to the "Gary Smith" incident: `UpsertContact` resolves identity by natural key (normalised AU mobile first, then case-insensitive email), so the staff New-contact form could silently rename an existing contact when given a matching mobile/email.

- **`GET /api/marketing/contacts/match`** — duplicate pre-check that mirrors the platform's natural-key resolution exactly (TS ports of `normalise_mobile`/`normalise_email` with parity tests; mobile wins over email; non-erased only). Gated `canMarketing` like creation.
- **NewContactModal warn-and-confirm** — submit runs the pre-check; on a match the modal shows an amber warning naming the existing contact (with a View-contact link) and the button becomes **Update existing contact** — only that second explicit submission posts. Editing mobile/email clears the pending confirmation. If the pre-check itself fails, creation is blocked (fail closed) rather than risking a silent identity takeover.
- **`created` flag surfaced** — the create route passes through the RPC's `created` boolean; the toast now says "Existing contact updated" vs "Contact created".

## Test plan
- [x] 14 normalisation parity tests (AU mobile shapes incl. spaces/dashes/61-prefix; NZ/short/long rejected; email trim+lower)
- [x] 5 modal tests: clean create (check → create), match shows warning and blocks POST, second submit confirms, key edit clears confirmation, pre-check failure fails closed
- [x] Full component suite green (95 tests); eslint 0 errors; tsc clean for touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi