### PR TITLE
fix(migrations): make word_of_mouth migration idempotent (unblocks demo/prod deploys)

### DIFF
--- a/src/migrations/20260714_053341_word_of_mouth_source.ts
+++ b/src/migrations/20260714_053341_word_of_mouth_source.ts
@@ -1,19 +1,23 @@
 import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
 
 /**
- * word_of_mouth source value (PO Decision H) — plus schema catch-up: the
- * customers.fraud_risk_* columns shipped in #63 without a committed
- * migration (dev runs push:true so nobody noticed); this migration heals
- * that drift for demo/prod.
+ * word_of_mouth source value (PO Decision H).
+ *
+ * The customers.fraud_risk_* columns are owned by 20260709_120104_fraud_risk;
+ * they were re-added here as a "schema catch-up" on the mistaken belief that #63
+ * shipped them without a committed migration. On any DB where that migration has
+ * already run (e.g. demo/prod), a plain ADD COLUMN fails with "already exists".
+ * All statements are therefore idempotent (IF NOT EXISTS / IF EXISTS) so this
+ * migration heals drift regardless of whether the columns/enum value are present.
  */
 export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
   await db.execute(sql`
-   ALTER TYPE "public"."enum_contacts_source" ADD VALUE 'word_of_mouth' BEFORE 'organic';
-  ALTER TABLE "customers" ADD COLUMN "fraud_risk_severity" varchar;
-  ALTER TABLE "customers" ADD COLUMN "fraud_risk_score" numeric;
-  ALTER TABLE "customers" ADD COLUMN "fraud_risk_categories" jsonb;
-  ALTER TABLE "customers" ADD COLUMN "fraud_risk_flagged_at" timestamp(3) with time zone;
-  ALTER TABLE "customers" ADD COLUMN "fraud_risk_active" boolean;`)
+   ALTER TYPE "public"."enum_contacts_source" ADD VALUE IF NOT EXISTS 'word_of_mouth' BEFORE 'organic';
+  ALTER TABLE "customers" ADD COLUMN IF NOT EXISTS "fraud_risk_severity" varchar;
+  ALTER TABLE "customers" ADD COLUMN IF NOT EXISTS "fraud_risk_score" numeric;
+  ALTER TABLE "customers" ADD COLUMN IF NOT EXISTS "fraud_risk_categories" jsonb;
+  ALTER TABLE "customers" ADD COLUMN IF NOT EXISTS "fraud_risk_flagged_at" timestamp(3) with time zone;
+  ALTER TABLE "customers" ADD COLUMN IF NOT EXISTS "fraud_risk_active" boolean;`)
 }
 
 export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
@@ -22,9 +26,9 @@ export async function down({ db, payload, req }: MigrateDownArgs): Promise<void>
   DROP TYPE "public"."enum_contacts_source";
   CREATE TYPE "public"."enum_contacts_source" AS ENUM('meta', 'google', 'campus', 'referral', 'social_dm', 'ai_search', 'organic', 'other');
   ALTER TABLE "contacts" ALTER COLUMN "source" SET DATA TYPE "public"."enum_contacts_source" USING "source"::"public"."enum_contacts_source";
-  ALTER TABLE "customers" DROP COLUMN "fraud_risk_severity";
-  ALTER TABLE "customers" DROP COLUMN "fraud_risk_score";
-  ALTER TABLE "customers" DROP COLUMN "fraud_risk_categories";
-  ALTER TABLE "customers" DROP COLUMN "fraud_risk_flagged_at";
-  ALTER TABLE "customers" DROP COLUMN "fraud_risk_active";`)
+  ALTER TABLE "customers" DROP COLUMN IF EXISTS "fraud_risk_severity";
+  ALTER TABLE "customers" DROP COLUMN IF EXISTS "fraud_risk_score";
+  ALTER TABLE "customers" DROP COLUMN IF EXISTS "fraud_risk_categories";
+  ALTER TABLE "customers" DROP COLUMN IF EXISTS "fraud_risk_flagged_at";
+  ALTER TABLE "customers" DROP COLUMN IF EXISTS "fraud_risk_active";`)
 }


### PR DESCRIPTION
## Problem

`make deploy ENV=demo` (and prod) fails at the Payload migration step:

```
ERROR: column "fraud_risk_severity" of relation "customers" already exists
migration: 20260714_053341_word_of_mouth_source
```

This blocks **all** deploys, independent of whatever change is being shipped.

## Root cause

`20260714_053341_word_of_mouth_source` (from `d23a6cf`) re-adds the five
`customers.fraud_risk_*` columns as a "schema catch-up", on the mistaken belief
that they shipped in #63 without a committed migration. They are in fact already
owned by **`20260709_120104_fraud_risk`**, which runs first. On any DB where that
migration has already applied (demo, and any synced prod), the plain
`ADD COLUMN` throws `already exists`.

The drift crept in because `20260709_120104_fraud_risk.ts` has **no `.json`
snapshot**, so `payload migrate:create` didn't "see" those columns in its
baseline and regenerated them into the word-of-mouth migration.

## Fix

Make every statement in the migration idempotent — `ADD COLUMN IF NOT EXISTS`,
`DROP COLUMN IF EXISTS`, and `ADD VALUE IF NOT EXISTS` for the enum — so it heals
drift whether or not a target DB already has the columns / enum value. The
`fraud_risk_*` columns remain owned by `20260709_120104_fraud_risk` (which runs
first); this migration's real job is the `word_of_mouth` enum value.

## Verification

Ran the `up()` SQL against Postgres 16, wrapped in a transaction like Payload's
migrator:

- **Columns already present (demo state):** runs clean, skips with NOTICEs, no error.
- **Idempotent:** second run also clean.
- **Fresh DB:** adds all five columns.
- Confirms `ALTER TYPE … ADD VALUE IF NOT EXISTS … BEFORE 'organic'` executes inside the migration transaction on PG 16.

## Follow-up (not in this PR)

Add the missing `.json` snapshot for `20260709_120104_fraud_risk` so future
`migrate:create` runs stop re-generating these columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ML3tVhDMjCmM4YqHTwq986