### PR TITLE
feat(marketing): PO review quick wins — advisory council, word-of-mouth source, help@ connector

### DIFF
--- a/contact-detail.yml
+++ b/contact-detail.yml
@@ -1,0 +1,243 @@
+- generic [active] [ref=f34e1]:
+  - button "Refresh health status" [ref=f34e7] [cursor=pointer]: ↻
+  - generic [ref=f34e8]:
+    - button "Open Menu" [ref=f34e10] [cursor=pointer]:
+      - generic "Open" [ref=f34e12]:
+        - img [ref=f34e13]
+    - generic [ref=f34e15]:
+      - complementary [ref=f34e16]:
+        - navigation [ref=f34e18]:
+          - button "Open search (⌘K)" [ref=f34e19] [cursor=pointer]:
+            - generic [ref=f34e20]: 🔍
+            - generic [ref=f34e21]: Search
+            - generic [ref=f34e22]: ⌘K
+          - link "Dashboard" [ref=f34e23] [cursor=pointer]:
+            - /url: /admin/dashboard
+            - generic [ref=f34e24]: 🏠
+            - generic [ref=f34e25]: Dashboard
+          - link "Applications" [ref=f34e26] [cursor=pointer]:
+            - /url: /admin/applications
+            - generic [ref=f34e27]: 💬
+            - generic [ref=f34e28]: Applications
+          - link "Accounts" [ref=f34e29] [cursor=pointer]:
+            - /url: /admin/accounts
+            - generic [ref=f34e30]: 🗂
+            - generic [ref=f34e31]: Accounts
+          - link "Collections 13 overdue accounts" [ref=f34e78] [cursor=pointer]:
+            - /url: /admin/collections-queue
+            - generic [ref=f34e33]: 📋
+            - generic [ref=f34e34]: Collections
+            - generic "13 overdue accounts" [ref=f34e79]: "13"
+          - link "Approvals" [ref=f34e35] [cursor=pointer]:
+            - /url: /admin/approvals
+            - generic [ref=f34e36]: ✅
+            - generic [ref=f34e37]: Approvals
+          - link "📅 Period Close" [ref=f34e38] [cursor=pointer]:
+            - /url: /admin/period-close
+            - generic [ref=f34e39]: 📅
+            - generic [ref=f34e40]: Period Close
+          - link "⚙️ ECL Config" [ref=f34e41] [cursor=pointer]:
+            - /url: /admin/ecl-config
+            - generic [ref=f34e42]: ⚙️
+            - generic [ref=f34e43]: ECL Config
+          - link "📤 Export Center" [ref=f34e44] [cursor=pointer]:
+            - /url: /admin/exports
+            - generic [ref=f34e45]: 📤
+            - generic [ref=f34e46]: Export Center
+          - link "🔬 Investigation" [ref=f34e47] [cursor=pointer]:
+            - /url: /admin/investigation
+            - generic [ref=f34e48]: 🔬
+            - generic [ref=f34e49]: Investigation
+          - link "Marketing" [ref=f34e50] [cursor=pointer]:
+            - /url: /admin/marketing
+            - generic [ref=f34e51]: 📣
+            - generic [ref=f34e52]: Marketing
+          - link "Log out" [ref=f34e54] [cursor=pointer]:
+            - /url: /api/auth/logout
+            - img [ref=f34e55]
+      - generic [ref=f34e59]:
+        - banner [ref=f34e60]:
+          - generic [ref=f34e63]:
+            - generic "Dashboard" [ref=f34e67]:
+              - img [ref=f34e68]
+            - link "Account" [ref=f34e71] [cursor=pointer]:
+              - /url: /admin/account
+              - img "yas" [ref=f34e72]
+        - generic [ref=f34e73]:
+          - link "← Back to Marketing" [ref=f34e74] [cursor=pointer]:
+            - /url: /admin/marketing
+          - generic [ref=f34e75]:
+            - generic [ref=f34e80]:
+              - heading "Rohan Sharp" [level=1] [ref=f34e81]
+              - generic [ref=f34e82]:
+                - generic [ref=f34e83]: "+61403320117"
+                - generic [ref=f34e84]: rohan@billie.loans
+            - generic [ref=f34e85]:
+              - generic [ref=f34e86]: —
+              - generic [ref=f34e87]: Consent granted
+              - 'link "Linked customer: 0FDF11CF" [ref=f34e88] [cursor=pointer]':
+                - /url: /admin/servicing/0FDF11CF
+          - generic [ref=f34e89]:
+            - generic [ref=f34e90]:
+              - generic [ref=f34e91]:
+                - textbox "Note text" [ref=f34e92]:
+                  - /placeholder: Log a note…
+                - button "Log note" [disabled] [ref=f34e93]
+              - generic [ref=f34e94]:
+                - article [ref=f34e95]:
+                  - generic [ref=f34e96]:
+                    - generic [ref=f34e97]: 📤
+                    - generic [ref=f34e98]: Message out
+                    - generic [ref=f34e99]: (outbound)
+                    - generic [ref=f34e100]: 8 July 2026, 9:18 pm
+                  - generic [ref=f34e101]: —
+                  - generic [ref=f34e102]: —
+                - article [ref=f34e103]:
+                  - generic [ref=f34e104]:
+                    - generic [ref=f34e105]: 📤
+                    - generic [ref=f34e106]: Message out
+                    - generic [ref=f34e107]: (outbound)
+                    - generic [ref=f34e108]: 8 July 2026, 9:18 pm
+                  - generic [ref=f34e109]: —
+                  - generic [ref=f34e110]: —
+                - article [ref=f34e111]:
+                  - generic [ref=f34e112]:
+                    - generic [ref=f34e113]: 📤
+                    - generic [ref=f34e114]: Message out
+                    - generic [ref=f34e115]: (outbound)
+                    - generic [ref=f34e116]: 8 July 2026, 5:15 pm
+                  - generic [ref=f34e117]: —
+                  - generic [ref=f34e118]: —
+                - article [ref=f34e119]:
+                  - generic [ref=f34e120]:
+                    - generic [ref=f34e121]: 🗒️
+                    - generic [ref=f34e122]: Note
+                    - generic [ref=f34e123]: 7 July 2026, 11:04 pm
+                  - generic [ref=f34e124]: —
+                  - generic [ref=f34e125]: linked
+                - article [ref=f34e126]:
+                  - generic [ref=f34e127]:
+                    - generic [ref=f34e128]: 🗒️
+                    - generic [ref=f34e129]: Note
+                    - generic [ref=f34e130]: 7 July 2026, 9:05 pm
+                  - generic [ref=f34e131]: —
+                  - generic [ref=f34e132]: second note — retest after platform event_id fix
+                - article [ref=f34e133]:
+                  - generic [ref=f34e134]:
+                    - generic [ref=f34e135]: 🗒️
+                    - generic [ref=f34e136]: Note
+                    - generic [ref=f34e137]: 5 July 2026, 10:39 pm
+                  - generic [ref=f34e138]: —
+                  - generic [ref=f34e139]: said hi
+            - generic [ref=f34e140]:
+              - generic [ref=f34e141]:
+                - heading "Customer link" [level=2] [ref=f34e142]
+                - generic [ref=f34e143]:
+                  - generic [ref=f34e144]:
+                    - generic [ref=f34e145]: Status
+                    - generic [ref=f34e146]: Linked
+                  - generic [ref=f34e147]:
+                    - generic [ref=f34e148]: Customer
+                    - link "0FDF11CF" [ref=f34e150] [cursor=pointer]:
+                      - /url: /admin/servicing/0FDF11CF
+                  - generic [ref=f34e151]:
+                    - generic [ref=f34e152]: Basis
+                    - generic [ref=f34e153]: manual
+                  - generic [ref=f34e154]:
+                    - generic [ref=f34e155]: Linked
+                    - generic [ref=f34e156]: 7 July 2026, 11:03 pm
+                  - generic [ref=f34e157]:
+                    - button "Change…" [ref=f34e158] [cursor=pointer]
+                    - button "Unlink" [ref=f34e159] [cursor=pointer]
+              - generic [ref=f34e160]:
+                - heading "Same person" [level=2] [ref=f34e161]
+                - generic [ref=f34e163]: —
+              - generic [ref=f34e164]:
+                - heading "Review" [level=2] [ref=f34e165]
+                - generic [ref=f34e166]:
+                  - generic [ref=f34e167]:
+                    - generic [ref=f34e168]: Status
+                    - generic [ref=f34e169]: —
+                  - generic [ref=f34e170]:
+                    - generic [ref=f34e171]: Reason
+                    - generic [ref=f34e172]: —
+                  - generic [ref=f34e173]:
+                    - button "Flag for review…" [ref=f34e174] [cursor=pointer]
+                    - button "Clear flag" [disabled] [ref=f34e175]
+              - generic [ref=f34e176]:
+                - heading "Consent history" [level=2] [ref=f34e177]
+                - generic [ref=f34e178]:
+                  - generic [ref=f34e179]:
+                    - generic [ref=f34e180]: contact.consent.granted.v1
+                    - generic [ref=f34e181]: 8 July 2026, 9:37 am
+                  - button "Record consent…" [ref=f34e183] [cursor=pointer]
+              - generic [ref=f34e184]:
+                - heading "Referrals" [level=2] [ref=f34e185]
+                - generic [ref=f34e186]:
+                  - generic [ref=f34e187]:
+                    - generic [ref=f34e188]: Referral code
+                    - generic [ref=f34e189]: 23CTBW
+                  - generic [ref=f34e190]:
+                    - generic [ref=f34e191]: Referred by
+                    - generic [ref=f34e192]: —
+                  - generic [ref=f34e193]:
+                    - generic [ref=f34e194]: Referred
+                    - generic [ref=f34e195]: "0"
+              - generic [ref=f34e196]:
+                - heading "Feedback (2)" [level=2] [ref=f34e197]
+                - generic [ref=f34e198]:
+                  - generic [ref=f34e199]:
+                    - generic [ref=f34e200]: "feature: Would love a dark mode in the app — fresh item posted by Claude at 22:36"
+                    - generic [ref=f34e201]: resolved
+                  - generic [ref=f34e202]:
+                    - generic [ref=f34e203]: "praise: Feedback retest after platform fix — 7 Jul"
+                    - generic [ref=f34e204]: resolved
+              - generic [ref=f34e205]:
+                - heading "Loan status" [level=2] [ref=f34e206]
+                - generic [ref=f34e209]: —
+              - generic [ref=f34e210]:
+                - heading "Data & privacy" [level=2] [ref=f34e211]
+                - generic [ref=f34e212]:
+                  - generic [ref=f34e213]:
+                    - generic [ref=f34e214]: Status
+                    - generic [ref=f34e215]: —
+                  - generic [ref=f34e216]:
+                    - button "Download export" [ref=f34e217] [cursor=pointer]
+                    - button "Erase contact…" [disabled] [ref=f34e218]
+              - generic [ref=f34e219]:
+                - heading "Audit (last 10)" [level=2] [ref=f34e220]
+                - generic [ref=f34e221]:
+                  - generic [ref=f34e222]:
+                    - generic [ref=f34e223]: contact.observed.v1
+                    - generic [ref=f34e224]: intake · 8 July 2026, 10:54 pm
+                  - generic [ref=f34e225]:
+                    - generic [ref=f34e226]: contact.observed.v1
+                    - generic [ref=f34e227]: intake · 8 July 2026, 10:46 pm
+                  - generic [ref=f34e228]:
+                    - generic [ref=f34e229]: contact.interaction.logged.v1
+                    - generic [ref=f34e230]: system · 8 July 2026, 9:18 pm
+                  - generic [ref=f34e231]:
+                    - generic [ref=f34e232]: contact.batch.assigned.v1
+                    - generic [ref=f34e233]: 95979e54-7f2e-4578-a9d0-807c8951d684 · 8 July 2026, 9:18 pm
+                  - generic [ref=f34e234]:
+                    - generic [ref=f34e235]: contact.interaction.logged.v1
+                    - generic [ref=f34e236]: system · 8 July 2026, 9:18 pm
+                  - generic [ref=f34e237]:
+                    - generic [ref=f34e238]: contact.observed.v1
+                    - generic [ref=f34e239]: 95979e54-7f2e-4578-a9d0-807c8951d684 · 8 July 2026, 9:18 pm
+                  - generic [ref=f34e240]:
+                    - generic [ref=f34e241]: contact.interaction.logged.v1
+                    - generic [ref=f34e242]: system · 8 July 2026, 8:18 pm
+                  - generic [ref=f34e243]:
+                    - generic [ref=f34e244]: contact.batch.assigned.v1
+                    - generic [ref=f34e245]: 95979e54-7f2e-4578-a9d0-807c8951d684 · 8 July 2026, 5:15 pm
+                  - generic [ref=f34e246]:
+                    - generic [ref=f34e247]: contact.consent.granted.v1
+                    - generic [ref=f34e248]: 95979e54-7f2e-4578-a9d0-807c8951d684 · 8 July 2026, 9:37 am
+                  - generic [ref=f34e249]:
+                    - generic [ref=f34e250]: contact.interaction.logged.v1
+                    - generic [ref=f34e251]: system · 7 July 2026, 11:04 pm
+  - region "Notifications alt+T"
+  - status [ref=f34e76]
+  - region "Notifications alt+T"
+  - alert [ref=f34e77]

--- a/event-processor/src/billie_servicing/config.py
+++ b/event-processor/src/billie_servicing/config.py
@@ -36,6 +36,16 @@ class Settings(BaseSettings):
     max_utterances: int = 2000  # Cap utterances array per conversation
     max_noticeboard_entries: int = 500  # Cap noticeboard array per conversation
 
+    # help@ mailbox connector (Decision J) — polls an IMAP inbox and logs
+    # each email as an inbound interaction on the matching contact's
+    # timeline. Enabled only when a host is configured.
+    help_mailbox_imap_host: str = ""
+    help_mailbox_imap_port: int = 993
+    help_mailbox_user: str = ""
+    help_mailbox_password: str = ""
+    help_mailbox_folder: str = "INBOX"
+    help_mailbox_poll_seconds: int = 300
+
     # Logging
     log_level: str = "INFO"
 

--- a/event-processor/src/billie_servicing/handlers/marketing.py
+++ b/event-processor/src/billie_servicing/handlers/marketing.py
@@ -108,6 +108,9 @@ async def handle_contact_updated(pool: asyncpg.Pool, event: Any) -> None:
     if attributes_patch and "needs_review" in attributes_patch:
         # Mirror to the dedicated column so the grid can filter on it.
         changed["needs_review"] = bool(attributes_patch.get("needs_review"))
+    if attributes_patch and "advisory_council" in attributes_patch:
+        # Advisory-council membership mirrors to panel_member (same pattern).
+        changed["panel_member"] = bool(attributes_patch.get("advisory_council"))
 
     values = {"contact_id": p.contact_id, **changed, "updated_at": _now()}
     await upsert(

--- a/event-processor/src/billie_servicing/help_mailbox.py
+++ b/event-processor/src/billie_servicing/help_mailbox.py
@@ -1,0 +1,203 @@
+"""help@ mailbox connector (Decision J).
+
+Polls an IMAP inbox and logs each email as an inbound ``message_in``
+interaction on the matching contact's timeline, via the same
+MarketingService.LogInteraction command every other channel uses. Contacts
+are resolved by sender email (non-erased, non-merged). Unmatched senders are
+skipped (marked seen) — help@ receives plenty of mail from non-contacts, and
+inventing contacts from inbound email is deliberately out of scope.
+
+Idempotent: the LogInteraction idempotency key derives from the Message-ID
+(or a content hash when absent), so a crash between processing and marking
+seen cannot double-log an email.
+
+Enabled only when ``HELP_MAILBOX_IMAP_HOST`` is configured; see config.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import email
+import email.utils
+import hashlib
+import imaplib
+import json
+from dataclasses import dataclass
+from datetime import timezone
+
+import asyncpg
+import structlog
+
+from . import marketing_client
+from .config import settings
+
+logger = structlog.get_logger(__name__)
+
+BODY_MAX_CHARS = 4000
+
+
+@dataclass
+class ParsedEmail:
+    from_addr: str
+    subject: str
+    body: str
+    message_id: str
+    occurred_at: str  # ISO-8601 UTC, or "" when the Date header is absent
+
+
+def parse_help_email(raw: bytes) -> ParsedEmail | None:
+    """Parse a raw RFC-822 message into the fields we log. Returns None when
+    there is no usable sender address."""
+    msg = email.message_from_bytes(raw)
+
+    _, from_addr = email.utils.parseaddr(msg.get("From", ""))
+    if not from_addr or "@" not in from_addr:
+        return None
+
+    subject = str(msg.get("Subject", "") or "").strip()
+
+    body = ""
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain" and not part.get_filename():
+                payload = part.get_payload(decode=True)
+                if payload:
+                    charset = part.get_content_charset() or "utf-8"
+                    body = payload.decode(charset, errors="replace")
+                    break
+    else:
+        payload = msg.get_payload(decode=True)
+        if payload:
+            charset = msg.get_content_charset() or "utf-8"
+            body = payload.decode(charset, errors="replace")
+    body = body.strip()[:BODY_MAX_CHARS]
+
+    message_id = str(msg.get("Message-ID", "") or "").strip()
+    if not message_id:
+        message_id = hashlib.sha256(raw).hexdigest()[:32]
+
+    occurred_at = ""
+    date_hdr = msg.get("Date")
+    if date_hdr:
+        try:
+            dt = email.utils.parsedate_to_datetime(date_hdr)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            occurred_at = dt.astimezone(timezone.utc).isoformat()
+        except (TypeError, ValueError):
+            pass
+
+    return ParsedEmail(
+        from_addr=from_addr.lower(),
+        subject=subject,
+        body=body,
+        message_id=message_id,
+        occurred_at=occurred_at,
+    )
+
+
+async def process_help_email(pool: asyncpg.Pool, raw: bytes) -> str:
+    """Log one raw email against its contact. Returns a status string:
+    ``logged`` | ``no_contact`` | ``unparseable``."""
+    parsed = parse_help_email(raw)
+    if parsed is None:
+        return "unparseable"
+
+    contact_id = await pool.fetchval(
+        "SELECT contact_id FROM contacts"
+        " WHERE lower(email) = $1"
+        " AND erased IS NOT TRUE AND merged_into IS NULL"
+        " ORDER BY updated_at DESC LIMIT 1",
+        parsed.from_addr,
+    )
+    if contact_id is None:
+        logger.info("help_mailbox: no contact for sender; skipping")
+        return "no_contact"
+
+    idempotency_key = (
+        "helpmail:" + hashlib.sha256(parsed.message_id.encode()).hexdigest()[:24]
+    )
+    await marketing_client.log_interaction(
+        idempotency_key=idempotency_key,
+        contact_id=str(contact_id),
+        kind="message_in",
+        channel="email",
+        direction="inbound",
+        subject=parsed.subject,
+        body=parsed.body,
+        source_system="help_mailbox",
+        occurred_at=parsed.occurred_at,
+        metadata_json=json.dumps({"mailbox": "help", "message_id": parsed.message_id}),
+        actor="help_mailbox",
+    )
+    logger.info("help_mailbox: interaction logged", contact_id=str(contact_id))
+    return "logged"
+
+
+def _fetch_unseen() -> list[tuple[bytes, bytes]]:
+    """Fetch (uid, raw_bytes) for every unseen message. Synchronous —
+    imaplib has no async API; callers run this in a thread."""
+    conn = imaplib.IMAP4_SSL(
+        settings.help_mailbox_imap_host, settings.help_mailbox_imap_port
+    )
+    try:
+        conn.login(settings.help_mailbox_user, settings.help_mailbox_password)
+        conn.select(settings.help_mailbox_folder)
+        _, data = conn.uid("search", None, "UNSEEN")
+        uids = data[0].split() if data and data[0] else []
+        out: list[tuple[bytes, bytes]] = []
+        for uid in uids:
+            _, msg_data = conn.uid("fetch", uid, "(RFC822)")
+            for part in msg_data or []:
+                if isinstance(part, tuple) and len(part) >= 2:
+                    out.append((uid, part[1]))
+                    break
+        return out
+    finally:
+        try:
+            conn.logout()
+        except Exception:  # noqa: BLE001 — best-effort teardown
+            pass
+
+
+def _mark_seen(uids: list[bytes]) -> None:
+    if not uids:
+        return
+    conn = imaplib.IMAP4_SSL(
+        settings.help_mailbox_imap_host, settings.help_mailbox_imap_port
+    )
+    try:
+        conn.login(settings.help_mailbox_user, settings.help_mailbox_password)
+        conn.select(settings.help_mailbox_folder)
+        for uid in uids:
+            conn.uid("store", uid, "+FLAGS", "(\\Seen)")
+    finally:
+        try:
+            conn.logout()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+async def run_help_mailbox_loop(pool: asyncpg.Pool) -> None:
+    """Poll the help@ mailbox forever. One IMAP round per interval; every
+    processed message (logged, unmatched or unparseable) is marked seen —
+    idempotency keys make crash-window replays harmless."""
+    logger.info(
+        "help_mailbox: polling enabled",
+        host=settings.help_mailbox_imap_host,
+        interval=settings.help_mailbox_poll_seconds,
+    )
+    while True:
+        try:
+            messages = await asyncio.to_thread(_fetch_unseen)
+            processed: list[bytes] = []
+            for uid, raw in messages:
+                try:
+                    await process_help_email(pool, raw)
+                    processed.append(uid)
+                except Exception:  # noqa: BLE001 — skip poisoned message, keep loop alive
+                    logger.exception("help_mailbox: failed to process message")
+            await asyncio.to_thread(_mark_seen, processed)
+        except Exception:  # noqa: BLE001 — IMAP outages must not kill the loop
+            logger.exception("help_mailbox: poll failed")
+        await asyncio.sleep(settings.help_mailbox_poll_seconds)

--- a/event-processor/src/billie_servicing/main.py
+++ b/event-processor/src/billie_servicing/main.py
@@ -342,6 +342,19 @@ async def run() -> None:
     # Start processor in background
     processor_task = asyncio.create_task(processor.start())
 
+    # help@ mailbox connector — optional, enabled by HELP_MAILBOX_IMAP_HOST.
+    # Uses the processor's pg pool once it exists (poll interval >> startup).
+    mailbox_task: asyncio.Task | None = None
+    if settings.help_mailbox_imap_host:
+        from .help_mailbox import run_help_mailbox_loop
+
+        async def _mailbox_when_ready() -> None:
+            while processor.pool is None:
+                await asyncio.sleep(1)
+            await run_help_mailbox_loop(processor.pool)
+
+        mailbox_task = asyncio.create_task(_mailbox_when_ready())
+
     # Wait for shutdown signal
     await shutdown_event.wait()
 
@@ -355,6 +368,13 @@ async def run() -> None:
         await processor_task
     except asyncio.CancelledError:
         pass
+
+    if mailbox_task is not None:
+        mailbox_task.cancel()
+        try:
+            await mailbox_task
+        except asyncio.CancelledError:
+            pass
 
     logger.info("Processor shutdown complete")
 

--- a/event-processor/tests/test_help_mailbox.py
+++ b/event-processor/tests/test_help_mailbox.py
@@ -1,0 +1,85 @@
+"""help@ mailbox connector: parsing + contact resolution + interaction logging."""
+
+from unittest.mock import AsyncMock, patch
+
+from billie_servicing.help_mailbox import parse_help_email, process_help_email
+
+
+def _raw(
+    from_hdr="Rohan Sharp <Rohan@Billie.LOANS>",
+    subject="Trouble with my repayment",
+    body="Hi team,\r\nSomething went wrong.\r\n",
+    message_id="<abc123@mail.example>",
+    date="Tue, 14 Jul 2026 10:00:00 +1000",
+):
+    headers = [f"From: {from_hdr}", f"Subject: {subject}"]
+    if message_id:
+        headers.append(f"Message-ID: {message_id}")
+    if date:
+        headers.append(f"Date: {date}")
+    headers.append('Content-Type: text/plain; charset="utf-8"')
+    return ("\r\n".join(headers) + "\r\n\r\n" + body).encode()
+
+
+class FakePool:
+    def __init__(self, contact_id):
+        self._contact_id = contact_id
+        self.queries = []
+
+    async def fetchval(self, sql, *args):
+        self.queries.append((sql, args))
+        return self._contact_id
+
+
+def test_parse_extracts_normalised_sender_subject_body_and_utc_date():
+    parsed = parse_help_email(_raw())
+    assert parsed.from_addr == "rohan@billie.loans"  # lowercased
+    assert parsed.subject == "Trouble with my repayment"
+    assert parsed.body.startswith("Hi team,")
+    assert parsed.message_id == "<abc123@mail.example>"
+    assert parsed.occurred_at == "2026-07-14T00:00:00+00:00"  # AEST -> UTC
+
+
+def test_parse_without_message_id_or_date_still_yields_stable_key():
+    raw = _raw(message_id=None, date=None)
+    a, b = parse_help_email(raw), parse_help_email(raw)
+    assert a.message_id and a.message_id == b.message_id  # content hash, stable
+    assert a.occurred_at == ""
+
+
+def test_parse_rejects_missing_sender():
+    assert parse_help_email(b"Subject: no sender\r\n\r\nhello") is None
+
+
+async def test_process_logs_inbound_interaction_for_matching_contact():
+    pool = FakePool("c-1")
+    with patch(
+        "billie_servicing.help_mailbox.marketing_client.log_interaction",
+        AsyncMock(return_value="ev-1"),
+    ) as log:
+        status = await process_help_email(pool, _raw())
+
+    assert status == "logged"
+    # Resolution excludes erased and merged records
+    sql, args = pool.queries[0]
+    assert "erased IS NOT TRUE" in sql and "merged_into IS NULL" in sql
+    assert args == ("rohan@billie.loans",)
+
+    kwargs = log.call_args.kwargs
+    assert kwargs["contact_id"] == "c-1"
+    assert kwargs["kind"] == "message_in"
+    assert kwargs["channel"] == "email"
+    assert kwargs["direction"] == "inbound"
+    assert kwargs["source_system"] == "help_mailbox"
+    assert kwargs["idempotency_key"].startswith("helpmail:")
+
+
+async def test_process_skips_unknown_sender_without_logging():
+    pool = FakePool(None)
+    with patch(
+        "billie_servicing.help_mailbox.marketing_client.log_interaction",
+        AsyncMock(),
+    ) as log:
+        status = await process_help_email(pool, _raw())
+    assert status == "no_contact"
+    log.assert_not_awaited()

--- a/event-processor/tests/test_marketing_handlers.py
+++ b/event-processor/tests/test_marketing_handlers.py
@@ -72,6 +72,27 @@ async def test_interaction_logged_inserts_row():
     assert any("interactions" in s for s, _ in pool.executed)
 
 
+async def test_contact_updated_mirrors_advisory_council_to_panel_member(mock_pool):
+    # merge_jsonb issues a second contacts write after the upsert, so scan
+    # every contacts write for the mirrored column rather than taking the last.
+    def _panel_values():
+        return [
+            row["panel_member"]
+            for row in (mock_pool.inserts_into("contacts") + mock_pool.updates_to("contacts"))
+            if "panel_member" in row
+        ]
+
+    await handle_contact_updated(mock_pool, _parsed("contact.updated.v1", {
+        "contact_id": "c-1", "attributes": {"advisory_council": True},
+        "updated_at": "2026-07-14T00:00:00+00:00", "actor": "staff-1"}))
+    assert _panel_values()[-1] is True
+
+    await handle_contact_updated(mock_pool, _parsed("contact.updated.v1", {
+        "contact_id": "c-1", "attributes": {"advisory_council": False},
+        "updated_at": "2026-07-14T00:01:00+00:00", "actor": "staff-1"}))
+    assert _panel_values()[-1] is False
+
+
 async def test_interaction_direction_normalised_to_enum_values(mock_pool):
     # The platform's notification echo shipped direction="out" for a while;
     # the projection must map short forms onto the pg enum, and degrade

--- a/marketing-grid.yml
+++ b/marketing-grid.yml
@@ -1,0 +1,180 @@
+- generic [active] [ref=f33e1]:
+  - button "Refresh health status" [ref=f33e83] [cursor=pointer]: ↻
+  - generic [ref=f33e2]:
+    - button "Open Menu" [ref=f33e84] [cursor=pointer]:
+      - generic "Open" [ref=f33e85]:
+        - img [ref=f33e86]
+    - generic [ref=f33e9]:
+      - complementary [ref=f33e88]:
+        - navigation [ref=f33e90]:
+          - button "Open search (⌘K)" [ref=f33e91] [cursor=pointer]:
+            - generic [ref=f33e92]: 🔍
+            - generic [ref=f33e93]: Search
+            - generic [ref=f33e94]: ⌘K
+          - link "Dashboard" [ref=f33e95] [cursor=pointer]:
+            - /url: /admin/dashboard
+            - generic [ref=f33e96]: 🏠
+            - generic [ref=f33e97]: Dashboard
+          - link "Applications" [ref=f33e98] [cursor=pointer]:
+            - /url: /admin/applications
+            - generic [ref=f33e99]: 💬
+            - generic [ref=f33e100]: Applications
+          - link "Accounts" [ref=f33e101] [cursor=pointer]:
+            - /url: /admin/accounts
+            - generic [ref=f33e102]: 🗂
+            - generic [ref=f33e103]: Accounts
+          - link "Collections 13 overdue accounts" [ref=f33e104] [cursor=pointer]:
+            - /url: /admin/collections-queue
+            - generic [ref=f33e105]: 📋
+            - generic [ref=f33e106]: Collections
+            - generic "13 overdue accounts" [ref=f33e107]: "13"
+          - link "Approvals" [ref=f33e108] [cursor=pointer]:
+            - /url: /admin/approvals
+            - generic [ref=f33e109]: ✅
+            - generic [ref=f33e110]: Approvals
+          - link "📅 Period Close" [ref=f33e111] [cursor=pointer]:
+            - /url: /admin/period-close
+            - generic [ref=f33e112]: 📅
+            - generic [ref=f33e113]: Period Close
+          - link "⚙️ ECL Config" [ref=f33e114] [cursor=pointer]:
+            - /url: /admin/ecl-config
+            - generic [ref=f33e115]: ⚙️
+            - generic [ref=f33e116]: ECL Config
+          - link "📤 Export Center" [ref=f33e117] [cursor=pointer]:
+            - /url: /admin/exports
+            - generic [ref=f33e118]: 📤
+            - generic [ref=f33e119]: Export Center
+          - link "🔬 Investigation" [ref=f33e120] [cursor=pointer]:
+            - /url: /admin/investigation
+            - generic [ref=f33e121]: 🔬
+            - generic [ref=f33e122]: Investigation
+          - link "Marketing" [ref=f33e123] [cursor=pointer]:
+            - /url: /admin/marketing
+            - generic [ref=f33e124]: 📣
+            - generic [ref=f33e125]: Marketing
+          - link "Log out" [ref=f33e127] [cursor=pointer]:
+            - /url: /api/auth/logout
+            - img [ref=f33e128]
+      - generic [ref=f33e10]:
+        - banner [ref=f33e11]:
+          - generic [ref=f33e14]:
+            - generic "Dashboard" [ref=f33e18]:
+              - img [ref=f33e19]
+            - link "Account" [ref=f33e22] [cursor=pointer]:
+              - /url: /admin/account
+              - img "yas" [ref=f33e23]
+        - generic [ref=f33e24]:
+          - generic [ref=f33e25]:
+            - heading "Marketing" [level=1] [ref=f33e26]
+            - button "+ New contact" [ref=f33e27] [cursor=pointer]
+            - button "Export CSV" [ref=f33e28] [cursor=pointer]
+            - link "Feedback queue →" [ref=f33e29] [cursor=pointer]:
+              - /url: /admin/marketing/feedback
+          - generic [ref=f33e30]:
+            - textbox "Search contacts" [ref=f33e31]:
+              - /placeholder: Search name, email, mobile
+            - generic [ref=f33e32]:
+              - generic [ref=f33e33]: Stage
+              - combobox "Stage" [ref=f33e34]:
+                - option "All stages" [selected]
+                - option "Lead"
+                - option "Waitlist"
+                - option "Invited"
+                - option "Applicant"
+                - option "Customer"
+                - option "Former customer"
+            - generic [ref=f33e35]:
+              - generic [ref=f33e36]: Source
+              - combobox "Source" [ref=f33e37]:
+                - option "All sources" [selected]
+                - option "Meta"
+                - option "Google"
+                - option "Campus"
+                - option "Referral"
+                - option "Social DM"
+                - option "AI search"
+                - option "Organic"
+                - option "Other"
+            - generic [ref=f33e38]:
+              - generic [ref=f33e39]: City
+              - combobox "City" [ref=f33e40]:
+                - option "All cities" [selected]
+                - option "Sydney"
+                - option "Melbourne"
+                - option "Brisbane"
+                - option "Perth"
+                - option "Adelaide"
+                - option "Canberra"
+            - generic [ref=f33e41]:
+              - generic [ref=f33e42]: Batch
+              - combobox "Batch" [ref=f33e43]:
+                - option "All batches" [selected]
+                - option "Waitlist batch 1"
+                - option "QA Test Batch (7 Jul)"
+            - generic [ref=f33e44]:
+              - generic [ref=f33e45]: Loan outcome
+              - combobox "Loan outcome" [ref=f33e46]:
+                - option "Any outcome" [selected]
+                - option "Repaid (win-back safe)"
+                - option "Disbursed (active)"
+                - option "Approved"
+            - generic [ref=f33e47]:
+              - generic [ref=f33e48]: Review
+              - combobox "Review" [ref=f33e49]:
+                - option "All contacts" [selected]
+                - option "⚑ Needs review"
+          - generic [ref=f33e50]:
+            - generic [ref=f33e51]: 0 selected
+            - generic [ref=f33e52]:
+              - generic [ref=f33e53]: Assign to batch
+              - combobox "Assign to batch" [disabled] [ref=f33e54]:
+                - option "Choose a batch…" [selected]
+                - option "Waitlist batch 1 (0) · sent 08/07/2026"
+                - option "QA Test Batch (7 Jul) (1) · sent 08/07/2026"
+                - option "＋ New batch…"
+            - button "Assign" [disabled] [ref=f33e55]
+            - generic [ref=f33e56]:
+              - generic [ref=f33e57]: Send invitations to
+              - combobox "Send invitations to" [ref=f33e58]:
+                - option "Choose a batch…" [selected]
+                - option "Waitlist batch 1 (0) · sent 08/07/2026"
+                - option "QA Test Batch (7 Jul) (1) · sent 08/07/2026"
+            - button "Send invitations" [disabled] [ref=f33e59]
+          - generic [ref=f33e60]:
+            - table [ref=f33e61]:
+              - rowgroup [ref=f33e62]:
+                - row "Select all on page Name Mobile Stage Source Batch Flags Consent Updated" [ref=f33e63]:
+                  - columnheader "Select all on page" [ref=f33e64]:
+                    - checkbox "Select all on page" [ref=f33e65]
+                  - columnheader "Name" [ref=f33e66]
+                  - columnheader "Mobile" [ref=f33e67]
+                  - columnheader "Stage" [ref=f33e68]
+                  - columnheader "Source" [ref=f33e69]
+                  - columnheader "Batch" [ref=f33e70]
+                  - columnheader "Flags" [ref=f33e71]
+                  - columnheader "Consent" [ref=f33e72]
+                  - columnheader "Updated" [ref=f33e73]
+              - rowgroup [ref=f33e74]:
+                - row "Select Rohan (old number) Rohan (old number) +61400111222 — Organic QA Test Batch (7 Jul) — Granted 8/7/26, 10:46 pm" [ref=f33e132] [cursor=pointer]:
+                  - cell "Select Rohan (old number)" [ref=f33e133]:
+                    - checkbox "Select Rohan (old number)" [ref=f33e134]
+                  - cell "Rohan (old number)" [ref=f33e135]:
+                    - link "Rohan (old number)" [ref=f33e136]:
+                      - /url: /admin/marketing/contacts/a79ae28f-2e9d-4650-b466-b5a00e5abfc5
+                  - cell "+61400111222" [ref=f33e137]
+                  - cell "—" [ref=f33e138]
+                  - cell "Organic" [ref=f33e139]
+                  - cell "QA Test Batch (7 Jul)" [ref=f33e140]:
+                    - button "QA Test Batch (7 Jul)" [ref=f33e141]
+                  - cell "—" [ref=f33e142]
+                  - cell "Granted" [ref=f33e143]:
+                    - generic [ref=f33e144]: Granted
+                  - cell "8/7/26, 10:46 pm" [ref=f33e145]
+            - generic [ref=f33e77]:
+              - button "← Previous" [disabled] [ref=f33e78]
+              - generic [ref=f33e79]: Page 1 of 1 · 1 contacts
+              - button "Next →" [disabled] [ref=f33e80]
+  - region "Notifications alt+T"
+  - status [ref=f33e146]
+  - region "Notifications alt+T"
+  - alert [ref=f33e147]

--- a/src/app/api/marketing/contacts/route.ts
+++ b/src/app/api/marketing/contacts/route.ts
@@ -32,6 +32,7 @@ export async function GET(request: NextRequest) {
   if (sp.get('city')) where.city = { like: sp.get('city') }
   if (sp.get('batch')) where.batchId = { equals: sp.get('batch') }
   if (sp.get('needs_review') === 'true') where.needsReview = { equals: true }
+  if (sp.get('advisory_council') === 'true') where.panelMember = { equals: true }
   // Win-back safety: former_customer alone mixes repaid (C-P) and written-off
   // (C-N) people — loan_status distinguishes them ("repaid" only for C-P).
   if (sp.get('loan_status')) where.loanStatus = { equals: sp.get('loan_status') }

--- a/src/collections/Contacts.ts
+++ b/src/collections/Contacts.ts
@@ -35,6 +35,7 @@ export const Contacts: CollectionConfig = {
         'referral',
         'social_dm',
         'ai_search',
+        'word_of_mouth',
         'organic',
         'other',
       ],

--- a/src/components/MarketingView/ContactDetail.tsx
+++ b/src/components/MarketingView/ContactDetail.tsx
@@ -13,7 +13,11 @@ import { useContactIdentity, type IdentitySibling } from '@/hooks/queries/useCon
 import { useContactReferrals } from '@/hooks/queries/useContactReferrals'
 import { useFeedbackQueue } from '@/hooks/queries/useFeedbackQueue'
 import { useAuth } from '@payloadcms/ui'
-import { useSetReviewFlag, useUnlinkContact } from '@/hooks/mutations/useMarketingCommands'
+import {
+  useSetAdvisoryCouncil,
+  useSetReviewFlag,
+  useUnlinkContact,
+} from '@/hooks/mutations/useMarketingCommands'
 import { isAdmin } from '@/lib/access'
 import { LinkCustomerModal } from './LinkCustomerModal'
 import { RecordConsentModal } from './RecordConsentModal'
@@ -159,6 +163,7 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
   const userIsAdmin = isAdmin(user)
   const unlink = useUnlinkContact()
   const reviewFlag = useSetReviewFlag()
+  const advisory = useSetAdvisoryCouncil()
 
   const logNoteMutation = useMutation({
     mutationFn: logNote,
@@ -442,6 +447,33 @@ export const ContactDetail: React.FC<ContactDetailProps> = ({ contactId }) => {
                 disabled={!contact.needsReview || reviewFlag.isPending}
               >
                 {reviewFlag.isPending ? 'Saving…' : 'Clear flag'}
+              </button>
+            </div>
+          </Panel>
+
+          {/* Advisory council (panel_member) — first-batch feedback panel.
+              Fixed layout: status row + one toggle button. */}
+          <Panel title="Advisory council">
+            <div className={styles.panelRow}>
+              <span className={styles.panelRowLabel}>Status</span>
+              <span className={styles.panelRowValue}>
+                {contact.panelMember ? 'Member' : '—'}
+              </span>
+            </div>
+            <div className={styles.panelButtonRow}>
+              <button
+                type="button"
+                className={styles.pageButton}
+                onClick={() =>
+                  advisory.mutate({ contactId, member: !contact.panelMember })
+                }
+                disabled={advisory.isPending}
+              >
+                {advisory.isPending
+                  ? 'Saving…'
+                  : contact.panelMember
+                    ? 'Remove from council'
+                    : 'Add to council…'}
               </button>
             </div>
           </Panel>

--- a/src/components/MarketingView/MarketingView.tsx
+++ b/src/components/MarketingView/MarketingView.tsx
@@ -42,6 +42,7 @@ const SOURCE_OPTIONS: Array<{ value: Contact['source'] & string; label: string }
   { value: 'referral', label: 'Referral' },
   { value: 'social_dm', label: 'Social DM' },
   { value: 'ai_search', label: 'AI search' },
+  { value: 'word_of_mouth', label: 'Word of mouth' },
   { value: 'organic', label: 'Organic' },
   { value: 'other', label: 'Other' },
 ]
@@ -105,6 +106,7 @@ const MarketingContactsGrid: React.FC = () => {
   const [city, setCity] = useState('')
   const [batch, setBatch] = useState('')
   const [needsReview, setNeedsReview] = useState('')
+  const [advisoryCouncil, setAdvisoryCouncil] = useState('')
   const [loanStatus, setLoanStatus] = useState('')
   const [page, setPage] = useState(1)
   const [selected, setSelected] = useState<Set<string>>(new Set())
@@ -124,10 +126,11 @@ const MarketingContactsGrid: React.FC = () => {
       city: city || undefined,
       batch: batch || undefined,
       needs_review: needsReview || undefined,
+      advisory_council: advisoryCouncil || undefined,
       loan_status: loanStatus || undefined,
       page,
     }),
-    [deferredQ, stage, source, city, batch, needsReview, loanStatus, page],
+    [deferredQ, stage, source, city, batch, needsReview, advisoryCouncil, loanStatus, page],
   )
 
   const { data, isLoading, isError, isFetching } = useMarketingContacts(filters)
@@ -265,6 +268,7 @@ const MarketingContactsGrid: React.FC = () => {
             if (city) params.set('city', city)
             if (batch) params.set('batch', batch)
             if (needsReview) params.set('needs_review', needsReview)
+            if (advisoryCouncil) params.set('advisory_council', advisoryCouncil)
             if (loanStatus) params.set('loan_status', loanStatus)
             window.open(`/api/marketing/contacts/export?${params.toString()}`, '_blank')
           }}
@@ -392,6 +396,21 @@ const MarketingContactsGrid: React.FC = () => {
           >
             <option value="">All contacts</option>
             <option value="true">⚑ Needs review</option>
+          </select>
+        </div>
+
+        <div className={styles.filterGroup}>
+          <label className={styles.filterLabel} htmlFor="marketing-advisory-filter">
+            Advisory council
+          </label>
+          <select
+            id="marketing-advisory-filter"
+            className={styles.filterSelect}
+            value={advisoryCouncil}
+            onChange={onFilter(setAdvisoryCouncil)}
+          >
+            <option value="">All contacts</option>
+            <option value="true">Members only</option>
           </select>
         </div>
       </div>

--- a/src/components/MarketingView/NewContactModal.tsx
+++ b/src/components/MarketingView/NewContactModal.tsx
@@ -23,6 +23,7 @@ const SOURCE_OPTIONS = [
   { value: 'referral', label: 'Referral' },
   { value: 'social_dm', label: 'Social DM' },
   { value: 'ai_search', label: 'AI search' },
+  { value: 'word_of_mouth', label: 'Word of mouth' },
   { value: 'organic', label: 'Organic' },
   { value: 'other', label: 'Other' },
 ]

--- a/src/hooks/mutations/useMarketingCommands.ts
+++ b/src/hooks/mutations/useMarketingCommands.ts
@@ -238,6 +238,38 @@ export function useRecordConsent() {
   })
 }
 
+export interface SetAdvisoryCouncilVars {
+  contactId: string
+  member: boolean
+}
+
+/** Advisory-council membership — rides UpdateContact's attributes delta;
+ * the projections mirror attributes.advisory_council onto panel_member. */
+export function useSetAdvisoryCouncil() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: SetAdvisoryCouncilVars) =>
+      fetch(`/api/marketing/contacts/${encodeURIComponent(vars.contactId)}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ attributes: { advisory_council: vars.member } }),
+      }).then(async (res) => {
+        if (!res.ok) {
+          const err = await res.json().catch(() => null)
+          throw new Error(err?.error?.message ?? `Command failed: ${res.status}`)
+        }
+        return res.json()
+      }),
+    onSuccess: (_res, vars) => {
+      toast.success(vars.member ? 'Added to Advisory council' : 'Removed from Advisory council')
+      invalidateWithLag(qc, [['marketing-contacts']])
+    },
+    onError: (e: Error) =>
+      toast.error('Failed to update Advisory council', { description: e.message }),
+  })
+}
+
 export interface MergeContactVars {
   survivorContactId: string
   mergedContactId: string

--- a/src/hooks/queries/useMarketingContacts.ts
+++ b/src/hooks/queries/useMarketingContacts.ts
@@ -10,6 +10,7 @@ export interface MarketingContactsFilters {
   city?: string
   batch?: string
   needs_review?: string
+  advisory_council?: string
   loan_status?: string
   page?: number
 }
@@ -32,6 +33,7 @@ function buildQueryString(filters: MarketingContactsFilters): string {
   if (filters.city) params.set('city', filters.city)
   if (filters.batch) params.set('batch', filters.batch)
   if (filters.needs_review) params.set('needs_review', filters.needs_review)
+  if (filters.advisory_council) params.set('advisory_council', filters.advisory_council)
   if (filters.loan_status) params.set('loan_status', filters.loan_status)
   if (filters.page) params.set('page', String(filters.page))
   const qs = params.toString()

--- a/src/lib/schemas/intake.ts
+++ b/src/lib/schemas/intake.ts
@@ -15,7 +15,7 @@ export const WaitlistIntakeSchema = z
     city: z.string().max(100).optional(),
     postcode: z.string().max(10).optional(),
     source: z
-      .enum(['meta', 'google', 'campus', 'referral', 'social_dm', 'ai_search', 'organic', 'other'])
+      .enum(['meta', 'google', 'campus', 'referral', 'social_dm', 'ai_search', 'word_of_mouth', 'organic', 'other'])
       .default('other'),
     utm: z.record(z.string(), z.string()).optional(),
     platforms: z.array(z.string()).optional(),

--- a/src/lib/schemas/marketing.ts
+++ b/src/lib/schemas/marketing.ts
@@ -32,7 +32,7 @@ export const CreateContactSchema = z
   .object({
     ...assertedContactFields,
     source: z
-      .enum(['meta', 'google', 'campus', 'referral', 'social_dm', 'ai_search', 'organic', 'other'])
+      .enum(['meta', 'google', 'campus', 'referral', 'social_dm', 'ai_search', 'word_of_mouth', 'organic', 'other'])
       .default('other'),
   })
   .refine((d) => !!d.mobile || !!d.email, { message: 'mobile or email is required' })

--- a/src/migrations/20260714_053341_word_of_mouth_source.json
+++ b/src/migrations/20260714_053341_word_of_mouth_source.json
@@ -1,0 +1,7805 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users_sessions": {
+      "name": "users_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "users_sessions_order_idx": {
+          "name": "users_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_sessions_parent_id_idx": {
+          "name": "users_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_sessions_parent_id_fk": {
+          "name": "users_sessions_parent_id_fk",
+          "tableFrom": "users_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_users_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'readonly'"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_id": {
+          "name": "avatar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "enable_a_p_i_key": {
+          "name": "enable_a_p_i_key",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_index": {
+          "name": "api_key_index",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_avatar_idx": {
+          "name": "users_avatar_idx",
+          "columns": [
+            {
+              "expression": "avatar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_avatar_id_media_id_fk": {
+          "name": "users_avatar_id_media_id_fk",
+          "tableFrom": "users",
+          "tableTo": "media",
+          "columnsFrom": [
+            "avatar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "media_updated_at_idx": {
+          "name": "media_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_created_at_idx": {
+          "name": "media_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "media_filename_idx": {
+          "name": "media_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers_identity_documents": {
+      "name": "customers_identity_documents",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "enum_customers_identity_documents_document_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_subtype": {
+          "name": "document_subtype",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_number": {
+          "name": "document_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_of_issue": {
+          "name": "state_of_issue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_issue": {
+          "name": "country_of_issue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "additional_info": {
+          "name": "additional_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_identity_documents_order_idx": {
+          "name": "customers_identity_documents_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_identity_documents_parent_id_idx": {
+          "name": "customers_identity_documents_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_identity_documents_parent_id_fk": {
+          "name": "customers_identity_documents_parent_id_fk",
+          "tableFrom": "customers_identity_documents",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_into": {
+          "name": "merged_into",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_name": {
+          "name": "preferred_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "middle_name": {
+          "name": "middle_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_phone_number": {
+          "name": "mobile_phone_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verified": {
+          "name": "identity_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_number": {
+          "name": "residential_address_street_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_name": {
+          "name": "residential_address_street_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street_type": {
+          "name": "residential_address_street_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_unit_number": {
+          "name": "residential_address_unit_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_street": {
+          "name": "residential_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_suburb": {
+          "name": "residential_address_suburb",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_city": {
+          "name": "residential_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_state": {
+          "name": "residential_address_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_postcode": {
+          "name": "residential_address_postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "residential_address_country": {
+          "name": "residential_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "residential_address_full_address": {
+          "name": "residential_address_full_address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_street": {
+          "name": "mailing_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_city": {
+          "name": "mailing_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_state": {
+          "name": "mailing_address_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_postcode": {
+          "name": "mailing_address_postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mailing_address_country": {
+          "name": "mailing_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Australia'"
+        },
+        "staff_flag": {
+          "name": "staff_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "investor_flag": {
+          "name": "investor_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founder_flag": {
+          "name": "founder_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vulnerable_flag": {
+          "name": "vulnerable_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ekyc_entity_id": {
+          "name": "ekyc_entity_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ekyc_status": {
+          "name": "ekyc_status",
+          "type": "enum_customers_ekyc_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "individual_status": {
+          "name": "individual_status",
+          "type": "enum_customers_individual_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_reason": {
+          "name": "reapplication_block_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_until": {
+          "name": "reapplication_block_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_at": {
+          "name": "reapplication_block_blocked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_application_number": {
+          "name": "reapplication_block_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_status": {
+          "name": "reapplication_block_clear_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_cleared_at": {
+          "name": "reapplication_block_cleared_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_overall_result": {
+          "name": "identity_verification_overall_result",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_provider": {
+          "name": "identity_verification_provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_provider_reference": {
+          "name": "identity_verification_provider_reference",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_lab_request_id": {
+          "name": "identity_verification_lab_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_checked_at": {
+          "name": "identity_verification_checked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_archived": {
+          "name": "identity_verification_report_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_archived_at": {
+          "name": "identity_verification_archived_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fraud_risk_severity": {
+          "name": "fraud_risk_severity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fraud_risk_score": {
+          "name": "fraud_risk_score",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fraud_risk_categories": {
+          "name": "fraud_risk_categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fraud_risk_flagged_at": {
+          "name": "fraud_risk_flagged_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fraud_risk_active": {
+          "name": "fraud_risk_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "customers_customer_id_idx": {
+          "name": "customers_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_merged_into_idx": {
+          "name": "customers_merged_into_idx",
+          "columns": [
+            {
+              "expression": "merged_into",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_updated_at_idx": {
+          "name": "customers_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_created_at_idx": {
+          "name": "customers_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers_rels": {
+      "name": "customers_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applications_id": {
+          "name": "applications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_accounts_id": {
+          "name": "loan_accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "customers_rels_order_idx": {
+          "name": "customers_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_parent_idx": {
+          "name": "customers_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_path_idx": {
+          "name": "customers_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_applications_id_idx": {
+          "name": "customers_rels_applications_id_idx",
+          "columns": [
+            {
+              "expression": "applications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_conversations_id_idx": {
+          "name": "customers_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "customers_rels_loan_accounts_id_idx": {
+          "name": "customers_rels_loan_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "loan_accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_rels_parent_fk": {
+          "name": "customers_rels_parent_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_applications_fk": {
+          "name": "customers_rels_applications_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "applications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_conversations_fk": {
+          "name": "customers_rels_conversations_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customers_rels_loan_accounts_fk": {
+          "name": "customers_rels_loan_accounts_fk",
+          "tableFrom": "customers_rels",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_utterances": {
+      "name": "conversations_utterances",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utterance": {
+          "name": "utterance",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_input_type": {
+          "name": "answer_input_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_seq": {
+          "name": "prev_seq",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_conversation": {
+          "name": "end_conversation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_utterances_order_idx": {
+          "name": "conversations_utterances_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_utterances_parent_id_idx": {
+          "name": "conversations_utterances_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_utterances_parent_id_fk": {
+          "name": "conversations_utterances_parent_id_fk",
+          "tableFrom": "conversations_utterances",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_facts": {
+      "name": "conversations_facts",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fact": {
+          "name": "fact",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_facts_order_idx": {
+          "name": "conversations_facts_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_facts_parent_id_idx": {
+          "name": "conversations_facts_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_facts_parent_id_fk": {
+          "name": "conversations_facts_parent_id_fk",
+          "tableFrom": "conversations_facts",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations_noticeboard": {
+      "name": "conversations_noticeboard",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "conversations_noticeboard_order_idx": {
+          "name": "conversations_noticeboard_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_noticeboard_parent_id_idx": {
+          "name": "conversations_noticeboard_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_noticeboard_parent_id_fk": {
+          "name": "conversations_noticeboard_parent_id_fk",
+          "tableFrom": "conversations_noticeboard",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_number": {
+          "name": "application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id_string": {
+          "name": "customer_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id_id": {
+          "name": "application_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_conversations_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "last_utterance_time": {
+          "name": "last_utterance_time",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_decision": {
+          "name": "final_decision",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_reason": {
+          "name": "decision_detail_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_retry_eligible": {
+          "name": "decision_detail_retry_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_source_application_number": {
+          "name": "decision_detail_source_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_detail_blocked_until": {
+          "name": "decision_detail_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_reason": {
+          "name": "reapplication_block_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_message_variant": {
+          "name": "reapplication_block_message_variant",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_stop_message": {
+          "name": "reapplication_block_stop_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_application_number": {
+          "name": "reapplication_block_source_application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_account_id": {
+          "name": "reapplication_block_source_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_source_decided_at": {
+          "name": "reapplication_block_source_decided_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_until": {
+          "name": "reapplication_block_blocked_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_blocked_at": {
+          "name": "reapplication_block_blocked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_canonical_customer_id": {
+          "name": "reapplication_block_canonical_customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_disposition_kind": {
+          "name": "reapplication_block_disposition_kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_manual_review_candidate": {
+          "name": "reapplication_block_manual_review_candidate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_recognition": {
+          "name": "reapplication_block_recognition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_status": {
+          "name": "reapplication_block_clear_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_cleared_at": {
+          "name": "reapplication_block_cleared_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_cleared_by": {
+          "name": "reapplication_block_cleared_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_justification": {
+          "name": "reapplication_block_clear_justification",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_request_id": {
+          "name": "reapplication_block_clear_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_lab_request_id": {
+          "name": "identity_verification_report_lab_request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_provider_reference": {
+          "name": "identity_verification_report_provider_reference",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_report_file_location": {
+          "name": "identity_verification_report_report_file_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_report_file_name": {
+          "name": "identity_verification_report_report_file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_raw_response_file_location": {
+          "name": "identity_verification_report_raw_response_file_location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_raw_response_file_name": {
+          "name": "identity_verification_report_raw_response_file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_verification_report_archived_at": {
+          "name": "identity_verification_report_archived_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_identity_risk": {
+          "name": "assessments_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_serviceability": {
+          "name": "assessments_serviceability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_fraud_check": {
+          "name": "assessments_fraud_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_account_conduct": {
+          "name": "assessments_account_conduct",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_post_identity_risk": {
+          "name": "assessments_post_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_credit_assessment_complete": {
+          "name": "assessments_credit_assessment_complete",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture": {
+          "name": "statement_capture",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_status": {
+          "name": "decision_status",
+          "type": "enum_conversations_decision_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_data": {
+          "name": "application_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversations_conversation_id_idx": {
+          "name": "conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_application_number_idx": {
+          "name": "conversations_application_number_idx",
+          "columns": [
+            {
+              "expression": "application_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_customer_id_idx": {
+          "name": "conversations_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_customer_id_string_idx": {
+          "name": "conversations_customer_id_string_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_application_id_idx": {
+          "name": "conversations_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_status_idx": {
+          "name": "conversations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_decision_status_idx": {
+          "name": "conversations_decision_status_idx",
+          "columns": [
+            {
+              "expression": "decision_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_created_at_idx": {
+          "name": "conversations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_monitor_grid_idx": {
+          "name": "conversations_monitor_grid_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_by_customer_idx": {
+          "name": "conversations_by_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_customer_id_id_customers_id_fk": {
+          "name": "conversations_customer_id_id_customers_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_application_id_id_applications_id_fk": {
+          "name": "conversations_application_id_id_applications_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_proc_state_steps": {
+      "name": "app_proc_state_steps",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "step_name": {
+          "name": "step_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_app_proc_state_steps_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'llm'"
+        },
+        "completion_event_name": {
+          "name": "completion_event_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer_input_type": {
+          "name": "answer_input_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_main": {
+          "name": "prompts_main",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_completeness_check": {
+          "name": "prompts_completeness_check",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_confirmation": {
+          "name": "prompts_confirmation",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_output_json": {
+          "name": "prompts_output_json",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompts_mapping_out": {
+          "name": "prompts_mapping_out",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_module_name": {
+          "name": "business_logic_module_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_method_name": {
+          "name": "business_logic_method_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_mapping_in": {
+          "name": "business_logic_mapping_in",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_logic_mapping_out": {
+          "name": "business_logic_mapping_out",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_proc_state_steps_order_idx": {
+          "name": "app_proc_state_steps_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_proc_state_steps_parent_id_idx": {
+          "name": "app_proc_state_steps_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_proc_state_steps_parent_id_fk": {
+          "name": "app_proc_state_steps_parent_id_fk",
+          "tableFrom": "app_proc_state_steps",
+          "tableTo": "app_proc_state",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_proc_state": {
+      "name": "app_proc_state",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stage_name": {
+          "name": "stage_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complete": {
+          "name": "complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_proc_state_order_idx": {
+          "name": "app_proc_state_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_proc_state_parent_id_idx": {
+          "name": "app_proc_state_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_proc_state_parent_id_fk": {
+          "name": "app_proc_state_parent_id_fk",
+          "tableFrom": "app_proc_state",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_application_process_conversation": {
+      "name": "applications_application_process_conversation",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "enum_applications_application_process_conversation_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_application_process_conversation_order_idx": {
+          "name": "applications_application_process_conversation_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_application_process_conversation_parent_id_idx": {
+          "name": "applications_application_process_conversation_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_application_process_conversation_parent_id_fk": {
+          "name": "applications_application_process_conversation_parent_id_fk",
+          "tableFrom": "applications_application_process_conversation",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_noticeboard_versions": {
+      "name": "applications_noticeboard_versions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_noticeboard_versions_order_idx": {
+          "name": "applications_noticeboard_versions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_noticeboard_versions_parent_id_idx": {
+          "name": "applications_noticeboard_versions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_noticeboard_versions_parent_id_fk": {
+          "name": "applications_noticeboard_versions_parent_id_fk",
+          "tableFrom": "applications_noticeboard_versions",
+          "tableTo": "applications_noticeboard",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_noticeboard": {
+      "name": "applications_noticeboard",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "applications_noticeboard_order_idx": {
+          "name": "applications_noticeboard_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_noticeboard_parent_id_idx": {
+          "name": "applications_noticeboard_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_noticeboard_parent_id_fk": {
+          "name": "applications_noticeboard_parent_id_fk",
+          "tableFrom": "applications_noticeboard",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_number": {
+          "name": "application_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_purpose": {
+          "name": "loan_purpose",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_amount": {
+          "name": "loan_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_fee": {
+          "name": "loan_fee",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_total_payable": {
+          "name": "loan_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_term": {
+          "name": "loan_term",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_attestation_acceptance": {
+          "name": "customer_attestation_acceptance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture_consent_provided": {
+          "name": "statement_capture_consent_provided",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_capture_completed": {
+          "name": "statement_capture_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_offer_acceptance": {
+          "name": "product_offer_acceptance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_outcome": {
+          "name": "application_outcome",
+          "type": "enum_applications_application_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_current_process_stage": {
+          "name": "application_process_current_process_stage",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_current_process_step": {
+          "name": "application_process_current_process_step",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_started_at": {
+          "name": "application_process_started_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_process_updated_at": {
+          "name": "application_process_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_identity_risk": {
+          "name": "assessments_identity_risk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_serviceability": {
+          "name": "assessments_serviceability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessments_fraud_check": {
+          "name": "assessments_fraud_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applications_application_number_idx": {
+          "name": "applications_application_number_idx",
+          "columns": [
+            {
+              "expression": "application_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_customer_id_idx": {
+          "name": "applications_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_application_outcome_idx": {
+          "name": "applications_application_outcome_idx",
+          "columns": [
+            {
+              "expression": "application_outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_updated_at_idx": {
+          "name": "applications_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_created_at_idx": {
+          "name": "applications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_customer_id_id_customers_id_fk": {
+          "name": "applications_customer_id_id_customers_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications_rels": {
+      "name": "applications_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "applications_rels_order_idx": {
+          "name": "applications_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_parent_idx": {
+          "name": "applications_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_path_idx": {
+          "name": "applications_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_rels_conversations_id_idx": {
+          "name": "applications_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_rels_parent_fk": {
+          "name": "applications_rels_parent_fk",
+          "tableFrom": "applications_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_rels_conversations_fk": {
+          "name": "applications_rels_conversations_fk",
+          "tableFrom": "applications_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_accounts_repayment_schedule_payments": {
+      "name": "loan_accounts_repayment_schedule_payments",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payment_number": {
+          "name": "payment_number",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_loan_accounts_repayment_schedule_payments_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'scheduled'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_remaining": {
+          "name": "amount_remaining",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_date": {
+          "name": "paid_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_transaction_ids": {
+          "name": "linked_transaction_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "loan_accounts_repayment_schedule_payments_order_idx": {
+          "name": "loan_accounts_repayment_schedule_payments_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_repayment_schedule_payments_parent_id_idx": {
+          "name": "loan_accounts_repayment_schedule_payments_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accts_repay_sched_payments_natural_key_idx": {
+          "name": "loan_accts_repay_sched_payments_natural_key_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_accounts_repayment_schedule_payments_parent_id_fk": {
+          "name": "loan_accounts_repayment_schedule_payments_parent_id_fk",
+          "tableFrom": "loan_accounts_repayment_schedule_payments",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loan_accounts": {
+      "name": "loan_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id_id": {
+          "name": "customer_id_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id_string": {
+          "name": "customer_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_loan_amount": {
+          "name": "loan_terms_loan_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_loan_fee": {
+          "name": "loan_terms_loan_fee",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_total_payable": {
+          "name": "loan_terms_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_opened_date": {
+          "name": "loan_terms_opened_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_terms_disbursed_date": {
+          "name": "loan_terms_disbursed_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_current_balance": {
+          "name": "balances_current_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_total_outstanding": {
+          "name": "balances_total_outstanding",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balances_total_paid": {
+          "name": "balances_total_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_payment_date": {
+          "name": "last_payment_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_payment_amount": {
+          "name": "last_payment_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_is_in_arrears": {
+          "name": "aging_is_in_arrears",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "aging_bucket": {
+          "name": "aging_bucket",
+          "type": "enum_loan_accounts_aging_bucket",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_current_d_p_d": {
+          "name": "aging_current_d_p_d",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aging_last_updated": {
+          "name": "aging_last_updated",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_status": {
+          "name": "account_status",
+          "type": "enum_loan_accounts_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "sdk_status": {
+          "name": "sdk_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commencement_date": {
+          "name": "commencement_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_loan_agreement_url": {
+          "name": "signed_loan_agreement_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_reason": {
+          "name": "closure_reason",
+          "type": "enum_loan_accounts_closure_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_previous_status": {
+          "name": "closure_previous_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_closed_date": {
+          "name": "closure_closed_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_final_balance": {
+          "name": "closure_final_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_total_paid": {
+          "name": "closure_total_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_loan_total_payable": {
+          "name": "closure_loan_total_payable",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closure_triggered_by_transaction_id": {
+          "name": "closure_triggered_by_transaction_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_schedule_id": {
+          "name": "repayment_schedule_schedule_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_number_of_payments": {
+          "name": "repayment_schedule_number_of_payments",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_payment_frequency": {
+          "name": "repayment_schedule_payment_frequency",
+          "type": "enum_loan_accounts_repayment_schedule_payment_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repayment_schedule_created_date": {
+          "name": "repayment_schedule_created_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "loan_accounts_loan_account_id_idx": {
+          "name": "loan_accounts_loan_account_id_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_account_number_idx": {
+          "name": "loan_accounts_account_number_idx",
+          "columns": [
+            {
+              "expression": "account_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_customer_id_idx": {
+          "name": "loan_accounts_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_customer_id_string_idx": {
+          "name": "loan_accounts_customer_id_string_idx",
+          "columns": [
+            {
+              "expression": "customer_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_loan_terms_loan_terms_disbursed_date_idx": {
+          "name": "loan_accounts_loan_terms_loan_terms_disbursed_date_idx",
+          "columns": [
+            {
+              "expression": "loan_terms_disbursed_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_aging_aging_is_in_arrears_idx": {
+          "name": "loan_accounts_aging_aging_is_in_arrears_idx",
+          "columns": [
+            {
+              "expression": "aging_is_in_arrears",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_aging_aging_bucket_idx": {
+          "name": "loan_accounts_aging_aging_bucket_idx",
+          "columns": [
+            {
+              "expression": "aging_bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_account_status_idx": {
+          "name": "loan_accounts_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_commencement_date_idx": {
+          "name": "loan_accounts_commencement_date_idx",
+          "columns": [
+            {
+              "expression": "commencement_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_updated_at_idx": {
+          "name": "loan_accounts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "loan_accounts_created_at_idx": {
+          "name": "loan_accounts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "loan_accounts_customer_id_id_customers_id_fk": {
+          "name": "loan_accounts_customer_id_id_customers_id_fk",
+          "tableFrom": "loan_accounts",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.write_off_requests_supporting_documents": {
+      "name": "write_off_requests_supporting_documents",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "write_off_requests_supporting_documents_order_idx": {
+          "name": "write_off_requests_supporting_documents_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_supporting_documents_parent_id_idx": {
+          "name": "write_off_requests_supporting_documents_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_supporting_documents_document_idx": {
+          "name": "write_off_requests_supporting_documents_document_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "write_off_requests_supporting_documents_document_id_media_id_fk": {
+          "name": "write_off_requests_supporting_documents_document_id_media_id_fk",
+          "tableFrom": "write_off_requests_supporting_documents",
+          "tableTo": "media",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "write_off_requests_supporting_documents_parent_id_fk": {
+          "name": "write_off_requests_supporting_documents_parent_id_fk",
+          "tableFrom": "write_off_requests_supporting_documents",
+          "tableTo": "write_off_requests",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.write_off_requests": {
+      "name": "write_off_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_number": {
+          "name": "request_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_balance": {
+          "name": "original_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "enum_write_off_requests_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_write_off_requests_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum_write_off_requests_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "requires_senior_approval": {
+          "name": "requires_senior_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_by_id": {
+          "name": "approval_details_decided_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_by_name": {
+          "name": "approval_details_decided_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_decided_at": {
+          "name": "approval_details_decided_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_comment": {
+          "name": "approval_details_comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by": {
+          "name": "approval_details_approved_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by_name": {
+          "name": "approval_details_approved_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_at": {
+          "name": "approval_details_approved_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by": {
+          "name": "approval_details_rejected_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by_name": {
+          "name": "approval_details_rejected_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_at": {
+          "name": "approval_details_rejected_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_reason": {
+          "name": "approval_details_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by": {
+          "name": "cancellation_details_cancelled_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by_name": {
+          "name": "cancellation_details_cancelled_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_at": {
+          "name": "cancellation_details_cancelled_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "write_off_requests_request_id_idx": {
+          "name": "write_off_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_event_id_idx": {
+          "name": "write_off_requests_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_request_number_idx": {
+          "name": "write_off_requests_request_number_idx",
+          "columns": [
+            {
+              "expression": "request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_loan_account_id_idx": {
+          "name": "write_off_requests_loan_account_id_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_customer_id_idx": {
+          "name": "write_off_requests_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_status_idx": {
+          "name": "write_off_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_requested_by_idx": {
+          "name": "write_off_requests_requested_by_idx",
+          "columns": [
+            {
+              "expression": "requested_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_approval_details_approval_details_dec_idx": {
+          "name": "write_off_requests_approval_details_approval_details_dec_idx",
+          "columns": [
+            {
+              "expression": "approval_details_decided_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_updated_at_idx": {
+          "name": "write_off_requests_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "write_off_requests_created_at_idx": {
+          "name": "write_off_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "write_off_requests_requested_by_id_users_id_fk": {
+          "name": "write_off_requests_requested_by_id_users_id_fk",
+          "tableFrom": "write_off_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "write_off_requests_approval_details_decided_by_id_users_id_fk": {
+          "name": "write_off_requests_approval_details_decided_by_id_users_id_fk",
+          "tableFrom": "write_off_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approval_details_decided_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reapplication_block_clear_requests": {
+      "name": "reapplication_block_clear_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_number": {
+          "name": "request_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canonical_customer_id": {
+          "name": "canonical_customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "justification": {
+          "name": "justification",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_reapplication_block_clear_requests_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by": {
+          "name": "approval_details_approved_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_by_name": {
+          "name": "approval_details_approved_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_approved_at": {
+          "name": "approval_details_approved_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_comment": {
+          "name": "approval_details_comment",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by": {
+          "name": "approval_details_rejected_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_by_name": {
+          "name": "approval_details_rejected_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_rejected_at": {
+          "name": "approval_details_rejected_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_details_reason": {
+          "name": "approval_details_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by": {
+          "name": "cancellation_details_cancelled_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_by_name": {
+          "name": "cancellation_details_cancelled_by_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_details_cancelled_at": {
+          "name": "cancellation_details_cancelled_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reapplication_block_clear_requests_request_id_idx": {
+          "name": "reapplication_block_clear_requests_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_event_id_idx": {
+          "name": "reapplication_block_clear_requests_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_request_number_idx": {
+          "name": "reapplication_block_clear_requests_request_number_idx",
+          "columns": [
+            {
+              "expression": "request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_canonical_customer_id_idx": {
+          "name": "reapplication_block_clear_requests_canonical_customer_id_idx",
+          "columns": [
+            {
+              "expression": "canonical_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_status_idx": {
+          "name": "reapplication_block_clear_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_requested_by_idx": {
+          "name": "reapplication_block_clear_requests_requested_by_idx",
+          "columns": [
+            {
+              "expression": "requested_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_updated_at_idx": {
+          "name": "reapplication_block_clear_requests_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reapplication_block_clear_requests_created_at_idx": {
+          "name": "reapplication_block_clear_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reapplication_block_clear_requests_requested_by_id_users_id_fk": {
+          "name": "reapplication_block_clear_requests_requested_by_id_users_id_fk",
+          "tableFrom": "reapplication_block_clear_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_notes": {
+      "name": "contact_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loan_account_id": {
+          "name": "loan_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "enum_contact_notes_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "enum_contact_notes_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_direction": {
+          "name": "contact_direction",
+          "type": "enum_contact_notes_contact_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "enum_contact_notes_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "enum_contact_notes_sentiment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'neutral'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amends_note_id": {
+          "name": "amends_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_contact_notes_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_notes_customer_idx": {
+          "name": "contact_notes_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_loan_account_idx": {
+          "name": "contact_notes_loan_account_idx",
+          "columns": [
+            {
+              "expression": "loan_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_application_idx": {
+          "name": "contact_notes_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_conversation_idx": {
+          "name": "contact_notes_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_created_by_idx": {
+          "name": "contact_notes_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_amends_note_idx": {
+          "name": "contact_notes_amends_note_idx",
+          "columns": [
+            {
+              "expression": "amends_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_status_idx": {
+          "name": "contact_notes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_created_at_idx": {
+          "name": "contact_notes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_notes_updated_at_idx": {
+          "name": "contact_notes_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_notes_customer_id_customers_id_fk": {
+          "name": "contact_notes_customer_id_customers_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_loan_account_id_loan_accounts_id_fk": {
+          "name": "contact_notes_loan_account_id_loan_accounts_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_application_id_applications_id_fk": {
+          "name": "contact_notes_application_id_applications_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_conversation_id_conversations_id_fk": {
+          "name": "contact_notes_conversation_id_conversations_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_created_by_id_users_id_fk": {
+          "name": "contact_notes_created_by_id_users_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_notes_amends_note_id_contact_notes_id_fk": {
+          "name": "contact_notes_amends_note_id_contact_notes_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "contact_notes",
+          "columnsFrom": [
+            "amends_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_ref_id": {
+          "name": "customer_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enum_notifications_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "enum_notifications_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_name": {
+          "name": "template_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_content_hash": {
+          "name": "template_content_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_git_sha": {
+          "name": "template_git_sha",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_hash": {
+          "name": "recipient_hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_category": {
+          "name": "tags_category",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_reason": {
+          "name": "tags_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags_step": {
+          "name": "tags_step",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_failed_at": {
+          "name": "failure_failed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_error_type": {
+          "name": "failure_error_type",
+          "type": "enum_notifications_failure_error_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_error_message": {
+          "name": "failure_error_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_attempt": {
+          "name": "failure_attempt",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_fallback_suggested": {
+          "name": "failure_fallback_suggested",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_account_id": {
+          "name": "statement_account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_start": {
+          "name": "statement_period_start",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_period_end": {
+          "name": "statement_period_end",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement_dispatched_at": {
+          "name": "statement_dispatched_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_mode": {
+          "name": "suppression_mode",
+          "type": "enum_notifications_suppression_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_reason": {
+          "name": "suppression_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_set_by": {
+          "name": "suppression_set_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_set_at": {
+          "name": "suppression_set_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppression_expires_at": {
+          "name": "suppression_expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_notification_id_idx": {
+          "name": "notifications_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_idempotency_key_idx": {
+          "name": "notifications_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_customer_ref_idx": {
+          "name": "notifications_customer_ref_idx",
+          "columns": [
+            {
+              "expression": "customer_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_customer_id_idx": {
+          "name": "notifications_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_status_idx": {
+          "name": "notifications_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_event_at_idx": {
+          "name": "notifications_event_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_customer_ref_id_customers_id_fk": {
+          "name": "notifications_customer_ref_id_customers_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_cases": {
+      "name": "collection_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_ref_id": {
+          "name": "customer_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum_collection_cases_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rung": {
+          "name": "rung",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardship_paused": {
+          "name": "hardship_paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_contact": {
+          "name": "stopped_contact",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overdue_amount": {
+          "name": "overdue_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_overdue": {
+          "name": "days_overdue",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_step": {
+          "name": "last_step",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cured_at": {
+          "name": "cured_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exhausted_at": {
+          "name": "exhausted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_at": {
+          "name": "resumed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_contact_at": {
+          "name": "stop_contact_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_cases_account_id_idx": {
+          "name": "collection_cases_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_customer_ref_idx": {
+          "name": "collection_cases_customer_ref_idx",
+          "columns": [
+            {
+              "expression": "customer_ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_customer_id_idx": {
+          "name": "collection_cases_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_state_idx": {
+          "name": "collection_cases_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_rung_idx": {
+          "name": "collection_cases_rung_idx",
+          "columns": [
+            {
+              "expression": "rung",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_hardship_paused_idx": {
+          "name": "collection_cases_hardship_paused_idx",
+          "columns": [
+            {
+              "expression": "hardship_paused",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_stopped_contact_idx": {
+          "name": "collection_cases_stopped_contact_idx",
+          "columns": [
+            {
+              "expression": "stopped_contact",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_opened_at_idx": {
+          "name": "collection_cases_opened_at_idx",
+          "columns": [
+            {
+              "expression": "opened_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_worklist_idx": {
+          "name": "collection_cases_worklist_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rung",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_cases_by_customer_idx": {
+          "name": "collection_cases_by_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_cases_customer_ref_id_customers_id_fk": {
+          "name": "collection_cases_customer_ref_id_customers_id_fk",
+          "tableFrom": "collection_cases",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customer_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_e164": {
+          "name": "mobile_e164",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postcode": {
+          "name": "postcode",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "enum_contacts_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm": {
+          "name": "utm",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_preference": {
+          "name": "channel_preference",
+          "type": "enum_contacts_channel_preference",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referral_code": {
+          "name": "referral_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referred_by_contact_id": {
+          "name": "referred_by_contact_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitlist_joined_at": {
+          "name": "waitlist_joined_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitlist_position": {
+          "name": "waitlist_position",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "panel_member": {
+          "name": "panel_member",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_review": {
+          "name": "needs_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_basis": {
+          "name": "link_basis",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "derived_stage": {
+          "name": "derived_stage",
+          "type": "enum_contacts_derived_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_status": {
+          "name": "loan_status",
+          "type": "enum_contacts_loan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "erased": {
+          "name": "erased",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into": {
+          "name": "merged_into",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_contact_id_idx": {
+          "name": "contacts_contact_id_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_email_idx": {
+          "name": "contacts_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_mobile_e164_idx": {
+          "name": "contacts_mobile_e164_idx",
+          "columns": [
+            {
+              "expression": "mobile_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_referral_code_idx": {
+          "name": "contacts_referral_code_idx",
+          "columns": [
+            {
+              "expression": "referral_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_referred_by_contact_id_idx": {
+          "name": "contacts_referred_by_contact_id_idx",
+          "columns": [
+            {
+              "expression": "referred_by_contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_needs_review_idx": {
+          "name": "contacts_needs_review_idx",
+          "columns": [
+            {
+              "expression": "needs_review",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_customer_id_idx": {
+          "name": "contacts_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_derived_stage_idx": {
+          "name": "contacts_derived_stage_idx",
+          "columns": [
+            {
+              "expression": "derived_stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_updated_at_idx": {
+          "name": "contacts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_created_at_idx": {
+          "name": "contacts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interactions": {
+      "name": "interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "interaction_id": {
+          "name": "interaction_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id_string": {
+          "name": "contact_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "enum_interactions_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "enum_interactions_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_system": {
+          "name": "source_system",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "interactions_interaction_id_idx": {
+          "name": "interactions_interaction_id_idx",
+          "columns": [
+            {
+              "expression": "interaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_contact_id_string_idx": {
+          "name": "interactions_contact_id_string_idx",
+          "columns": [
+            {
+              "expression": "contact_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_contact_idx": {
+          "name": "interactions_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_occurred_at_idx": {
+          "name": "interactions_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_updated_at_idx": {
+          "name": "interactions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "interactions_created_at_idx": {
+          "name": "interactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interactions_contact_id_contacts_id_fk": {
+          "name": "interactions_contact_id_contacts_id_fk",
+          "tableFrom": "interactions",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_audit_log": {
+      "name": "contact_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contact_id_string": {
+          "name": "contact_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_audit_log_contact_id_string_idx": {
+          "name": "contact_audit_log_contact_id_string_idx",
+          "columns": [
+            {
+              "expression": "contact_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_audit_log_occurred_at_idx": {
+          "name": "contact_audit_log_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_audit_log_updated_at_idx": {
+          "name": "contact_audit_log_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_audit_log_created_at_idx": {
+          "name": "contact_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batches": {
+      "name": "batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_actor": {
+          "name": "created_by_actor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_created_at": {
+          "name": "batch_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_count": {
+          "name": "invited_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_unconsented": {
+          "name": "skipped_unconsented",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped_needs_review": {
+          "name": "skipped_needs_review",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "batches_batch_id_idx": {
+          "name": "batches_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_updated_at_idx": {
+          "name": "batches_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "batches_created_at_idx": {
+          "name": "batches_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id_string": {
+          "name": "contact_id_string",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_type": {
+          "name": "feedback_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_area": {
+          "name": "product_area",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_actor": {
+          "name": "status_actor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_note": {
+          "name": "status_note",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_feedback_id_idx": {
+          "name": "feedback_feedback_id_idx",
+          "columns": [
+            {
+              "expression": "feedback_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_contact_id_string_idx": {
+          "name": "feedback_contact_id_string_idx",
+          "columns": [
+            {
+              "expression": "contact_id_string",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_customer_id_idx": {
+          "name": "feedback_customer_id_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_product_area_idx": {
+          "name": "feedback_product_area_idx",
+          "columns": [
+            {
+              "expression": "product_area",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_status_idx": {
+          "name": "feedback_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_updated_at_idx": {
+          "name": "feedback_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_created_at_idx": {
+          "name": "feedback_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customers_id": {
+          "name": "customers_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversations_id": {
+          "name": "conversations_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applications_id": {
+          "name": "applications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "loan_accounts_id": {
+          "name": "loan_accounts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "write_off_requests_id": {
+          "name": "write_off_requests_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reapplication_block_clear_requests_id": {
+          "name": "reapplication_block_clear_requests_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_notes_id": {
+          "name": "contact_notes_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notifications_id": {
+          "name": "notifications_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_cases_id": {
+          "name": "collection_cases_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts_id": {
+          "name": "contacts_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interactions_id": {
+          "name": "interactions_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_audit_log_id": {
+          "name": "contact_audit_log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batches_id": {
+          "name": "batches_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_media_id_idx": {
+          "name": "payload_locked_documents_rels_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_customers_id_idx": {
+          "name": "payload_locked_documents_rels_customers_id_idx",
+          "columns": [
+            {
+              "expression": "customers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_conversations_id_idx": {
+          "name": "payload_locked_documents_rels_conversations_id_idx",
+          "columns": [
+            {
+              "expression": "conversations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_applications_id_idx": {
+          "name": "payload_locked_documents_rels_applications_id_idx",
+          "columns": [
+            {
+              "expression": "applications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_loan_accounts_id_idx": {
+          "name": "payload_locked_documents_rels_loan_accounts_id_idx",
+          "columns": [
+            {
+              "expression": "loan_accounts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_write_off_requests_id_idx": {
+          "name": "payload_locked_documents_rels_write_off_requests_id_idx",
+          "columns": [
+            {
+              "expression": "write_off_requests_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_reapplication_block_clear__idx": {
+          "name": "payload_locked_documents_rels_reapplication_block_clear__idx",
+          "columns": [
+            {
+              "expression": "reapplication_block_clear_requests_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contact_notes_id_idx": {
+          "name": "payload_locked_documents_rels_contact_notes_id_idx",
+          "columns": [
+            {
+              "expression": "contact_notes_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_notifications_id_idx": {
+          "name": "payload_locked_documents_rels_notifications_id_idx",
+          "columns": [
+            {
+              "expression": "notifications_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_collection_cases_id_idx": {
+          "name": "payload_locked_documents_rels_collection_cases_id_idx",
+          "columns": [
+            {
+              "expression": "collection_cases_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contacts_id_idx": {
+          "name": "payload_locked_documents_rels_contacts_id_idx",
+          "columns": [
+            {
+              "expression": "contacts_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_interactions_id_idx": {
+          "name": "payload_locked_documents_rels_interactions_id_idx",
+          "columns": [
+            {
+              "expression": "interactions_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_contact_audit_log_id_idx": {
+          "name": "payload_locked_documents_rels_contact_audit_log_id_idx",
+          "columns": [
+            {
+              "expression": "contact_audit_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_batches_id_idx": {
+          "name": "payload_locked_documents_rels_batches_id_idx",
+          "columns": [
+            {
+              "expression": "batches_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_feedback_id_idx": {
+          "name": "payload_locked_documents_rels_feedback_id_idx",
+          "columns": [
+            {
+              "expression": "feedback_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_media_fk": {
+          "name": "payload_locked_documents_rels_media_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_customers_fk": {
+          "name": "payload_locked_documents_rels_customers_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "customers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_conversations_fk": {
+          "name": "payload_locked_documents_rels_conversations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_applications_fk": {
+          "name": "payload_locked_documents_rels_applications_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "applications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_loan_accounts_fk": {
+          "name": "payload_locked_documents_rels_loan_accounts_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "loan_accounts",
+          "columnsFrom": [
+            "loan_accounts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_write_off_requests_fk": {
+          "name": "payload_locked_documents_rels_write_off_requests_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "write_off_requests",
+          "columnsFrom": [
+            "write_off_requests_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_reapplication_block_clear_r_fk": {
+          "name": "payload_locked_documents_rels_reapplication_block_clear_r_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "reapplication_block_clear_requests",
+          "columnsFrom": [
+            "reapplication_block_clear_requests_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contact_notes_fk": {
+          "name": "payload_locked_documents_rels_contact_notes_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contact_notes",
+          "columnsFrom": [
+            "contact_notes_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_notifications_fk": {
+          "name": "payload_locked_documents_rels_notifications_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "notifications",
+          "columnsFrom": [
+            "notifications_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_collection_cases_fk": {
+          "name": "payload_locked_documents_rels_collection_cases_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "collection_cases",
+          "columnsFrom": [
+            "collection_cases_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contacts_fk": {
+          "name": "payload_locked_documents_rels_contacts_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contacts_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_interactions_fk": {
+          "name": "payload_locked_documents_rels_interactions_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "interactions",
+          "columnsFrom": [
+            "interactions_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_contact_audit_log_fk": {
+          "name": "payload_locked_documents_rels_contact_audit_log_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "contact_audit_log",
+          "columnsFrom": [
+            "contact_audit_log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_batches_fk": {
+          "name": "payload_locked_documents_rels_batches_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "batches",
+          "columnsFrom": [
+            "batches_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_feedback_fk": {
+          "name": "payload_locked_documents_rels_feedback_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "feedback",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_users_id_idx": {
+          "name": "payload_preferences_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.enum_users_role": {
+      "name": "enum_users_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "supervisor",
+        "operations",
+        "readonly",
+        "service",
+        "marketing"
+      ]
+    },
+    "public.enum_customers_identity_documents_document_type": {
+      "name": "enum_customers_identity_documents_document_type",
+      "schema": "public",
+      "values": [
+        "DRIVERS_LICENCE",
+        "PASSPORT",
+        "MEDICARE"
+      ]
+    },
+    "public.enum_customers_ekyc_status": {
+      "name": "enum_customers_ekyc_status",
+      "schema": "public",
+      "values": [
+        "successful",
+        "failed",
+        "pending"
+      ]
+    },
+    "public.enum_customers_individual_status": {
+      "name": "enum_customers_individual_status",
+      "schema": "public",
+      "values": [
+        "LIVING",
+        "DECEASED",
+        "MISSING"
+      ]
+    },
+    "public.enum_conversations_status": {
+      "name": "enum_conversations_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "soft_end",
+        "hard_end",
+        "approved",
+        "declined"
+      ]
+    },
+    "public.enum_conversations_decision_status": {
+      "name": "enum_conversations_decision_status",
+      "schema": "public",
+      "values": [
+        "approved",
+        "declined",
+        "referred",
+        "no_decision"
+      ]
+    },
+    "public.enum_app_proc_state_steps_type": {
+      "name": "enum_app_proc_state_steps_type",
+      "schema": "public",
+      "values": [
+        "llm",
+        "business_logic",
+        "user_input"
+      ]
+    },
+    "public.enum_applications_application_process_conversation_role": {
+      "name": "enum_applications_application_process_conversation_role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ]
+    },
+    "public.enum_applications_application_outcome": {
+      "name": "enum_applications_application_outcome",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "declined",
+        "withdrawn"
+      ]
+    },
+    "public.enum_loan_accounts_repayment_schedule_payments_status": {
+      "name": "enum_loan_accounts_repayment_schedule_payments_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "paid",
+        "missed",
+        "partial"
+      ]
+    },
+    "public.enum_loan_accounts_aging_bucket": {
+      "name": "enum_loan_accounts_aging_bucket",
+      "schema": "public",
+      "values": [
+        "current",
+        "early_arrears",
+        "late_arrears",
+        "default",
+        "closed"
+      ]
+    },
+    "public.enum_loan_accounts_account_status": {
+      "name": "enum_loan_accounts_account_status",
+      "schema": "public",
+      "values": [
+        "pending_disbursement",
+        "active",
+        "paid_off",
+        "in_arrears",
+        "written_off"
+      ]
+    },
+    "public.enum_loan_accounts_closure_reason": {
+      "name": "enum_loan_accounts_closure_reason",
+      "schema": "public",
+      "values": [
+        "PAID_OFF",
+        "WRITTEN_OFF",
+        "ADMIN_CLOSED"
+      ]
+    },
+    "public.enum_loan_accounts_repayment_schedule_payment_frequency": {
+      "name": "enum_loan_accounts_repayment_schedule_payment_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "fortnightly",
+        "monthly"
+      ]
+    },
+    "public.enum_write_off_requests_reason": {
+      "name": "enum_write_off_requests_reason",
+      "schema": "public",
+      "values": [
+        "hardship",
+        "bankruptcy",
+        "deceased",
+        "unable_to_locate",
+        "fraud_victim",
+        "disputed",
+        "aged_debt",
+        "other"
+      ]
+    },
+    "public.enum_write_off_requests_status": {
+      "name": "enum_write_off_requests_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.enum_write_off_requests_priority": {
+      "name": "enum_write_off_requests_priority",
+      "schema": "public",
+      "values": [
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.enum_reapplication_block_clear_requests_status": {
+      "name": "enum_reapplication_block_clear_requests_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.enum_contact_notes_channel": {
+      "name": "enum_contact_notes_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "internal",
+        "system"
+      ]
+    },
+    "public.enum_contact_notes_topic": {
+      "name": "enum_contact_notes_topic",
+      "schema": "public",
+      "values": [
+        "general_enquiry",
+        "complaint",
+        "escalation",
+        "internal_note",
+        "account_update",
+        "collections"
+      ]
+    },
+    "public.enum_contact_notes_contact_direction": {
+      "name": "enum_contact_notes_contact_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.enum_contact_notes_priority": {
+      "name": "enum_contact_notes_priority",
+      "schema": "public",
+      "values": [
+        "low",
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.enum_contact_notes_sentiment": {
+      "name": "enum_contact_notes_sentiment",
+      "schema": "public",
+      "values": [
+        "positive",
+        "neutral",
+        "negative",
+        "escalation"
+      ]
+    },
+    "public.enum_contact_notes_status": {
+      "name": "enum_contact_notes_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "amended"
+      ]
+    },
+    "public.enum_notifications_status": {
+      "name": "enum_notifications_status",
+      "schema": "public",
+      "values": [
+        "sent",
+        "failed",
+        "blocked",
+        "statement",
+        "suppression_change"
+      ]
+    },
+    "public.enum_notifications_channel": {
+      "name": "enum_notifications_channel",
+      "schema": "public",
+      "values": [
+        "email",
+        "sms"
+      ]
+    },
+    "public.enum_notifications_failure_error_type": {
+      "name": "enum_notifications_failure_error_type",
+      "schema": "public",
+      "values": [
+        "transient",
+        "permanent",
+        "auth",
+        "template",
+        "contact_missing",
+        "opt_out",
+        "suppressed"
+      ]
+    },
+    "public.enum_notifications_suppression_mode": {
+      "name": "enum_notifications_suppression_mode",
+      "schema": "public",
+      "values": [
+        "all",
+        "non_essential",
+        "marketing_only",
+        "panic_button",
+        "off"
+      ]
+    },
+    "public.enum_collection_cases_state": {
+      "name": "enum_collection_cases_state",
+      "schema": "public",
+      "values": [
+        "open",
+        "awaiting_human",
+        "cured"
+      ]
+    },
+    "public.enum_contacts_source": {
+      "name": "enum_contacts_source",
+      "schema": "public",
+      "values": [
+        "meta",
+        "google",
+        "campus",
+        "referral",
+        "social_dm",
+        "ai_search",
+        "word_of_mouth",
+        "organic",
+        "other"
+      ]
+    },
+    "public.enum_contacts_channel_preference": {
+      "name": "enum_contacts_channel_preference",
+      "schema": "public",
+      "values": [
+        "whatsapp",
+        "sms"
+      ]
+    },
+    "public.enum_contacts_derived_stage": {
+      "name": "enum_contacts_derived_stage",
+      "schema": "public",
+      "values": [
+        "lead",
+        "waitlist",
+        "invited",
+        "applicant",
+        "customer",
+        "former_customer"
+      ]
+    },
+    "public.enum_contacts_loan_status": {
+      "name": "enum_contacts_loan_status",
+      "schema": "public",
+      "values": [
+        "approved",
+        "disbursed",
+        "repaid"
+      ]
+    },
+    "public.enum_interactions_kind": {
+      "name": "enum_interactions_kind",
+      "schema": "public",
+      "values": [
+        "signup",
+        "message_out",
+        "message_in",
+        "feedback_prompt",
+        "referral",
+        "stage_change",
+        "note",
+        "import"
+      ]
+    },
+    "public.enum_interactions_direction": {
+      "name": "enum_interactions_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "9c22592f-8d04-434d-a0e3-eaa581452ed8",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/src/migrations/20260714_053341_word_of_mouth_source.ts
+++ b/src/migrations/20260714_053341_word_of_mouth_source.ts
@@ -1,0 +1,30 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * word_of_mouth source value (PO Decision H) — plus schema catch-up: the
+ * customers.fraud_risk_* columns shipped in #63 without a committed
+ * migration (dev runs push:true so nobody noticed); this migration heals
+ * that drift for demo/prod.
+ */
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TYPE "public"."enum_contacts_source" ADD VALUE 'word_of_mouth' BEFORE 'organic';
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_severity" varchar;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_score" numeric;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_categories" jsonb;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_flagged_at" timestamp(3) with time zone;
+  ALTER TABLE "customers" ADD COLUMN "fraud_risk_active" boolean;`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "contacts" ALTER COLUMN "source" SET DATA TYPE text;
+  DROP TYPE "public"."enum_contacts_source";
+  CREATE TYPE "public"."enum_contacts_source" AS ENUM('meta', 'google', 'campus', 'referral', 'social_dm', 'ai_search', 'organic', 'other');
+  ALTER TABLE "contacts" ALTER COLUMN "source" SET DATA TYPE "public"."enum_contacts_source" USING "source"::"public"."enum_contacts_source";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_severity";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_score";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_categories";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_flagged_at";
+  ALTER TABLE "customers" DROP COLUMN "fraud_risk_active";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -15,6 +15,7 @@ import * as migration_20260707_141505 from './20260707_141505';
 import * as migration_20260708_020322 from './20260708_020322';
 import * as migration_20260708_121539_contact_merged_into from './20260708_121539_contact_merged_into';
 import * as migration_20260709_120104_fraud_risk from './20260709_120104_fraud_risk';
+import * as migration_20260714_053341_word_of_mouth_source from './20260714_053341_word_of_mouth_source';
 
 export const migrations = [
   {
@@ -101,5 +102,10 @@ export const migrations = [
     up: migration_20260709_120104_fraud_risk.up,
     down: migration_20260709_120104_fraud_risk.down,
     name: '20260709_120104_fraud_risk',
+  },
+  {
+    up: migration_20260714_053341_word_of_mouth_source.up,
+    down: migration_20260714_053341_word_of_mouth_source.down,
+    name: '20260714_053341_word_of_mouth_source'
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1583,7 +1583,9 @@ export interface Contact {
   mobileE164?: string | null;
   city?: string | null;
   postcode?: string | null;
-  source?: ('meta' | 'google' | 'campus' | 'referral' | 'social_dm' | 'ai_search' | 'organic' | 'other') | null;
+  source?:
+    | ('meta' | 'google' | 'campus' | 'referral' | 'social_dm' | 'ai_search' | 'word_of_mouth' | 'organic' | 'other')
+    | null;
   utm?:
     | {
         [k: string]: unknown;


### PR DESCRIPTION
## Summary
The three unblocked items from the PO review (companion: billie-platform-services#63 for the platform-side mirror).

**Advisory council** (wiki overstated this — the flag had no UI or command path)
- Contact page: new *Advisory council* panel with Add/Remove toggle, riding the existing PATCH route's `attributes` delta (`advisory_council`)
- Grid: "Advisory council → Members only" filter (+ CSV export param)
- Event-processor mirrors `attributes.advisory_council` → `panelMember` column, same pattern as the `needs_review` mirror

**Word-of-mouth source** (Decision H, system-side readiness)
- `word_of_mouth` accepted by the public intake schema and the staff-create schema, selectable in the New-contact form, filterable in the grid
- Payload migration `20260714_053341_word_of_mouth_source` adds the pg enum value — and **heals schema drift**: the `customers.fraud_risk_*` columns from #63 were never captured in a committed migration (dev uses `push:true`, so it went unnoticed); demo/prod get them via this migration
- The website/chat "how did you hear about us?" question is a content change wherever the signup form lives — the system now accepts its answer

**help@ mailbox connector** (Decision J)
- Optional IMAP poller in the event-processor (enabled by `HELP_MAILBOX_IMAP_HOST` + credentials; default off)
- Each unseen email → parsed (sender, subject, plain-text body capped at 4k, Date→UTC) → contact resolved by sender email (non-erased, non-merged) → logged as an inbound email interaction via `LogInteraction` with a Message-ID-derived idempotency key; unknown senders are skipped and marked seen
- IMAP calls run in a worker thread; poisoned messages and IMAP outages never kill the loop

## Test plan
- [x] 5 new connector tests (parse: normalised sender/UTC date/stable fallback key/missing sender; process: logged with correct fields + exclusion SQL, unknown sender skipped without logging)
- [x] Advisory mirror handler test (set → true, unset → false)
- [x] Full event-processor suite: 287 passed; CRM component/lib/intake suites: 112 passed
- [x] Migration generated against a throwaway Postgres and verified to apply after all existing migrations; eslint 0 errors; tsc clean

## Config (for demo when ready)
`HELP_MAILBOX_IMAP_HOST`, `HELP_MAILBOX_IMAP_PORT` (993), `HELP_MAILBOX_USER`, `HELP_MAILBOX_PASSWORD`, `HELP_MAILBOX_FOLDER` (INBOX), `HELP_MAILBOX_POLL_SECONDS` (300)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf3YKd6cQxzwGmSRYjEWHi