### PR TITLE
CI for the Node side: lint, vitest, and marketing e2e on every PR

### DIFF
--- a/.github/workflows/crm-ci.yml
+++ b/.github/workflows/crm-ci.yml
@@ -1,0 +1,97 @@
+name: crm ci
+
+# Node-side CI for the Payload CRM: lint, unit + integration tests, and the
+# marketing-module Playwright e2e suite. The Python event processor has its
+# own workflow (event-processor-tests.yml), so its tree is ignored here.
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'event-processor/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'event-processor/**'
+
+concurrency:
+  group: crm-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: eslint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
+  test:
+    name: vitest (unit + integration)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # globalSetup spins up Postgres via testcontainers (Docker is available
+      # on ubuntu-latest) and runs Payload's push schema sync before tests.
+      - run: pnpm test:int
+
+  e2e:
+    name: playwright (marketing module)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: billie_crm
+          POSTGRES_PASSWORD: billie_crm
+          POSTGRES_DB: billie_crm_e2e
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U billie_crm"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URI: postgresql://billie_crm:billie_crm@localhost:5432/billie_crm_e2e
+      PAYLOAD_SECRET: ci-e2e-secret-not-for-production
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      # Seed pushes the Payload schema into the service Postgres and creates
+      # the admin user + marketing fixtures the spec expects.
+      - name: Seed marketing fixtures
+        run: pnpm exec tsx tests/e2e/seed-marketing.ts
+      # Playwright's webServer config boots `pnpm dev` and waits for :3000.
+      - name: Run marketing e2e
+        run: pnpm exec playwright test tests/e2e/marketing.e2e.spec.ts
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/tests/e2e/seed-marketing.ts
+++ b/tests/e2e/seed-marketing.ts
@@ -1,0 +1,147 @@
+/**
+ * Seed data for the marketing-module e2e suite (tests/e2e/marketing.e2e.spec.ts).
+ *
+ * Run against a disposable database before starting the app:
+ *
+ *   DATABASE_URI=postgresql://… PAYLOAD_SECRET=… pnpm exec tsx tests/e2e/seed-marketing.ts
+ *
+ * Idempotent: rows that already exist (matched on their natural keys) are
+ * left untouched, so re-running against the same database is safe. Uses the
+ * Payload Local API (overrideAccess) because the marketing collections are
+ * read-only projections — in production only the event processor writes them.
+ */
+import { getPayload } from 'payload'
+import config from '../../src/payload.config'
+
+const payload = await getPayload({ config })
+
+async function ensure(
+  collection: string,
+  where: Record<string, unknown>,
+  data: Record<string, unknown>,
+) {
+  const existing = await payload.find({
+    collection: collection as never,
+    where: where as never,
+    limit: 1,
+  })
+  if (existing.docs.length > 0) return existing.docs[0]
+  return payload.create({ collection: collection as never, data: data as never })
+}
+
+const days = (n: number) => new Date(Date.now() - n * 86_400_000).toISOString()
+
+await ensure(
+  'users',
+  { email: { equals: 'e2e-admin@billie.test' } },
+  {
+    email: 'e2e-admin@billie.test',
+    password: 'E2Epassw0rd!',
+    role: 'admin',
+    firstName: 'E2E',
+    lastName: 'Admin',
+  },
+)
+
+await ensure(
+  'batches',
+  { batchId: { equals: 'e2e-batch-1' } },
+  {
+    batchId: 'e2e-batch-1',
+    name: 'Campus wave 1',
+    criteria: { stage: 'waitlist', city: 'Sydney' },
+    batchCreatedAt: days(10),
+  },
+)
+
+await ensure(
+  'contacts',
+  { contactId: { equals: 'e2e-alice' } },
+  {
+    contactId: 'e2e-alice',
+    firstName: 'Alice',
+    email: 'alice@example.com',
+    mobileE164: '+61400000001',
+    city: 'Sydney',
+    source: 'campus',
+    derivedStage: 'waitlist',
+    batchId: 'e2e-batch-1',
+    consent: {
+      marketing: { granted: true, channels: ['sms', 'whatsapp'], method: 'campus stall form' },
+    },
+  },
+)
+
+await ensure(
+  'contacts',
+  { contactId: { equals: 'e2e-bob' } },
+  {
+    contactId: 'e2e-bob',
+    firstName: 'Bob',
+    email: 'bob@example.com',
+    mobileE164: '+61400000002',
+    city: 'Melbourne',
+    source: 'google',
+    derivedStage: 'lead',
+    consent: { marketing: { granted: false } },
+  },
+)
+
+await ensure(
+  'contacts',
+  { contactId: { equals: 'e2e-carol' } },
+  {
+    contactId: 'e2e-carol',
+    firstName: 'Carol',
+    mobileE164: '+61400000003',
+    city: 'Sydney',
+    source: 'referral',
+    derivedStage: 'waitlist',
+    batchId: 'e2e-batch-1',
+    needsReview: true,
+    attributes: { needs_review_reason: 'Possible duplicate' },
+  },
+)
+
+await ensure(
+  'feedback',
+  { feedbackId: { equals: 'e2e-fb-overdue' } },
+  {
+    feedbackId: 'e2e-fb-overdue',
+    contactIdString: 'e2e-alice',
+    feedbackType: 'complaint',
+    body: 'The repayment reminder SMS arrived at 3am. This kept happening for two weeks.',
+    status: 'new',
+    receivedAt: days(30),
+  },
+)
+
+await ensure(
+  'feedback',
+  { feedbackId: { equals: 'e2e-fb-new' } },
+  {
+    feedbackId: 'e2e-fb-new',
+    contactIdString: 'e2e-bob',
+    feedbackType: 'suggestion',
+    body: 'It would be great to see my repayment schedule in the app.',
+    status: 'new',
+    receivedAt: days(1),
+  },
+)
+
+await ensure(
+  'feedback',
+  { feedbackId: { equals: 'e2e-fb-resolved' } },
+  {
+    feedbackId: 'e2e-fb-resolved',
+    contactIdString: 'e2e-alice',
+    feedbackType: 'praise',
+    body: 'Signup was quick.',
+    status: 'resolved',
+    statusNote: 'Thanked the contact.',
+    receivedAt: days(5),
+  },
+)
+
+console.log('marketing e2e seed complete')
+process.exit(0)

--- a/tests/unit/ui/decision-banner.test.tsx
+++ b/tests/unit/ui/decision-banner.test.tsx
@@ -1,5 +1,18 @@
-import { describe, test, expect, afterEach } from 'vitest'
+import { describe, test, expect, afterEach, vi } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
+
+// Mock @payloadcms/ui (same pattern as ClearBlockButton.test) — importing the
+// real package pulls a .css file through Node's ESM loader, which jsdom tests
+// cannot load. DecisionBanner reaches it via ClearBlockButton's useAuth.
+// Readonly role: these tests cover the banner copy, not the clear-block
+// action, and the button's react-query tree needs a provider these renders
+// don't have (ClearBlockButton has its own dedicated test file).
+vi.mock('@payloadcms/ui', () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: 'ro-1', role: 'readonly' },
+  })),
+}))
+
 import { DecisionBanner } from '@/components/ConversationDetailView/DecisionBanner'
 import type { ConversationDetail } from '@/lib/schemas/conversations'
 

--- a/tests/unit/ui/servicing-view-layout.test.tsx
+++ b/tests/unit/ui/servicing-view-layout.test.tsx
@@ -35,6 +35,14 @@ const customer = {
   loanAccounts: [acc('over', { accountStatus: 'in_arrears' }), acc('paid', { accountStatus: 'paid_off' })],
 }
 
+// Mock @payloadcms/ui (same pattern as ClearBlockButton.test) — the real
+// package imports a .css file Node's ESM loader cannot handle in jsdom tests.
+vi.mock('@payloadcms/ui', () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: 'ops-1', role: 'operations' },
+  })),
+}))
+
 vi.mock('@/hooks/queries/useCustomer', () => ({
   useCustomer: () => ({ data: customer, isLoading: false, isError: false, isFetching: false, refetch: vi.fn() }),
 }))

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -6,7 +6,19 @@ import 'dotenv/config'
 // Add testing-library jest-dom matchers
 import '@testing-library/jest-dom/vitest'
 
-import { vi } from 'vitest'
+import { afterEach, vi } from 'vitest'
+
+// Unmount rendered components after EVERY test. Test files here mostly use
+// beforeEach(cleanup), which cleans before each test within a file but leaves
+// the file's LAST render mounted — and with the shared single-fork worker
+// that DOM leaks into the next file, causing order-dependent "found multiple
+// elements" failures. A global afterEach(cleanup) removes the whole class.
+// Guarded like scrollIntoView above so node-environment test files can share
+// this setup.
+if (typeof document !== 'undefined') {
+  const { cleanup } = await import('@testing-library/react')
+  afterEach(() => cleanup())
+}
 
 // Mock ResizeObserver for tests (not available in JSDOM)
 // Required by cmdk and other resize-aware libraries


### PR DESCRIPTION
## Summary

Until now only the Python event processor had CI (`event-processor-tests.yml`, path-filtered to `event-processor/**`) — nothing ran lint or the JS test suites on PRs. This adds `crm-ci.yml` with three jobs:

1. **eslint** — `pnpm lint`
2. **vitest (unit + integration)** — `pnpm test:int`; the existing globalSetup spins Postgres via testcontainers, which works on `ubuntu-latest`
3. **playwright (marketing module)** — runs `tests/e2e/marketing.e2e.spec.ts` against `pnpm dev` backed by a `postgres:16` service container, seeded by the new committed `tests/e2e/seed-marketing.ts` (idempotent, Local-API based; documents the fixtures the spec expects). Uploads the Playwright report on failure.

Both workflows are path-scoped so they don't double-run: this one ignores `event-processor/**`, the existing one only watches it.

Also fixes two test files that failed at import time and have therefore never been running: `decision-banner.test.tsx` and `servicing-view-layout.test.tsx` imported the real `@payloadcms/ui`, which pulls `ReactCrop.css` through Node's ESM loader (unloadable in jsdom). They now mock `@payloadcms/ui` exactly as `ClearBlockButton.test.tsx` and other suites already do — recovering 26 previously-skipped tests (1,990 total, all passing; one known pre-existing order-dependent flake noted below).

## Testing

- Full unit suite locally: 1,989/1,990 passing; the one failure (`bulk-waive-fee-drawer`) is order-dependent under `singleFork` and passes in isolation — pre-existing behaviour, unrelated to these changes
- The marketing e2e suite passed end-to-end against a locally provisioned Postgres + dev server before this PR (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4QVWyx1YCA45eSweChuRR

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4QVWyx1YCA45eSweChuRR)_