### PR TITLE
feat(fraud): Part B — ingest fraud_risk.* + application fraud panel + AttentionStrip alert

### DIFF
--- a/docs/superpowers/plans/2026-07-09-fraud-alerting-partB-crm.md
+++ b/docs/superpowers/plans/2026-07-09-fraud-alerting-partB-crm.md
@@ -1,0 +1,554 @@
+# Fraud Alerting — Part B (billie-crm ingestion + display + alert) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** In billie-crm, ingest `fraud_risk.assessment.v1` / `fraud_risk.halt.v1`, persist them, show a read-only fraud panel on the application view, and raise a customer-level fraud chip in the existing AttentionStrip alert framework.
+
+**Architecture:** billie-crm is two processes over one Postgres. The **Python event-processor** (`event-processor/`) consumes `inbox:billie-servicing` (where the fraud events already arrive, currently dropped) and writes Postgres; two new handlers persist the fraud data. The **Payload CMS / Next.js** app (`src/`) reads Postgres and renders the staff UI; changes there add the display + alert. The `conversations.assessments_fraud_check` JSONB column **already exists** (no migration for the panel); a small `customers.fraudRisk` group + migration backs the customer chip.
+
+**Tech Stack:** Python 3.11 (asyncpg, structlog, pytest, ruff, mypy); TypeScript / Payload 3 / Next 16 / React 19 (pnpm, Vitest, Prettier).
+
+**Spec:** `docs/superpowers/specs/2026-07-09-fraud-alerting-slack-crm-design.md` (Part B). **This plan runs in `/Users/rohansharp/workspace/billie-crm`**, on its own branch/PR — independent of billieChat (Part A).
+
+## Global Constraints
+
+- **Repo:** `/Users/rohansharp/workspace/billie-crm`. Python side under `event-processor/`; TS side under `src/`.
+- **Fraud events arrive as a raw dict envelope** (no typed SDK branch). In handlers: `payload = parse_payload(event)`; `conversation_id = event.get("cid") or event.get("conv") or payload.get("conversation_id")`; `customer_id = event.get("usr")`. Never use attribute access (`event.payload`).
+- **Keys:** `conversations` is keyed on `conversation_id` (reliable — `application_number` is often empty early). `customers` is keyed on `customer_id`.
+- **JSONB writes need `json.dumps`** (asyncpg has no dict→jsonb codec) — mirror `_set_assessment`.
+- **`conversations.assessments_fraud_check` already exists** (column + Payload field). No migration needed for the application-panel data.
+- **Payload collections are read-only projections** — only the Python processor writes them (`create/update/delete: () => false`). Group fields flatten camelCase→snake_case (`fraudRisk.score` → `fraud_risk_score`).
+- **After any collection change:** `pnpm generate:types` (and `pnpm generate:importmap` only if a component is registered — not needed here).
+- **Python tests:** run from `event-processor/`: `pytest`, `ruff check src tests`, `mypy src` (strict, py311, line-length 100). MockPool fixture (`mock_pool`) — no real DB.
+- **TS checks:** `pnpm typecheck` (tsc), `pnpm lint` (eslint), `pnpm build`. Vitest (`pnpm exec vitest run <file> --config ./vitest.config.mts`) spins a **Postgres testcontainer via globalSetup — needs Docker**; if Docker is unavailable, rely on typecheck+lint+build and note the vitest run as pending.
+- **Prettier (TS):** single quotes, **no semicolons**, trailing commas everywhere, 100-col width.
+- **Assessment persistence policy:** skip LOW (benign); persist MEDIUM+ into `assessments_fraud_check` (latest wins, matching how other assessments overwrite). The customer chip is driven by `fraud_risk.halt.v1` (HIGH/CRITICAL).
+
+---
+
+### Task 1: Python fraud handlers (event-processor)
+
+**Files:**
+- Create: `event-processor/src/billie_servicing/handlers/fraud.py`
+- Modify: `event-processor/src/billie_servicing/handlers/conversation.py` (add `_ASSESSMENT_COLUMNS["fraudCheck"]`)
+- Modify: `event-processor/src/billie_servicing/handlers/__init__.py` (export)
+- Modify: `event-processor/src/billie_servicing/main.py` (import + register)
+- Test: `event-processor/tests/test_fraud_risk.py`
+
+**Interfaces:**
+- Produces: `async handle_fraud_risk_assessment(pool, event)` and `async handle_fraud_risk_halt(pool, event)`.
+
+- [ ] **Step 1: Add the fraudCheck column mapping**
+
+In `event-processor/src/billie_servicing/handlers/conversation.py`, add one entry to `_ASSESSMENT_COLUMNS` (around line 35-41):
+
+```python
+_ASSESSMENT_COLUMNS = {
+    "identityRisk": "assessments_identity_risk",
+    "serviceability": "assessments_serviceability",
+    "accountConduct": "assessments_account_conduct",
+    "postIdentityRisk": "assessments_post_identity_risk",
+    "creditAssessmentComplete": "assessments_credit_assessment_complete",
+    "fraudCheck": "assessments_fraud_check",
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `event-processor/tests/test_fraud_risk.py`:
+
+```python
+"""Tests for the fraud_risk.* handlers."""
+import pytest
+
+from billie_servicing.handlers.fraud import (
+    handle_fraud_risk_assessment,
+    handle_fraud_risk_halt,
+)
+
+CONV = "7d5ee9c2-dd6b-4091-8a3a-6c148a4c4142"
+
+ASSESSMENT_PAYLOAD = {
+    "conversation_id": CONV,
+    "application_number": "",
+    "final_score": 70,
+    "severity": "HIGH",
+    "categories": ["PROMPT_INJECTION"],
+    "rationale": "asked to ignore instructions",
+    "signals": ["ignore all previous"],
+    "would_halt": True,
+    "mode": "shadow",
+}
+
+HALT_PAYLOAD = dict(ASSESSMENT_PAYLOAD)
+
+
+class TestFraudRiskAssessment:
+    @pytest.mark.asyncio
+    async def test_medium_plus_writes_fraud_check(self, mock_pool):
+        event = {"typ": "fraud_risk.assessment.v1", "usr": "CUST1", "conv": CONV,
+                 "payload": dict(ASSESSMENT_PAYLOAD)}
+        await handle_fraud_risk_assessment(mock_pool, event)
+        updates = [c for c in mock_pool.calls_against("conversations")
+                   if c.op == "UPDATE" and "assessments_fraud_check" in c.values]
+        assert updates, "expected an assessments_fraud_check UPDATE"
+
+    @pytest.mark.asyncio
+    async def test_low_is_skipped(self, mock_pool):
+        low = dict(ASSESSMENT_PAYLOAD, severity="LOW", final_score=5)
+        event = {"typ": "fraud_risk.assessment.v1", "usr": "CUST1", "conv": CONV,
+                 "payload": low}
+        await handle_fraud_risk_assessment(mock_pool, event)
+        updates = [c for c in mock_pool.calls_against("conversations")
+                   if "assessments_fraud_check" in (c.values or {})]
+        assert not updates, "LOW severity must not be persisted"
+
+
+class TestFraudRiskHalt:
+    @pytest.mark.asyncio
+    async def test_sets_customer_fraud_risk_active(self, mock_pool):
+        event = {"typ": "fraud_risk.halt.v1", "usr": "CUST1", "conv": CONV,
+                 "payload": dict(HALT_PAYLOAD)}
+        await handle_fraud_risk_halt(mock_pool, event)
+        doc = mock_pool.last_upsert("customers")
+        assert doc is not None
+        assert doc["customer_id"] == "CUST1"
+        assert doc["fraud_risk_active"] is True
+        assert doc["fraud_risk_severity"] == "HIGH"
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /Users/rohansharp/workspace/billie-crm/event-processor && python -m pytest tests/test_fraud_risk.py -v`
+Expected: FAIL — `ModuleNotFoundError: billie_servicing.handlers.fraud`.
+
+- [ ] **Step 4: Write the handlers**
+
+Create `event-processor/src/billie_servicing/handlers/fraud.py`:
+
+```python
+"""Handlers for fraud_risk.* events emitted by the billieChat FraudRiskAgent."""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncpg
+import structlog
+
+from ..db import coerce_date, upsert
+from .conversation import _ASSESSMENT_COLUMNS, _set_assessment
+from .identity import resolve_canonical_customer_id
+from .sanitize import parse_payload, safe_str, strip_dollar_keys
+
+logger = structlog.get_logger()
+
+_MEDIUM_PLUS = {"MEDIUM", "HIGH", "CRITICAL"}
+
+
+async def handle_fraud_risk_assessment(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
+    """Persist a MEDIUM+ fraud assessment onto the conversation's fraudCheck slot.
+
+    LOW (benign) assessments are skipped. The latest MEDIUM+ assessment wins,
+    matching how the other assessment columns overwrite.
+    """
+    payload = parse_payload(event)
+    conversation_id = safe_str(
+        event.get("cid") or event.get("conv") or payload.get("conversation_id"),
+        "conversation_id",
+    )
+    severity = str(payload.get("severity", "")).upper()
+    log = logger.bind(conversation_id=conversation_id, severity=severity)
+
+    if severity not in _MEDIUM_PLUS:
+        log.info("fraud_risk.assessment.v1 below MEDIUM — skipping")
+        return
+    if not conversation_id:
+        log.warning("fraud_risk.assessment.v1 without conversation id — skipping")
+        return
+
+    data = strip_dollar_keys(payload)
+    await _set_assessment(pool, conversation_id, _ASSESSMENT_COLUMNS["fraudCheck"], data)
+    log.info("fraud check assessment persisted")
+
+
+async def handle_fraud_risk_halt(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
+    """Raise the customer-level fraud alert from a HIGH/CRITICAL fraud_risk.halt.v1.
+
+    Mirrors the reapplication-block customer mirror: resolve the canonical customer
+    id and upsert the fraud_risk_* fields that drive the AttentionStrip chip.
+    """
+    payload = parse_payload(event)
+    severity = str(payload.get("severity", "")).upper()
+    categories = payload.get("categories") or []
+    score = payload.get("final_score")
+
+    customer_id = safe_str(event.get("usr") or payload.get("customer_id"), "customer_id")
+    canonical_id = await resolve_canonical_customer_id(pool, customer_id or None)
+    log = logger.bind(customer_id=customer_id, severity=severity)
+    if not canonical_id:
+        log.warning("fraud_risk.halt.v1 without resolvable customer id — no mirror")
+        return
+
+    now = datetime.now(UTC)
+    await upsert(
+        pool,
+        "customers",
+        conflict_columns=["customer_id"],
+        values={
+            "customer_id": canonical_id,
+            "fraud_risk_severity": severity or None,
+            "fraud_risk_score": int(score) if isinstance(score, (int, float)) else None,
+            "fraud_risk_categories": json.dumps(categories),
+            "fraud_risk_flagged_at": coerce_date(payload.get("flagged_at")) or now,
+            "fraud_risk_active": True,
+            "updated_at": now,
+            "created_at": now,
+        },
+        insert_only_columns=["created_at"],
+    )
+    log.info("customer fraud-risk alert raised")
+```
+
+- [ ] **Step 5: Export the handlers**
+
+In `event-processor/src/billie_servicing/handlers/__init__.py`, add to the import block:
+
+```python
+from .fraud import (
+    handle_fraud_risk_assessment,
+    handle_fraud_risk_halt,
+)
+```
+
+and add both names to the `__all__` list (keep it sorted/consistent with the file).
+
+- [ ] **Step 6: Register the handlers**
+
+In `event-processor/src/billie_servicing/main.py`, add both names to the `.handlers` import block (near `handle_final_decision`), and inside `setup_handlers()` (near the assessment registrations):
+
+```python
+    processor.register_handler("fraud_risk.assessment.v1", handle_fraud_risk_assessment)
+    processor.register_handler("fraud_risk.halt.v1", handle_fraud_risk_halt)
+```
+
+- [ ] **Step 7: Run tests + lint + type-check**
+
+Run: `cd /Users/rohansharp/workspace/billie-crm/event-processor && python -m pytest tests/test_fraud_risk.py -v`
+Expected: PASS (4 tests).
+Run: `cd /Users/rohansharp/workspace/billie-crm/event-processor && ruff check src tests && mypy src`
+Expected: clean. (If `mypy` flags the `fraud_risk_score` int cast or dict typing, address minimally.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm
+git add event-processor/
+git commit -m "feat(fraud): ingest fraud_risk.* — fraudCheck assessment + customer fraud-risk mirror"
+```
+
+---
+
+### Task 2: Customers `fraudRisk` group + migration
+
+**Files:**
+- Modify: `src/collections/Customers.ts`
+- Create: `src/migrations/<timestamp>_fraud_risk.ts`
+- Modify: `src/payload-types.ts` (generated — do not hand-edit; run the generator)
+
+**Interfaces:**
+- Produces columns `customers.fraud_risk_{severity,score,categories,flagged_at,active}` and the `customer.fraudRisk` field the API/hook (Task 3) reads.
+
+- [ ] **Step 1: Add the group to Customers.ts**
+
+Insert this group as a peer in the `fields: [...]` array of `src/collections/Customers.ts`, right after the `identityVerification` group (mirroring the `reapplicationBlock`/`identityVerification` posture — `admin.readOnly: true`):
+
+```ts
+    {
+      // Latest HIGH/CRITICAL fraud-risk incident, mirrored from fraud_risk.halt.v1
+      // (billieChat FraudRiskAgent). Drives the AttentionStrip fraud chip.
+      name: 'fraudRisk',
+      type: 'group',
+      admin: {
+        readOnly: true,
+        description: 'Latest HIGH/CRITICAL fraud-risk incident (flagged for review)',
+      },
+      fields: [
+        {
+          name: 'severity',
+          type: 'text',
+          admin: { description: 'HIGH or CRITICAL' },
+        },
+        {
+          name: 'score',
+          type: 'number',
+          admin: { description: 'Final fraud risk score 0-100' },
+        },
+        {
+          name: 'categories',
+          type: 'json',
+          admin: { description: 'Detected fraud/abuse categories' },
+        },
+        {
+          name: 'flaggedAt',
+          type: 'date',
+        },
+        {
+          name: 'active',
+          type: 'checkbox',
+          admin: { description: 'True while the fraud alert is active' },
+        },
+      ],
+    },
+```
+
+- [ ] **Step 2: Create the migration**
+
+Create `src/migrations/<YYYYMMDD_HHMMSS>_fraud_risk.ts` (use the actual timestamp; match the format of `20260610_114936_reapplication_block_identity_verification.ts`):
+
+```ts
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_severity" varchar;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_score" numeric;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_categories" jsonb;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_flagged_at" timestamp(3) with time zone;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_active" boolean;`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_severity";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_score";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_categories";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_flagged_at";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_active";`)
+}
+```
+
+(Preferred: generate the migration scaffold via `make -C infra/fly pg-migrate-create ENV=dev NAME=fraud_risk` against a local Postgres, then paste the DDL above; if no local Postgres is available, hand-author the file with the current timestamp — dev/test use `push: true` so the columns are created from the collection field at boot regardless.)
+
+- [ ] **Step 3: Regenerate types**
+
+Run: `cd /Users/rohansharp/workspace/billie-crm && pnpm generate:types`
+Expected: `src/payload-types.ts` now contains a `fraudRisk?: {...}` block on the `Customer` type.
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd /Users/rohansharp/workspace/billie-crm && pnpm typecheck`
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm
+git add src/collections/Customers.ts src/migrations/ src/payload-types.ts
+git commit -m "feat(fraud): customers.fraudRisk group + migration"
+```
+
+---
+
+### Task 3: Customer API + hook + AttentionStrip fraud chip
+
+**Files:**
+- Modify: `src/app/api/customer/[customerId]/route.ts`
+- Modify: `src/hooks/queries/useCustomer.ts`
+- Modify: `src/lib/accountTriage.ts`
+- Modify: `src/components/ServicingView/AttentionStrip.tsx`
+- Modify: `src/components/ServicingView/ServicingView.tsx`
+- Test: `tests/unit/lib/account-triage.test.ts`, `tests/unit/ui/attention-strip.test.tsx`
+
+**Interfaces:**
+- Consumes `customer.fraudRisk` (Task 2). Produces the `fraud_risk` AttentionItem kind + the customer-cockpit chip.
+
+- [ ] **Step 1: Expose fraudRisk from the API**
+
+In `src/app/api/customer/[customerId]/route.ts`, add one line to the returned `customer` object, right after `identityVerification: customer.identityVerification ?? null,`:
+
+```ts
+        fraudRisk: customer.fraudRisk ?? null,
+```
+
+- [ ] **Step 2: Add fraudRisk to CustomerData**
+
+In `src/hooks/queries/useCustomer.ts`, add to the `CustomerData` interface, right after the `identityVerification?` block and before `loanAccounts?`:
+
+```ts
+  /** Latest HIGH/CRITICAL fraud-risk incident (billieChat FraudRiskAgent). */
+  fraudRisk?: {
+    severity?: string | null
+    score?: number | null
+    categories?: string[] | null
+    flaggedAt?: string | null
+    active?: boolean | null
+  } | null
+```
+
+- [ ] **Step 3: Write the failing accountTriage test**
+
+Append to `tests/unit/lib/account-triage.test.ts`:
+
+```ts
+  it('emits a high-severity fraud_risk chip when fraudRisk is active', () => {
+    const items = getAttentionItems({
+      vulnerable: false,
+      accounts: [],
+      fraudRisk: { severity: 'CRITICAL', score: 90, active: true },
+      today: TODAY,
+    })
+    expect(items.map((i) => i.kind)).toContain('fraud_risk')
+    const chip = items.find((i) => i.kind === 'fraud_risk')!
+    expect(chip.severity).toBe('high')
+    expect(chip.accountId).toBeNull()
+    expect(chip.label).toContain('CRITICAL')
+  })
+
+  it('does not emit a fraud_risk chip when inactive', () => {
+    const items = getAttentionItems({
+      vulnerable: false,
+      accounts: [],
+      fraudRisk: { severity: 'CRITICAL', score: 90, active: false },
+      today: TODAY,
+    })
+    expect(items.map((i) => i.kind)).not.toContain('fraud_risk')
+  })
+```
+
+- [ ] **Step 4: Run it to verify failure**
+
+Run: `cd /Users/rohansharp/workspace/billie-crm && pnpm exec vitest run tests/unit/lib/account-triage.test.ts --config ./vitest.config.mts`
+Expected: FAIL — `getAttentionItems` has no `fraudRisk` param / no `fraud_risk` kind. (If Docker/Postgres is unavailable and globalSetup fails, note it and rely on `pnpm typecheck` for this step; the assertions still document intent.)
+
+- [ ] **Step 5: Implement the accountTriage branch**
+
+In `src/lib/accountTriage.ts`:
+
+(a) Add `| 'fraud_risk'` to the `AttentionItem['kind']` union.
+
+(b) Add the opts param + branch in `getAttentionItems`. Add `fraudRisk?: CustomerData['fraudRisk']` to the opts type, destructure `fraudRisk = null` (with the other defaults), and add this branch (after the reapplication-block branch):
+
+```ts
+  // Fraud risk (billieChat FraudRiskAgent) — customer-level, active HIGH/CRITICAL.
+  if (fraudRisk?.active && (fraudRisk.severity ?? '').toUpperCase() !== '') {
+    items.push({
+      kind: 'fraud_risk',
+      label: `Fraud risk: ${(fraudRisk.severity ?? '').toUpperCase()} — flagged for review`,
+      accountId: null,
+      severity: 'high',
+    })
+  }
+```
+
+- [ ] **Step 6: Add the ICON + thread it in**
+
+(a) In `src/components/ServicingView/AttentionStrip.tsx`, add to the `ICON` record (required for the exhaustive `Record` to typecheck):
+
+```ts
+  fraud_risk: '🚩',
+```
+
+(b) In `src/components/ServicingView/ServicingView.tsx`, add `fraudRisk: customer?.fraudRisk ?? null` to the `getAttentionItems({...})` call and add `customer?.fraudRisk` to that `useMemo`'s dependency array.
+
+- [ ] **Step 7: Add the AttentionStrip component test**
+
+Append to `tests/unit/ui/attention-strip.test.tsx` a case rendering an `items` array containing `{ kind: 'fraud_risk', label: 'Fraud risk: CRITICAL — flagged for review', accountId: null, severity: 'high' }` and asserting the chip text renders and `data-testid="attention-chip-fraud_risk"` is present and disabled (accountId null). Follow the existing test structure in that file.
+
+- [ ] **Step 8: Run tests + typecheck + lint**
+
+Run: `cd /Users/rohansharp/workspace/billie-crm && pnpm exec vitest run tests/unit/lib/account-triage.test.ts tests/unit/ui/attention-strip.test.tsx --config ./vitest.config.mts`
+Expected: PASS (or, if Docker unavailable, `pnpm typecheck` + `pnpm lint` clean and vitest noted as pending-Docker).
+Run: `cd /Users/rohansharp/workspace/billie-crm && pnpm typecheck && pnpm lint`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm
+git add src/ tests/
+git commit -m "feat(fraud): customer fraud-risk chip in AttentionStrip + API/hook wiring"
+```
+
+---
+
+### Task 4: Fraud panel on the application view
+
+**Files:**
+- Modify: `src/components/ConversationDetailView/AssessmentPanel/index.tsx`
+
+**Interfaces:**
+- Consumes `assessments.fraudCheck` (already surfaced by `/api/conversations/[id]`; no API/schema change).
+
+- [ ] **Step 1: Derive the fraud data**
+
+In `AssessmentPanel/index.tsx`, near the other assessment derivations (around lines 170-173), add:
+
+```ts
+  // Fraud risk (billieChat FraudRiskAgent) — written to assessments.fraudCheck.
+  const fraudCheck = assessments?.fraudCheck as Record<string, unknown> | undefined
+  const fraudSeverity = (fraudCheck?.severity as string | undefined)?.toUpperCase()
+  const fraudSummary = fraudSeverity ? fraudSeverity : 'No data'
+```
+
+- [ ] **Step 2: Add the section**
+
+Add a `<AssessmentSection>` (modeled on the Post-IDV Check section) right after the Post-IDV Check section closes and before the Statements section:
+
+```tsx
+      {/* Fraud risk */}
+      <AssessmentSection title="Fraud risk" summary={fraudSummary}>
+        {fraudCheck ? (
+          <div>
+            <p className={fraudSeverity && ['HIGH', 'CRITICAL'].includes(fraudSeverity) ? styles.fail : styles.pass}>
+              {fraudSeverity} — score {String(fraudCheck.final_score ?? '?')}
+            </p>
+            <pre className={styles.jsonPreview}>{JSON.stringify(fraudCheck, null, 2)}</pre>
+          </div>
+        ) : (
+          <p>No fraud-risk assessment data.</p>
+        )}
+      </AssessmentSection>
+```
+
+- [ ] **Step 3: Type-check + lint**
+
+Run: `cd /Users/rohansharp/workspace/billie-crm && pnpm typecheck && pnpm lint`
+Expected: clean. (`styles.pass`/`styles.fail`/`styles.jsonPreview` already exist in the panel's CSS module — reused above.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm
+git add src/components/ConversationDetailView/AssessmentPanel/index.tsx
+git commit -m "feat(fraud): fraud-risk section on the application AssessmentPanel"
+```
+
+---
+
+### Task 5: Verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Python suite**
+
+Run: `cd /Users/rohansharp/workspace/billie-crm/event-processor && python -m pytest tests/test_fraud_risk.py tests/test_handler_exports.py -v && ruff check src tests && mypy src`
+Expected: all pass; handler-exports test green (confirms `__init__.py`/`__all__` in sync); ruff/mypy clean.
+
+- [ ] **Step 2: TS checks**
+
+Run: `cd /Users/rohansharp/workspace/billie-crm && pnpm typecheck && pnpm lint && pnpm build`
+Expected: clean build.
+Run (if Docker available): `pnpm exec vitest run tests/unit/lib/account-triage.test.ts tests/unit/ui/attention-strip.test.tsx --config ./vitest.config.mts`
+Expected: pass. If Docker is unavailable, record that the two vitest files are pending a Docker-enabled run; typecheck/lint/build stand as the gate.
+
+- [ ] **Step 3: Commit any fixes**
+
+```bash
+cd /Users/rohansharp/workspace/billie-crm && git add -A && git commit -m "chore(fraud): verification fixes" || echo "nothing to commit"
+```
+
+## Rollout note
+
+billie-crm already receives `fraud_risk.*` on `inbox:billie-servicing` (routed by billieChat's broker), so registering the handlers starts consuming them immediately on the next event-processor deploy — no billieChat change. The migration adds the `customers.fraud_risk_*` columns (applied at deploy; dev/test use `push: true`). The application-panel data needs no migration (the `assessments_fraud_check` column already exists).

--- a/docs/superpowers/specs/2026-07-09-fraud-alerting-slack-crm-design.md
+++ b/docs/superpowers/specs/2026-07-09-fraud-alerting-slack-crm-design.md
@@ -1,0 +1,138 @@
+# Fraud Alerting — Slack (billieChat) + CRM ingestion/display/alert (billie-crm) — Design
+
+- **Date:** 2026-07-09
+- **Status:** Approved design, pending implementation plans
+- **Depends on:** the FraudRiskAgent (`docs/superpowers/specs/2026-07-08-fraud-risk-agent-design.md`, merged to `main` in PR #136), which emits `fraud_risk.assessment.v1` and `fraud_risk.halt.v1` to `chatLedger`.
+
+## 1. Goal
+
+When the FraudRiskAgent detects a **HIGH or CRITICAL** incident:
+
+1. **Part A (billieChat):** page the **support** Slack channel, including a deep link into the CRM application view for that conversation.
+2. **Part B (billie-crm):** ingest the `fraud_risk.*` events, persist the assessment, display it read-only on the application view, and raise a passive customer-level alert using the CRM's existing AttentionStrip alert framework.
+
+The two parts live in **two repos** and ship as **two implementation plans / branches**, executed in order (Part A first).
+
+## 2. Decisions (locked)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Slack trigger | Fire on **HIGH + CRITICAL**, in **shadow and enforce** modes (never `off`) |
+| 2 | Slack failure | **Best-effort / non-fatal** — a Slack failure never interrupts scoring, emission, or the enforce-mode stop |
+| 3 | Slack content | Includes a **deep link** to the CRM application view for the conversation |
+| 4 | CRM alert style | **Passive banner + panel** — read-only fraud panel on the application view + a fraud chip in the customer cockpit's AttentionStrip (leverages the existing framework; no new alert framework) |
+| 5 | CRM primary alert surface | **Customer-level** (keyed by `customer_id`), because HIGH/CRITICAL incidents often precede an `application_number` |
+
+---
+
+## Part A — billieChat: Slack support alert
+
+### A1. Trigger point
+
+In `backend/backend/src/agents/fraudRiskAgent/fraudRiskAgent.py`, `handle_user_input`, after `severity` is computed (and after the `off`-mode early return), when `severity in {HIGH, CRITICAL}` (the existing `_HALTING` set): fire a support-channel Slack alert. Placed **before** the enforce-only branch, so it pages in both `shadow` and `enforce`.
+
+### A2. Fire-once per conversation
+
+A multi-message probing session must page support **once**, not per message. Add a guard to `state.py`:
+
+- `async try_claim_alert(self, conv: str, ttl: int) -> bool` — `SET fraudRisk:alerted:{conv} "1" NX EX ttl`; returns `True` only on the first claim (mirrors `try_claim_halt`). The alert fires only when the claim is won.
+
+### A3. The alert call
+
+Uses the existing framework: `slackUtils.send_slack_alert(message, *, category="incidents", title=..., color="danger", fields=[...])`, which routes to `SLACK_SUPPORT_WEBHOOK_URL` (the support channel), lazy-imported. Because `send_slack_alert` is synchronous/blocking (`requests.post`, 10s timeout) and the handler is async, it runs via `asyncio.to_thread(...)`.
+
+Message contents: severity, conversation id, application number, final score, categories, `would_halt`, mode, and a **deep link** (§A4). Example (mrkdwn):
+
+```
+[FRAUD RISK CRITICAL] conv=<conv> application=<app> score=85
+categories=[PROMPT_INJECTION, SYSTEM_PROMPT_EXFIL] would_halt=true mode=shadow
+<https://crm.example/admin/applications/<conv>|Open in CRM>
+```
+
+Plus `fields` (severity, score, application, conversation, mode) for the Slack attachment, matching the OTP-incident call site's shape.
+
+### A4. CRM deep link
+
+- New config key **`crm_base_url`** (env override **`CRM_BASE_URL`**), set per environment (dev `http://localhost:3000`; demo/prod the deployed billie-crm admin base URLs). Added to all four `config.{dev,test,demo,prod}.json`.
+- Deep link: `{crm_base_url}/admin/applications/{conversation_id}` — the CRM application/conversation detail view. The exact path segment and whether it keys on `conversation_id` vs `application_number` is confirmed against the CRM's `ApplicationsRouter` during Part B planning; `conversation_id` (always present on the fraud event as `conv`) is the default.
+- If `crm_base_url` is unset/empty, the link is **omitted** from the message (the alert still fires).
+
+### A5. Non-fatal contract
+
+The entire alert path — claim, deep-link construction, `asyncio.to_thread(send_slack_alert)` — is wrapped in a single `try/except Exception` that only `logger.warning`s on failure. It runs **after** the assessment is emitted and does not gate the halt event or the enforce-mode `post_to_noticeboard`. Consequences of any failure (missing `SLACK_SUPPORT_WEBHOOK_URL`, HTTP error, timeout, missing `crm_base_url`): the alert is skipped/incomplete, a warning is logged, and `handle_user_input` proceeds exactly as if alerting were absent. `send_slack_alert` itself already no-ops (returns `False`) when the webhook env var is unset.
+
+### A6. Files (Part A)
+
+- **Modify** `backend/backend/src/agents/fraudRiskAgent/fraudRiskAgent.py` — the guarded alert block + a small `_alert_support(...)` helper.
+- **Modify** `backend/backend/src/agents/fraudRiskAgent/state.py` — `try_claim_alert`.
+- **Modify** `backend/backend/src/config.{dev,test,demo,prod}.json` — `crm_base_url` + `fraudRisk_alert_ttl_seconds` (fire-once TTL, default 86400).
+- **Modify** `backend/tests/unit/agents/test_fraudRiskAgent.py`, `test_fraudRiskState.py` — tests.
+
+### A7. Tests (Part A)
+
+- Alert fires (mocked `send_slack_alert`) on HIGH and CRITICAL; not on LOW/MEDIUM; not in `off`; fires in both `shadow` and `enforce`.
+- Fire-once: two HIGH/CRITICAL messages in one conversation → one alert (claim guard).
+- Deep link present when `crm_base_url` set; omitted when unset.
+- **Slack failure is non-fatal:** with `send_slack_alert` raising, `handle_user_input` still emits the assessment and (enforce) posts the stop — no exception propagates.
+- `try_claim_alert` unit test in `test_fraudRiskState.py` (SET NX true then false).
+
+---
+
+## Part B — billie-crm: ingest → persist → display → alert
+
+Entirely within `/Users/rohansharp/workspace/billie-crm`. billieChat needs no change — the broker already routes `fraud_risk.assessment.v1` / `fraud_risk.halt.v1` into `inbox:billie-servicing`, where they currently arrive and are silently ACK-dropped (no handler). billie-crm is a two-process system: a **Python event-processor** (consumer) and a **Payload CMS / Next.js** app (UI + API) over one Postgres.
+
+### B1. Ingest (Python event-processor)
+
+New `event-processor/src/billie_servicing/handlers/fraud_risk.py`, exported from `handlers/__init__.py` and registered in `main.py:setup_handlers`:
+
+- **`handle_fraud_risk_assessment(pool, event)`** — for `fraud_risk.assessment.v1`. Parses the envelope payload (the `FraudRiskDecision` dict: `final_score`, `severity`, `categories`, `rationale`, `signals`, `would_halt`, `mode`, `conversation_id`, `application_number`). **Skips LOW** (benign — no write). For MEDIUM+, upserts a rolling fraud summary into the application record's **existing** `assessments.fraudCheck` JSONB slot (`conversations.assessments_fraud_check`), via `merge_jsonb`/`upsert_conversation`: `{ latest: {...}, peak_severity, peak_score, flagged_count, last_flagged_at }`. **Update-only** keyed by the conversation's stable id — does not create a conversation row if none exists (mirrors the `handle_assessment` / reapplication handlers; exact key column read from `Conversations.ts` at plan time).
+- **`handle_fraud_risk_halt(pool, event)`** — for `fraud_risk.halt.v1` (HIGH/CRITICAL). Raises the **customer-level** fraud alert by upserting `customers.fraud_risk_*` (keyed by `customer_id`, update-only): severity, score, categories, `flagged_at`, `active=true`. This drives the AttentionStrip chip.
+
+The processor's `_parse_event` needs no change (unknown prefixes already fall to the envelope path, matching `application.reapplication_blocked.v1`); a `fraud_risk.` branch is optional and out of scope for v1.
+
+### B2. Persist
+
+- **Application/conversation level:** reuse `conversations.assessments_fraud_check` (JSONB, already migrated — no schema change).
+- **Customer level:** add a `fraudRisk` group to `src/collections/Customers.ts` (modeled on the `reapplicationBlock`/`identityVerification` groups), flattening to columns `fraud_risk_severity`, `fraud_risk_score`, `fraud_risk_categories`, `fraud_risk_flagged_at`, `fraud_risk_active`. Add a migration under `src/migrations/` mirroring `20260610_114936_reapplication_block_identity_verification.ts`, then `pnpm generate:types`.
+
+### B3. Display — application view
+
+Add a **Fraud risk** section to `src/components/ConversationDetailView/AssessmentPanel/index.tsx`, reading the `assessments.fraudCheck` data already surfaced by `GET /api/conversations/[conversationId]` (`route.ts:172`): peak severity (color-coded), score, categories, rationale, last-flagged time, flagged count. No API change needed for this panel. (A HIGH/CRITICAL branch in `DecisionBanner` is optional polish, out of scope for v1.)
+
+### B4. Alert — customer cockpit (AttentionStrip)
+
+Leverage the existing framework:
+
+- **Data:** add `fraudRisk` to the `CustomerData` type in `src/hooks/queries/useCustomer.ts` and return `fraudRisk: customer.fraudRisk ?? null` from `src/app/api/customer/[customerId]/route.ts` (alongside `reapplicationBlock`/`identityVerification`).
+- **Logic:** add a `fraud_risk` kind to the `AttentionItem` union and a branch in `getAttentionItems(...)` in `src/lib/accountTriage.ts` — emit a chip when `fraudRisk?.active` and severity is HIGH/CRITICAL, e.g. `label: "Fraud risk: CRITICAL — flagged for review"`, `severity: 'high'`.
+- **UI:** add a `fraud_risk` entry to the `ICON` map in `src/components/ServicingView/AttentionStrip.tsx`. It then renders automatically in the cockpit (`ServicingView.tsx`).
+
+### B5. Files (Part B)
+
+**Python (event-processor):** `handlers/fraud_risk.py` (new), `handlers/__init__.py`, `main.py`, plus pytest under `event-processor/tests/`.
+**Payload/Next (TypeScript):** `src/collections/Customers.ts`, a new migration in `src/migrations/`, `payload-types.ts` (generated), `src/hooks/queries/useCustomer.ts`, `src/app/api/customer/[customerId]/route.ts`, `src/lib/accountTriage.ts`, `src/components/ServicingView/AttentionStrip.tsx`, `src/components/ConversationDetailView/AssessmentPanel/index.tsx`, plus Vitest tests under `tests/`.
+
+### B6. Tests (Part B)
+
+- **Python (pytest, MockPool):** `handle_fraud_risk_assessment` writes the rolling summary into `assessments_fraud_check` for MEDIUM+, skips LOW, is update-only. `handle_fraud_risk_halt` sets `customers.fraud_risk_*` active with the right severity. Handler registration wired in `main.py`.
+- **TypeScript (Vitest):** `getAttentionItems` emits the fraud chip when `fraudRisk.active` HIGH/CRITICAL and not otherwise; `AssessmentPanel` renders the fraud section from `fraudCheck` data.
+
+---
+
+## 3. Rollout & sequencing
+
+- **Part A** ships in the billieChat `feat/fraud-alerting` branch. The alert fires wherever the FraudRiskAgent runs (shadow on demo; off/disabled in prod until the agent is enabled). `SLACK_SUPPORT_WEBHOOK_URL` and `CRM_BASE_URL` must be set for the alert/link to be live; both no-op gracefully when unset.
+- **Part B** ships in a billie-crm branch after Part A. It is independent — it consumes events that already flow to the CRM, so it can be enabled without any billieChat redeploy.
+
+## 4. Out of scope (v1)
+
+- An actionable fraud-review **queue** with maker-checker (the "Approvals" pattern) — the chosen surface is the passive banner/chip. Can be layered later.
+- A `DecisionBanner` fraud branch on the application view (optional polish).
+- A typed `fraud_risk.` parser branch in the CRM `_parse_event` (envelope path suffices).
+- Postgres projection / analytics for `fraud_risk.*` (already noted as a fast-follow in the agent spec).
+
+## 5. Key edge cases
+
+- **Pre-application / anonymous sessions:** `application_number` is often `""` early in a conversation. The **customer-level chip (keyed by `customer_id`) is the reliable primary surface**; the application-detail panel attaches only when a conversation/application row exists. Handlers are **update-only** — they never create junk customer/conversation rows for anonymous sessions.
+- **Volume:** `fraud_risk.assessment.v1` fires for every message; the CRM assessment handler skips LOW and only rolls up MEDIUM+, and the Slack alert is fire-once per conversation — both bound write/alert volume.

--- a/event-processor/src/billie_servicing/handlers/__init__.py
+++ b/event-processor/src/billie_servicing/handlers/__init__.py
@@ -50,6 +50,10 @@ from .customer import (
     handle_customer_changed,
     handle_customer_verified,
 )
+from .fraud import (
+    handle_fraud_risk_assessment,
+    handle_fraud_risk_halt,
+)
 from .identity import (
     handle_customer_identity_linked,
     handle_customer_identity_merged,
@@ -134,6 +138,9 @@ __all__ = [
     # Credit assessment & post-identity handlers
     "handle_post_identity_risk_check",
     "handle_credit_assessment_complete",
+    # Fraud risk handlers (fraud_risk.* from billieChat FraudRiskAgent)
+    "handle_fraud_risk_assessment",
+    "handle_fraud_risk_halt",
     # Write-off handlers (CRM-originated events)
     "handle_writeoff_requested",
     "handle_writeoff_approved",

--- a/event-processor/src/billie_servicing/handlers/conversation.py
+++ b/event-processor/src/billie_servicing/handlers/conversation.py
@@ -38,6 +38,7 @@ _ASSESSMENT_COLUMNS = {
     "accountConduct": "assessments_account_conduct",
     "postIdentityRisk": "assessments_post_identity_risk",
     "creditAssessmentComplete": "assessments_credit_assessment_complete",
+    "fraudCheck": "assessments_fraud_check",
 }
 
 

--- a/event-processor/src/billie_servicing/handlers/fraud.py
+++ b/event-processor/src/billie_servicing/handlers/fraud.py
@@ -1,0 +1,82 @@
+"""Handlers for fraud_risk.* events emitted by the billieChat FraudRiskAgent."""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncpg
+import structlog
+
+from ..db import coerce_date, upsert
+from .conversation import _ASSESSMENT_COLUMNS, _set_assessment
+from .identity import resolve_canonical_customer_id
+from .sanitize import parse_payload, safe_str, strip_dollar_keys
+
+logger = structlog.get_logger()
+
+_MEDIUM_PLUS = {"MEDIUM", "HIGH", "CRITICAL"}
+
+
+async def handle_fraud_risk_assessment(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
+    """Persist a MEDIUM+ fraud assessment onto the conversation's fraudCheck slot.
+
+    LOW (benign) assessments are skipped. The latest MEDIUM+ assessment wins,
+    matching how the other assessment columns overwrite.
+    """
+    payload = parse_payload(event)
+    conversation_id = safe_str(
+        event.get("cid") or event.get("conv") or payload.get("conversation_id"),
+        "conversation_id",
+    )
+    severity = str(payload.get("severity", "")).upper()
+    log = logger.bind(conversation_id=conversation_id, severity=severity)
+
+    if severity not in _MEDIUM_PLUS:
+        log.info("fraud_risk.assessment.v1 below MEDIUM — skipping")
+        return
+    if not conversation_id:
+        log.warning("fraud_risk.assessment.v1 without conversation id — skipping")
+        return
+
+    data = strip_dollar_keys(payload)
+    await _set_assessment(pool, conversation_id, _ASSESSMENT_COLUMNS["fraudCheck"], data)
+    log.info("fraud check assessment persisted")
+
+
+async def handle_fraud_risk_halt(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
+    """Raise the customer-level fraud alert from a HIGH/CRITICAL fraud_risk.halt.v1.
+
+    Mirrors the reapplication-block customer mirror: resolve the canonical customer
+    id and upsert the fraud_risk_* fields that drive the AttentionStrip chip.
+    """
+    payload = parse_payload(event)
+    severity = str(payload.get("severity", "")).upper()
+    categories = payload.get("categories") or []
+    score = payload.get("final_score")
+
+    customer_id = safe_str(event.get("usr") or payload.get("customer_id"), "customer_id")
+    canonical_id = await resolve_canonical_customer_id(pool, customer_id or None)
+    log = logger.bind(customer_id=customer_id, severity=severity)
+    if not canonical_id:
+        log.warning("fraud_risk.halt.v1 without resolvable customer id — no mirror")
+        return
+
+    now = datetime.now(UTC)
+    await upsert(
+        pool,
+        "customers",
+        conflict_columns=["customer_id"],
+        values={
+            "customer_id": canonical_id,
+            "fraud_risk_severity": severity or None,
+            "fraud_risk_score": int(score) if isinstance(score, int | float) else None,
+            "fraud_risk_categories": json.dumps(categories),
+            "fraud_risk_flagged_at": coerce_date(payload.get("flagged_at")) or now,
+            "fraud_risk_active": True,
+            "updated_at": now,
+            "created_at": now,
+        },
+        insert_only_columns=["created_at"],
+    )
+    log.info("customer fraud-risk alert raised")

--- a/event-processor/src/billie_servicing/main.py
+++ b/event-processor/src/billie_servicing/main.py
@@ -60,6 +60,9 @@ from .handlers import (
     handle_feedback_received,
     handle_feedback_status_changed,
     handle_final_decision,
+    # Fraud risk handlers (fraud_risk.* from billieChat FraudRiskAgent)
+    handle_fraud_risk_assessment,
+    handle_fraud_risk_halt,
     # Identity verification archival (PR #67)
     handle_identity_report_archived,
     # Aging handler (platform → CRM read-only projection of arrears state)
@@ -222,6 +225,12 @@ def setup_handlers(processor: EventProcessor) -> None:
     processor.register_handler("credit_assessment_accountConduct_result", handle_assessment)
     processor.register_handler("post_identity_risk_checks_complete", handle_post_identity_risk_check)
     processor.register_handler("credit_assessment_complete", handle_credit_assessment_complete)
+
+    # Fraud risk (billieChat FraudRiskAgent) — MEDIUM+ assessments land on the
+    # conversation's fraudCheck slot; HIGH/CRITICAL halts raise the customer-level
+    # fraud-risk mirror consumed by the CRM's AttentionStrip chip.
+    processor.register_handler("fraud_risk.assessment.v1", handle_fraud_risk_assessment)
+    processor.register_handler("fraud_risk.halt.v1", handle_fraud_risk_halt)
 
     # =========================================================================
     # Write-off events (CRM-originated, manual parsing)

--- a/event-processor/tests/test_fraud_risk.py
+++ b/event-processor/tests/test_fraud_risk.py
@@ -55,3 +55,20 @@ class TestFraudRiskHalt:
         assert doc["customer_id"] == "CUST1"
         assert doc["fraud_risk_active"] is True
         assert doc["fraud_risk_severity"] == "HIGH"
+
+    @pytest.mark.asyncio
+    async def test_halt_writes_score_categories_and_flagged_at(self, mock_pool):
+        event = {"typ": "fraud_risk.halt.v1", "usr": "CUST1", "conv": CONV,
+                 "payload": dict(HALT_PAYLOAD)}
+        await handle_fraud_risk_halt(mock_pool, event)
+        doc = mock_pool.last_upsert("customers")
+        assert doc["fraud_risk_score"] == 70
+        assert "PROMPT_INJECTION" in str(doc["fraud_risk_categories"])
+        assert doc["fraud_risk_flagged_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_halt_without_customer_id_makes_no_mirror(self, mock_pool):
+        # No usr and no customer_id → no resolvable customer → no junk row.
+        event = {"typ": "fraud_risk.halt.v1", "conv": CONV, "payload": dict(HALT_PAYLOAD)}
+        await handle_fraud_risk_halt(mock_pool, event)
+        assert mock_pool.last_upsert("customers") is None

--- a/event-processor/tests/test_fraud_risk.py
+++ b/event-processor/tests/test_fraud_risk.py
@@ -1,0 +1,57 @@
+"""Tests for the fraud_risk.* handlers."""
+import pytest
+
+from billie_servicing.handlers.fraud import (
+    handle_fraud_risk_assessment,
+    handle_fraud_risk_halt,
+)
+
+CONV = "7d5ee9c2-dd6b-4091-8a3a-6c148a4c4142"
+
+ASSESSMENT_PAYLOAD = {
+    "conversation_id": CONV,
+    "application_number": "",
+    "final_score": 70,
+    "severity": "HIGH",
+    "categories": ["PROMPT_INJECTION"],
+    "rationale": "asked to ignore instructions",
+    "signals": ["ignore all previous"],
+    "would_halt": True,
+    "mode": "shadow",
+}
+
+HALT_PAYLOAD = dict(ASSESSMENT_PAYLOAD)
+
+
+class TestFraudRiskAssessment:
+    @pytest.mark.asyncio
+    async def test_medium_plus_writes_fraud_check(self, mock_pool):
+        event = {"typ": "fraud_risk.assessment.v1", "usr": "CUST1", "conv": CONV,
+                 "payload": dict(ASSESSMENT_PAYLOAD)}
+        await handle_fraud_risk_assessment(mock_pool, event)
+        updates = [c for c in mock_pool.calls_against("conversations")
+                   if c.op == "UPDATE" and "assessments_fraud_check" in c.values]
+        assert updates, "expected an assessments_fraud_check UPDATE"
+
+    @pytest.mark.asyncio
+    async def test_low_is_skipped(self, mock_pool):
+        low = dict(ASSESSMENT_PAYLOAD, severity="LOW", final_score=5)
+        event = {"typ": "fraud_risk.assessment.v1", "usr": "CUST1", "conv": CONV,
+                 "payload": low}
+        await handle_fraud_risk_assessment(mock_pool, event)
+        updates = [c for c in mock_pool.calls_against("conversations")
+                   if "assessments_fraud_check" in (c.values or {})]
+        assert not updates, "LOW severity must not be persisted"
+
+
+class TestFraudRiskHalt:
+    @pytest.mark.asyncio
+    async def test_sets_customer_fraud_risk_active(self, mock_pool):
+        event = {"typ": "fraud_risk.halt.v1", "usr": "CUST1", "conv": CONV,
+                 "payload": dict(HALT_PAYLOAD)}
+        await handle_fraud_risk_halt(mock_pool, event)
+        doc = mock_pool.last_upsert("customers")
+        assert doc is not None
+        assert doc["customer_id"] == "CUST1"
+        assert doc["fraud_risk_active"] is True
+        assert doc["fraud_risk_severity"] == "HIGH"

--- a/src/app/api/customer/[customerId]/route.ts
+++ b/src/app/api/customer/[customerId]/route.ts
@@ -107,6 +107,7 @@ export async function GET(
         vulnerableFlag: customer.vulnerableFlag || false,
         reapplicationBlock: customer.reapplicationBlock ?? null,
         identityVerification: customer.identityVerification ?? null,
+        fraudRisk: customer.fraudRisk ?? null,
       },
       accounts: accountsWithBalances.map((account) => ({
         id: account.id,

--- a/src/collections/Customers.ts
+++ b/src/collections/Customers.ts
@@ -320,7 +320,9 @@ export const Customers: CollectionConfig = {
         {
           name: 'clearStatus',
           type: 'text',
-          admin: { description: 'Status of the most recent block-clear request (e.g. approved, rejected)' },
+          admin: {
+            description: 'Status of the most recent block-clear request (e.g. approved, rejected)',
+          },
         },
         {
           name: 'clearedAt',
@@ -371,6 +373,42 @@ export const Customers: CollectionConfig = {
         {
           name: 'archivedAt',
           type: 'date',
+        },
+      ],
+    },
+    {
+      // Latest HIGH/CRITICAL fraud-risk incident, mirrored from fraud_risk.halt.v1
+      // (billieChat FraudRiskAgent). Drives the AttentionStrip fraud chip.
+      name: 'fraudRisk',
+      type: 'group',
+      admin: {
+        readOnly: true,
+        description: 'Latest HIGH/CRITICAL fraud-risk incident (flagged for review)',
+      },
+      fields: [
+        {
+          name: 'severity',
+          type: 'text',
+          admin: { description: 'HIGH or CRITICAL' },
+        },
+        {
+          name: 'score',
+          type: 'number',
+          admin: { description: 'Final fraud risk score 0-100' },
+        },
+        {
+          name: 'categories',
+          type: 'json',
+          admin: { description: 'Detected fraud/abuse categories' },
+        },
+        {
+          name: 'flaggedAt',
+          type: 'date',
+        },
+        {
+          name: 'active',
+          type: 'checkbox',
+          admin: { description: 'True while the fraud alert is active' },
         },
       ],
     },
@@ -459,4 +497,4 @@ export const Customers: CollectionConfig = {
       },
     },
   ],
-} 
+}

--- a/src/components/ConversationDetailView/AssessmentPanel/index.tsx
+++ b/src/components/ConversationDetailView/AssessmentPanel/index.tsx
@@ -172,6 +172,11 @@ export function AssessmentPanel({ conversation, conversationId }: AssessmentPane
   const pirDecision = postIdentityRisk?.decision as string | undefined
   const pirHasS3 = Boolean(postIdentityRisk?.s3Key || postIdentityRisk?.file_location)
 
+  // Fraud risk (billieChat FraudRiskAgent) — written to assessments.fraudCheck.
+  const fraudCheck = assessments?.fraudCheck as Record<string, unknown> | undefined
+  const fraudSeverity = (fraudCheck?.severity as string | undefined)?.toUpperCase()
+  const fraudSummary = fraudSeverity ? fraudSeverity : 'No data'
+
   // Statements summary
   const sc = statementCapture as Record<string, unknown> | undefined
   const consentStatus = sc?.consentStatus as string | undefined
@@ -320,6 +325,26 @@ export function AssessmentPanel({ conversation, conversationId }: AssessmentPane
             <p>No post-IDV check data.</p>
           ) : null}
         </div>
+      </AssessmentSection>
+
+      {/* Fraud risk */}
+      <AssessmentSection title="Fraud risk" summary={fraudSummary}>
+        {fraudCheck ? (
+          <div>
+            <p
+              className={
+                fraudSeverity && ['HIGH', 'CRITICAL'].includes(fraudSeverity)
+                  ? styles.fail
+                  : styles.pass
+              }
+            >
+              {fraudSeverity} — score {String(fraudCheck.final_score ?? '?')}
+            </p>
+            <pre className={styles.jsonPreview}>{JSON.stringify(fraudCheck, null, 2)}</pre>
+          </div>
+        ) : (
+          <p>No fraud-risk assessment data.</p>
+        )}
       </AssessmentSection>
 
       {/* Statements */}

--- a/src/components/ServicingView/AttentionStrip.module.css
+++ b/src/components/ServicingView/AttentionStrip.module.css
@@ -11,3 +11,4 @@
 .collections { background: var(--theme-elevation-50, #eef2fb); color: var(--theme-elevation-650, #2f5bb0); border-color: var(--theme-elevation-150, #cdd9f0); }
 .hardship { background: var(--theme-warning-100, #fdf3e0); color: var(--theme-warning-700, #b7791f); border-color: var(--theme-warning-200, #f0dcae); }
 .stop_contact { background: var(--theme-error-100, #fbeceb); color: var(--theme-error-500, #c0362c); border-color: var(--theme-error-300, #f1c4bf); font-weight: 700; }
+.fraud_risk { background: var(--theme-error-100, #fdecea); color: var(--theme-error-500, #b4231a); border-color: var(--theme-error-300, #f0b8b1); font-weight: 700; }

--- a/src/components/ServicingView/AttentionStrip.tsx
+++ b/src/components/ServicingView/AttentionStrip.tsx
@@ -19,6 +19,7 @@ const ICON: Record<AttentionItem['kind'], string> = {
   collections: '☎',
   hardship: '🛡',
   stop_contact: '🔕',
+  fraud_risk: '🚩',
 }
 
 export const AttentionStrip: React.FC<AttentionStripProps> = ({

--- a/src/components/ServicingView/ServicingView.tsx
+++ b/src/components/ServicingView/ServicingView.tsx
@@ -128,6 +128,7 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
           selectedAccountId && hasPendingWriteOff ? [selectedAccountId] : [],
         reapplicationBlock: customer?.reapplicationBlock ?? null,
         collectionsCases,
+        fraudRisk: customer?.fraudRisk ?? null,
       }),
     [
       customer?.vulnerableFlag,
@@ -136,6 +137,7 @@ export const ServicingView: React.FC<ServicingViewProps> = ({ customerId }) => {
       selectedAccountId,
       hasPendingWriteOff,
       collectionsCases,
+      customer?.fraudRisk,
     ],
   )
 

--- a/src/hooks/queries/useCustomer.ts
+++ b/src/hooks/queries/useCustomer.ts
@@ -125,6 +125,14 @@ export interface CustomerData {
     reportArchived?: boolean | null
     archivedAt?: string | null
   } | null
+  /** Latest HIGH/CRITICAL fraud-risk incident (billieChat FraudRiskAgent). */
+  fraudRisk?: {
+    severity?: string | null
+    score?: number | null
+    categories?: string[] | null
+    flaggedAt?: string | null
+    active?: boolean | null
+  } | null
   loanAccounts?: LoanAccountData[] | null
 }
 

--- a/src/lib/accountTriage.ts
+++ b/src/lib/accountTriage.ts
@@ -23,6 +23,7 @@ export interface AttentionItem {
     | 'collections'
     | 'hardship'
     | 'stop_contact'
+    | 'fraud_risk'
   label: string
   accountId: string | null
   severity: 'high' | 'medium'
@@ -95,6 +96,7 @@ export function getAttentionItems(opts: {
   pendingWriteOffAccountIds?: string[]
   reapplicationBlock?: CustomerData['reapplicationBlock']
   collectionsCases?: CollectionsCaseRow[]
+  fraudRisk?: CustomerData['fraudRisk']
   today?: Date
 }): AttentionItem[] {
   const {
@@ -103,6 +105,7 @@ export function getAttentionItems(opts: {
     pendingWriteOffAccountIds = [],
     reapplicationBlock = null,
     collectionsCases = [],
+    fraudRisk = null,
     today = new Date(),
   } = opts
   const items: AttentionItem[] = []
@@ -117,6 +120,16 @@ export function getAttentionItems(opts: {
     items.push({
       kind: 'reapplication_blocked',
       label: `Re-application blocked — ${formatBlockReason(reapplicationBlock?.reason)} (${formatBlockedUntil(reapplicationBlock ?? {})})`,
+      accountId: null,
+      severity: 'high',
+    })
+  }
+
+  // Fraud risk (billieChat FraudRiskAgent) — customer-level, active HIGH/CRITICAL.
+  if (fraudRisk?.active && (fraudRisk.severity ?? '').toUpperCase() !== '') {
+    items.push({
+      kind: 'fraud_risk',
+      label: `Fraud risk: ${(fraudRisk.severity ?? '').toUpperCase()} — flagged for review`,
       accountId: null,
       severity: 'high',
     })

--- a/src/migrations/20260709_120104_fraud_risk.ts
+++ b/src/migrations/20260709_120104_fraud_risk.ts
@@ -1,0 +1,19 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_severity" varchar;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_score" numeric;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_categories" jsonb;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_flagged_at" timestamp(3) with time zone;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_active" boolean;`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_severity";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_score";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_categories";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_flagged_at";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_active";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -14,6 +14,7 @@ import * as migration_20260707_121002 from './20260707_121002';
 import * as migration_20260707_141505 from './20260707_141505';
 import * as migration_20260708_020322 from './20260708_020322';
 import * as migration_20260708_121539_contact_merged_into from './20260708_121539_contact_merged_into';
+import * as migration_20260709_120104_fraud_risk from './20260709_120104_fraud_risk';
 
 export const migrations = [
   {
@@ -94,6 +95,11 @@ export const migrations = [
   {
     up: migration_20260708_121539_contact_merged_into.up,
     down: migration_20260708_121539_contact_merged_into.down,
-    name: '20260708_121539_contact_merged_into'
+    name: '20260708_121539_contact_merged_into',
+  },
+  {
+    up: migration_20260709_120104_fraud_risk.up,
+    down: migration_20260709_120104_fraud_risk.down,
+    name: '20260709_120104_fraud_risk',
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -357,6 +357,36 @@ export interface Customer {
     reportArchived?: boolean | null;
     archivedAt?: string | null;
   };
+  /**
+   * Latest HIGH/CRITICAL fraud-risk incident (flagged for review)
+   */
+  fraudRisk?: {
+    /**
+     * HIGH or CRITICAL
+     */
+    severity?: string | null;
+    /**
+     * Final fraud risk score 0-100
+     */
+    score?: number | null;
+    /**
+     * Detected fraud/abuse categories
+     */
+    categories?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+    flaggedAt?: string | null;
+    /**
+     * True while the fraud alert is active
+     */
+    active?: boolean | null;
+  };
   identityDocuments?:
     | {
         documentType: 'DRIVERS_LICENCE' | 'PASSPORT' | 'MEDICARE';
@@ -1994,6 +2024,15 @@ export interface CustomersSelect<T extends boolean = true> {
         checkedAt?: T;
         reportArchived?: T;
         archivedAt?: T;
+      };
+  fraudRisk?:
+    | T
+    | {
+        severity?: T;
+        score?: T;
+        categories?: T;
+        flaggedAt?: T;
+        active?: T;
       };
   identityDocuments?:
     | T

--- a/tests/unit/lib/account-triage.test.ts
+++ b/tests/unit/lib/account-triage.test.ts
@@ -288,4 +288,28 @@ describe('getAttentionItems', () => {
       { kind: 'stop_contact', label: 'Contact stopped', accountId: null, severity: 'high' },
     ])
   })
+
+  it('emits a high-severity fraud_risk chip when fraudRisk is active', () => {
+    const items = getAttentionItems({
+      vulnerable: false,
+      accounts: [],
+      fraudRisk: { severity: 'CRITICAL', score: 90, active: true },
+      today: TODAY,
+    })
+    expect(items.map((i) => i.kind)).toContain('fraud_risk')
+    const chip = items.find((i) => i.kind === 'fraud_risk')!
+    expect(chip.severity).toBe('high')
+    expect(chip.accountId).toBeNull()
+    expect(chip.label).toContain('CRITICAL')
+  })
+
+  it('does not emit a fraud_risk chip when inactive', () => {
+    const items = getAttentionItems({
+      vulnerable: false,
+      accounts: [],
+      fraudRisk: { severity: 'CRITICAL', score: 90, active: false },
+      today: TODAY,
+    })
+    expect(items.map((i) => i.kind)).not.toContain('fraud_risk')
+  })
 })

--- a/tests/unit/ui/assessment-views.test.tsx
+++ b/tests/unit/ui/assessment-views.test.tsx
@@ -113,6 +113,29 @@ describe('AssessmentPanel — identity summary', () => {
   })
 })
 
+describe('AssessmentPanel — fraud risk summary', () => {
+  afterEach(() => cleanup())
+
+  it('shows the severity and score, with fail styling for HIGH severity', () => {
+    const conversation = baseConversation({
+      assessments: { fraudCheck: { severity: 'HIGH', final_score: 87 } },
+    })
+    render(<AssessmentPanel conversation={conversation} conversationId="conv-001" />)
+    expect(screen.getAllByText('HIGH').length).toBeGreaterThan(0)
+    const fraudBtn = screen.getAllByRole('button').find((b) => b.textContent?.includes('Fraud risk'))
+    fireEvent.click(fraudBtn!)
+    expect(screen.getByText(/score 87/)).toBeInTheDocument()
+  })
+
+  it('shows "No data" summary and fallback message when fraudCheck is absent', () => {
+    const conversation = baseConversation({ assessments: {} })
+    render(<AssessmentPanel conversation={conversation} conversationId="conv-001" />)
+    const fraudBtn = screen.getAllByRole('button').find((b) => b.textContent?.includes('Fraud risk'))
+    fireEvent.click(fraudBtn!)
+    expect(screen.getByText('No fraud-risk assessment data.')).toBeInTheDocument()
+  })
+})
+
 describe('AssessmentPanel — application term label', () => {
   afterEach(() => cleanup())
 

--- a/tests/unit/ui/attention-strip.test.tsx
+++ b/tests/unit/ui/attention-strip.test.tsx
@@ -57,4 +57,19 @@ describe('AttentionStrip', () => {
     fireEvent.click(screen.getByText('Contact stopped'))
     expect(onSelectAccount).not.toHaveBeenCalled()
   })
+
+  test('renders a disabled fraud_risk chip (customer-level, not clickable)', () => {
+    const fraudItems: AttentionItem[] = [
+      { kind: 'fraud_risk', label: 'Fraud risk: CRITICAL — flagged for review', accountId: null, severity: 'high' },
+    ]
+    const onSelectAccount = vi.fn()
+    render(<AttentionStrip items={fraudItems} onSelectAccount={onSelectAccount} />)
+
+    expect(screen.getByText('Fraud risk: CRITICAL — flagged for review')).toBeInTheDocument()
+    const chip = screen.getByTestId('attention-chip-fraud_risk')
+    expect(chip).toBeDisabled()
+
+    fireEvent.click(chip)
+    expect(onSelectAccount).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
Part B of fraud alerting: billie-crm now **ingests** the `fraud_risk.assessment.v1` / `fraud_risk.halt.v1` events emitted by the billieChat FraudRiskAgent, **persists** them, **displays** a fraud-risk section on the application view, and **raises a customer-level fraud chip** in the existing AttentionStrip alert framework.

(These events already route to `inbox:billie-servicing` from billieChat's broker — they were arriving and being silently dropped for lack of a handler.)

## What's in it
- **Ingest (Python event-processor):** `handlers/fraud.py` — `handle_fraud_risk_assessment` (skips LOW; writes MEDIUM+ into the pre-existing `assessments_fraud_check` JSONB slot via `_set_assessment`) and `handle_fraud_risk_halt` (mirrors the reapplication-block customer mirror: resolve canonical id → upsert `customers.fraud_risk_*`). Registered in `main.py`, exported from `handlers/__init__.py`.
- **Persist:** a `customers.fraudRisk` group + migration (`fraud_risk_{severity,score,categories,flagged_at,active}`). The application-panel data needs **no** migration (the `assessments_fraud_check` column already existed).
- **Display (application view):** a read-only "Fraud risk" section on `AssessmentPanel`, reading `assessments.fraudCheck` (already surfaced by the conversations API — no route change).
- **Alert (customer cockpit):** a `fraud_risk` chip in `AttentionStrip` (accountTriage kind + branch + `🚩` icon + high-severity red CSS), driven by `customer.fraudRisk.active`, wired through the customer API + `useCustomer` hook.

## Verification
- Python: **281 tests pass** (incl. 5 fraud handler tests: MEDIUM+ write, LOW skip, customer-active mirror, score/categories/flaggedAt, and the no-junk-row guard). Ruff clean.
- TS: `pnpm typecheck` clean; `pnpm lint` 0 errors; **Vitest 29/29** for the fraud accountTriage + AttentionStrip tests (against the Docker Postgres testcontainer).
- A final cross-language review confirmed the field/type contract lines up end-to-end on both the chip and panel paths.

## Known limitation / follow-up
- **The fraud chip has no deactivation/expiry path yet** — `fraud_risk.halt.v1` sets `active=true`, and nothing clears it. This is within the documented v1 scope (the actionable review queue / resolution was deferred). Recommend a follow-up (a resolve event or an admin "clear") before the FraudRiskAgent is enabled in enforce mode.

Depends on the billieChat FraudRiskAgent (merged, PR #136) for the events. The billieChat-side Slack alert is a separate PR (#137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7Ho4HCdHW9pTjudWYgZfu