### PR TITLE
Period-close leftovers: anomaly severity styling, ack-hook contract, mapper tests, URL-addressable wizard (BTB-68/BTB-192)

### DIFF
--- a/src/components/PeriodCloseView/PeriodCloseWizard.tsx
+++ b/src/components/PeriodCloseView/PeriodCloseWizard.tsx
@@ -151,7 +151,14 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
   useEffect(() => {
     const stepParam = searchParams?.get('step')
     const periodParam = searchParams?.get('period')
+    if (!stepParam && !periodParam) {
+      // Normal fresh load — no deep link attempted, nothing to clean.
+      return
+    }
     if (!stepParam || !periodParam || !STEP_ORDER.includes(stepParam as WizardStep)) {
+      // Malformed/partial deep link (e.g. unknown step id) — don't leave
+      // garbage in the URL.
+      router.replace(pathname, { scroll: false })
       return
     }
 
@@ -190,23 +197,33 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
       return
     }
 
-    const expiresAt = stored.preview?.expiresAt
-    if (expiresAt && new Date(expiresAt).getTime() <= Date.now()) {
-      try {
-        sessionStorage.removeItem(key)
-      } catch {
-        // ignore
+    // Fail closed: a stored preview with a missing/unparsable expiresAt is
+    // treated as expired rather than silently restored as valid. Absence of
+    // a preview entirely (e.g. still on 'select') isn't an expiry concern.
+    if (stored.preview) {
+      const expiresAtMs = new Date(stored.preview.expiresAt ?? '').getTime()
+      if (Number.isNaN(expiresAtMs) || expiresAtMs <= Date.now()) {
+        try {
+          sessionStorage.removeItem(key)
+        } catch {
+          // ignore
+        }
+        toast.error('Your period close preview has expired. Please start again.')
+        router.replace(pathname, { scroll: false })
+        return
       }
-      toast.error('Your period close preview has expired. Please start again.')
-      router.replace(pathname, { scroll: false })
-      return
     }
 
     setPeriodDate(periodParam)
     if (stored.preview) setPreview(stored.preview)
-    if (stored.localAnomalies) {
+    if (stored.localAnomalies) setLocalAnomalies(stored.localAnomalies)
+    // Only arm the "skip the next resync" guard when we restored BOTH a
+    // preview and its localAnomalies together — otherwise the guard can get
+    // stuck armed (preview stays null/undefined so the sync effect's deps
+    // never change to consume it) and silently swallow the next *real*
+    // preview's anomaly resync, satisfying the ack gate without any acks.
+    if (stored.preview && stored.localAnomalies) {
       justRestoredAnomaliesRef.current = true
-      setLocalAnomalies(stored.localAnomalies)
     }
     setCurrentStep(stepParam as WizardStep)
     // Restore is a one-time mount effect — intentionally does not react to

--- a/src/components/PeriodCloseView/PeriodCloseWizard.tsx
+++ b/src/components/PeriodCloseView/PeriodCloseWizard.tsx
@@ -231,13 +231,15 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Calculate expected confirm text
+  // Calculate expected confirm text. Journals post on a movement basis
+  // computed live at finalization — the phrase says so explicitly rather
+  // than implying the reviewed balances above are what gets posted.
   const expectedConfirmText = useMemo(() => {
     if (!periodDate) return ''
     const date = new Date(periodDate)
     const month = date.toLocaleString('en-US', { month: 'short' }).toUpperCase()
     const year = date.getFullYear()
-    return `CLOSE ${month} ${year}`
+    return `I CONFIRM FINALIZATION OF PERIOD ${month} ${year}; JOURNALS WILL POST ON A MOVEMENT BASIS`
   }, [periodDate])
 
   // Validation
@@ -748,8 +750,11 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
               </div>
             </div>
 
-            {/* Summary */}
+            {/* Closing balances — these are the preview snapshot for review only.
+                The ledger computes movement-basis journals live at finalize,
+                so these are NOT the amounts that will be posted. */}
             <div className={styles.finalSummary}>
+              <h4 className={styles.sectionTitle}>Closing balances (for review — not the posted amounts)</h4>
               <div className={styles.summaryRow}>
                 <span>Total ECL Allowance:</span>
                 <strong>{formatCurrency(preview.totalECLAllowance)}</strong>
@@ -764,30 +769,24 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
               </div>
             </div>
 
-            {/* Journal Entries Preview */}
-            {preview.journalEntries && preview.journalEntries.length > 0 && (
-              <div className={styles.section}>
-                <h4 className={styles.sectionTitle}>Journal Entries to Generate</h4>
-                <table className={styles.table}>
-                  <thead>
-                    <tr>
-                      <th>Type</th>
-                      <th>Description</th>
-                      <th className={styles.numericCol}>Amount</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {preview.journalEntries.map((entry, idx) => (
-                      <tr key={idx}>
-                        <td>{entry.type}</td>
-                        <td>{entry.description}</td>
-                        <td className={styles.numericCol}>{formatCurrency(entry.amount)}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+            {/* What will actually post: the ECL provision movement, computed
+                live at finalization (movement-basis journals), not the
+                closing balances above. */}
+            <div className={styles.section}>
+              <h4 className={styles.sectionTitle}>To be posted (movement basis)</h4>
+              <div className={styles.summaryRow}>
+                <span>ECL provision movement ({(preview.eclChange ?? 0) >= 0 ? 'charge' : 'release'}):</span>
+                <strong
+                  className={(preview.eclChange ?? 0) >= 0 ? styles.changePositive : styles.changeNegative}
+                >
+                  {formatCurrency(Math.abs(preview.eclChange ?? 0))}
+                </strong>
               </div>
-            )}
+              <p className={styles.notes}>
+                Final amounts are computed at finalization from live state; write-off utilisation and
+                late-arrival accruals may adjust them.
+              </p>
+            </div>
 
             {/* Type to Confirm */}
             <div className={styles.confirmSection}>

--- a/src/components/PeriodCloseView/PeriodCloseWizard.tsx
+++ b/src/components/PeriodCloseView/PeriodCloseWizard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { useState, useCallback, useMemo, useEffect } from 'react'
+import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { toast } from 'sonner'
 import { formatCurrency } from '@/lib/formatters'
 import { useClosedPeriods } from '@/hooks/queries/useClosedPeriods'
@@ -22,6 +23,12 @@ const STEPS: { id: WizardStep; label: string; number: number }[] = [
   { id: 'anomalies', label: 'Anomaly Review', number: 4 },
   { id: 'finalize', label: 'Finalize', number: 5 },
 ]
+
+/** Linear step order derived from STEPS — single source of truth for goNext/goBack. */
+const STEP_ORDER: WizardStep[] = STEPS.map((step) => step.id)
+
+/** sessionStorage key for a period's in-progress wizard state (BTB-192 session resume). */
+const storageKeyFor = (period: string) => `periodClose:${period}`
 
 export interface PeriodCloseWizardProps {
   /** Current user ID for audit trail */
@@ -61,8 +68,17 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
   const { acknowledgeAnomaly, isPending: isAcknowledging } = useAcknowledgeAnomaly()
   const { finalizePeriodClose, isPending: isFinalizing, error: finalizeError } = useFinalizePeriodClose()
 
+  // Set when a session restore explicitly restores localAnomalies, so the
+  // sync-from-preview effect below doesn't immediately clobber restored
+  // acknowledgments with the original (unacknowledged) preview.anomalies.
+  const justRestoredAnomaliesRef = useRef(false)
+
   // Sync local anomalies when preview changes
   useEffect(() => {
+    if (justRestoredAnomaliesRef.current) {
+      justRestoredAnomaliesRef.current = false
+      return
+    }
     if (preview?.anomalies) {
       setLocalAnomalies(preview.anomalies)
     }
@@ -92,6 +108,111 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
     const interval = setInterval(updateTimer, 60_000)
     return () => clearInterval(interval)
   }, [preview?.expiresAt])
+
+  // URL + session resume (BTB-192): step/period are reflected in the query
+  // string (never preview data — privacy rule: no data in query strings)
+  // and the wizard's in-progress state is mirrored to sessionStorage so
+  // navigating away and back resumes where the operator left off.
+  const pathname = usePathname()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const goToStep = useCallback(
+    (step: WizardStep) => {
+      setCurrentStep(step)
+      if (step === 'success' || !periodDate) {
+        router.replace(pathname, { scroll: false })
+        return
+      }
+      const qs = new URLSearchParams({ step, period: periodDate }).toString()
+      router.replace(`${pathname}?${qs}`, { scroll: false })
+    },
+    [periodDate, pathname, router]
+  )
+
+  // Persist wizard state on every change. The 'success' step means the
+  // close is complete — nothing left to resume — so drop the entry instead
+  // of writing it.
+  useEffect(() => {
+    if (!periodDate) return
+    const key = storageKeyFor(periodDate)
+    if (currentStep === 'success') {
+      sessionStorage.removeItem(key)
+      return
+    }
+    try {
+      sessionStorage.setItem(key, JSON.stringify({ currentStep, preview, localAnomalies, periodDate }))
+    } catch {
+      // sessionStorage unavailable/full — resume just won't be offered.
+    }
+  }, [periodDate, currentStep, preview, localAnomalies])
+
+  // Restore once on mount, only when the URL carries a step+period pair.
+  useEffect(() => {
+    const stepParam = searchParams?.get('step')
+    const periodParam = searchParams?.get('period')
+    if (!stepParam || !periodParam || !STEP_ORDER.includes(stepParam as WizardStep)) {
+      return
+    }
+
+    const key = storageKeyFor(periodParam)
+    let raw: string | null = null
+    try {
+      raw = sessionStorage.getItem(key)
+    } catch {
+      raw = null
+    }
+
+    if (!raw) {
+      router.replace(pathname, { scroll: false })
+      return
+    }
+
+    let stored: {
+      currentStep?: WizardStep
+      preview?: PeriodClosePreview | null
+      localAnomalies?: PeriodCloseAnomaly[]
+      periodDate?: string
+    } | null = null
+    try {
+      stored = JSON.parse(raw)
+    } catch {
+      stored = null
+    }
+
+    if (!stored) {
+      try {
+        sessionStorage.removeItem(key)
+      } catch {
+        // ignore
+      }
+      router.replace(pathname, { scroll: false })
+      return
+    }
+
+    const expiresAt = stored.preview?.expiresAt
+    if (expiresAt && new Date(expiresAt).getTime() <= Date.now()) {
+      try {
+        sessionStorage.removeItem(key)
+      } catch {
+        // ignore
+      }
+      toast.error('Your period close preview has expired. Please start again.')
+      router.replace(pathname, { scroll: false })
+      return
+    }
+
+    setPeriodDate(periodParam)
+    if (stored.preview) setPreview(stored.preview)
+    if (stored.localAnomalies) {
+      justRestoredAnomaliesRef.current = true
+      setLocalAnomalies(stored.localAnomalies)
+    }
+    setCurrentStep(stepParam as WizardStep)
+    // Restore is a one-time mount effect — intentionally does not react to
+    // later changes in searchParams/pathname/router.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Calculate expected confirm text
   const expectedConfirmText = useMemo(() => {
@@ -160,11 +281,11 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
         requestedBy: userId,
       })
       setPreview(result)
-      setCurrentStep('preview')
+      goToStep('preview')
     } catch {
       // Error handled by mutation
     }
-  }, [periodDate, periodError, generatePreview, userId, resetPreview])
+  }, [periodDate, periodError, generatePreview, userId, resetPreview, goToStep])
 
   const handleAcknowledge = useCallback(
     async (anomalyId: string) => {
@@ -210,11 +331,11 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
         })),
         finalizedAt: result.finalizedAt,
       })
-      setCurrentStep('success')
+      goToStep('success')
     } catch {
       // Error handled by mutation
     }
-  }, [preview, confirmText, expectedConfirmText, finalizePeriodClose, userId])
+  }, [preview, confirmText, expectedConfirmText, finalizePeriodClose, userId, goToStep])
 
   const handleStartNew = useCallback(() => {
     setCurrentStep('select')
@@ -223,7 +344,10 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
     setLocalAnomalies([])
     setConfirmText('')
     setFinalizeResult(null)
-  }, [])
+    // Defensive: the 'success' step transition already strips the query
+    // params, but a full reset should never leave a stale URL behind.
+    router.replace(pathname, { scroll: false })
+  }, [pathname, router])
 
   // Navigation
   const canProceed = useMemo(() => {
@@ -244,20 +368,18 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
   }, [currentStep, periodDate, periodError, preview, localAnomalies, confirmText, expectedConfirmText])
 
   const goNext = useCallback(() => {
-    const stepOrder: WizardStep[] = ['select', 'preview', 'movement', 'anomalies', 'finalize']
-    const currentIndex = stepOrder.indexOf(currentStep)
-    if (currentIndex < stepOrder.length - 1) {
-      setCurrentStep(stepOrder[currentIndex + 1])
+    const currentIndex = STEP_ORDER.indexOf(currentStep)
+    if (currentIndex < STEP_ORDER.length - 1) {
+      goToStep(STEP_ORDER[currentIndex + 1])
     }
-  }, [currentStep])
+  }, [currentStep, goToStep])
 
   const goBack = useCallback(() => {
-    const stepOrder: WizardStep[] = ['select', 'preview', 'movement', 'anomalies', 'finalize']
-    const currentIndex = stepOrder.indexOf(currentStep)
+    const currentIndex = STEP_ORDER.indexOf(currentStep)
     if (currentIndex > 0) {
-      setCurrentStep(stepOrder[currentIndex - 1])
+      goToStep(STEP_ORDER[currentIndex - 1])
     }
-  }, [currentStep])
+  }, [currentStep, goToStep])
 
   // Render step content
   const renderStepContent = () => {

--- a/src/components/PeriodCloseView/styles.module.css
+++ b/src/components/PeriodCloseView/styles.module.css
@@ -429,6 +429,14 @@
   border-left: 4px solid var(--theme-elevation-200, #333);
 }
 
+.anomalyCard.severityinfo {
+  border-left-color: #60a5fa;
+}
+
+.anomalyCard.severitywarning {
+  border-left-color: #fbbf24;
+}
+
 .anomalyCard.severitylow {
   border-left-color: #60a5fa;
 }
@@ -459,6 +467,16 @@
   padding: 0.125rem 0.5rem;
   border-radius: 4px;
   text-transform: uppercase;
+}
+
+.severityBadge.info {
+  background: rgba(96, 165, 250, 0.2);
+  color: #60a5fa;
+}
+
+.severityBadge.warning {
+  background: rgba(251, 191, 36, 0.2);
+  color: #fbbf24;
 }
 
 .severityBadge.low {

--- a/src/hooks/mutations/useAcknowledgeAnomaly.ts
+++ b/src/hooks/mutations/useAcknowledgeAnomaly.ts
@@ -8,8 +8,8 @@ interface AcknowledgeRequest {
 
 interface AcknowledgeResponse {
   success: boolean
-  anomalyId: string
-  acknowledgedAt: string
+  errorMessage?: string
+  allAnomaliesAcknowledged: boolean
 }
 
 /**
@@ -40,7 +40,11 @@ export function useAcknowledgeAnomaly() {
         const error = await res.json().catch(() => ({}))
         throw new Error(error.message || 'Failed to acknowledge anomaly')
       }
-      return res.json()
+      const body: AcknowledgeResponse = await res.json()
+      if (body.success === false) {
+        throw new Error(body.errorMessage || 'Failed to acknowledge anomaly')
+      }
+      return body
     },
   })
 

--- a/tests/unit/components/PeriodCloseWizard.finalize-movement.test.tsx
+++ b/tests/unit/components/PeriodCloseWizard.finalize-movement.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * PeriodCloseWizard — finalize step tells the truth about what will post
+ * (Task 28 / review finding F11).
+ *
+ * The finalize step used to have the operator confirm against "closing
+ * balances" that are not the posted amounts (the engine posts
+ * movement-basis journals computed at finalize) and rendered an
+ * always-empty "Journal Entries to Generate" table (the mapper hard-codes
+ * `journalEntries: []` on preview — real entries only exist post-finalize).
+ * This suite locks in the fix: the finalize step relabels the balance
+ * tiles as review-only, surfaces the actual movement-basis figure that will
+ * post (from `preview.eclChange`, already mapped from `eclMovement`), and
+ * drops the empty journal table. The post-finalize success screen (which
+ * renders the REAL entries from FinalizeResponse) is unchanged — covered
+ * here only by a regression test.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { toast } from 'sonner'
+import { PeriodCloseWizard } from '@/components/PeriodCloseView/PeriodCloseWizard'
+import { formatCurrency } from '@/lib/formatters'
+import type { PeriodClosePreview } from '@/hooks/mutations/usePeriodClosePreview'
+import type { FinalizeResponse } from '@/hooks/mutations/useFinalizePeriodClose'
+
+// ─── next/navigation ────────────────────────────────────────────────────
+const PATHNAME = '/admin/period-close'
+const mockReplace = vi.fn()
+const mockPush = vi.fn()
+const mockBack = vi.fn()
+let mockSearch = ''
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => PATHNAME,
+  useRouter: () => ({ replace: mockReplace, push: mockPush, back: mockBack }),
+  useSearchParams: () => new URLSearchParams(mockSearch),
+}))
+
+// ─── sonner ─────────────────────────────────────────────────────────────
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+// ─── Wizard's data hooks ────────────────────────────────────────────────
+const mockGeneratePreview = vi.fn()
+const mockAcknowledgeAnomaly = vi.fn()
+const mockFinalizePeriodClose = vi.fn()
+
+vi.mock('@/hooks/queries/useClosedPeriods', () => ({
+  useClosedPeriods: () => ({
+    data: { periods: [], lastClosedPeriod: undefined },
+    isLoading: false,
+    isFallback: false,
+    fallbackMessage: undefined,
+  }),
+}))
+
+vi.mock('@/hooks/mutations/usePeriodClosePreview', () => ({
+  usePeriodClosePreview: () => ({
+    generatePreview: mockGeneratePreview,
+    isPending: false,
+    error: null,
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/mutations/useAcknowledgeAnomaly', () => ({
+  useAcknowledgeAnomaly: () => ({
+    acknowledgeAnomaly: mockAcknowledgeAnomaly,
+    isPending: false,
+  }),
+}))
+
+vi.mock('@/hooks/mutations/useFinalizePeriodClose', () => ({
+  useFinalizePeriodClose: () => ({
+    finalizePeriodClose: mockFinalizePeriodClose,
+    isPending: false,
+    error: null,
+  }),
+}))
+
+const PERIOD = '2026-04-30'
+const FUTURE_EXPIRY = '2099-01-01T00:00:00.000Z'
+
+const buildPreview = (overrides: Partial<PeriodClosePreview> = {}): PeriodClosePreview => ({
+  previewId: 'preview-1',
+  periodDate: PERIOD,
+  expiresAt: FUTURE_EXPIRY,
+  status: 'ready',
+  totalAccounts: 10,
+  totalAccruedYield: 100,
+  totalECLAllowance: 200,
+  totalCarryingAmount: 900,
+  eclByBucket: [],
+  anomalies: [],
+  anomalyCount: 0,
+  acknowledgedCount: 0,
+  reconciled: true,
+  journalEntries: [],
+  ...overrides,
+})
+
+const storageKey = (period: string) => `periodClose:${period}`
+
+const seedFinalizeStep = (preview: PeriodClosePreview) => {
+  sessionStorage.setItem(
+    storageKey(PERIOD),
+    JSON.stringify({
+      currentStep: 'finalize',
+      preview,
+      localAnomalies: [],
+      periodDate: PERIOD,
+    })
+  )
+}
+
+const renderWizard = () => render(<PeriodCloseWizard userId="user-1" userName="Test User" />)
+
+beforeEach(() => {
+  sessionStorage.clear()
+  mockSearch = `step=finalize&period=${PERIOD}`
+  mockReplace.mockClear()
+  mockPush.mockClear()
+  mockBack.mockClear()
+  mockGeneratePreview.mockReset()
+  mockAcknowledgeAnomaly.mockReset()
+  mockFinalizePeriodClose.mockReset()
+  vi.mocked(toast.error).mockClear()
+})
+
+describe('PeriodCloseWizard — finalize step is honest about movement-basis posting (Task 28 / F11)', () => {
+  it('(a) relabels the closing balance tiles as review-only, not the posted amounts', async () => {
+    seedFinalizeStep(buildPreview())
+
+    renderWizard()
+
+    expect(
+      await screen.findByText('Closing balances (for review — not the posted amounts)')
+    ).toBeInTheDocument()
+  })
+
+  it('(b) shows the movement-basis ECL charge to be posted, from preview.eclChange, with the caveat line', async () => {
+    seedFinalizeStep(buildPreview({ eclChange: 500 }))
+
+    renderWizard()
+
+    expect(await screen.findByText('To be posted (movement basis)')).toBeInTheDocument()
+    expect(screen.getByText(/ECL provision movement \(charge\):/)).toBeInTheDocument()
+    expect(screen.getByText(formatCurrency(500))).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Final amounts are computed at finalization from live state; write-off utilisation and late-arrival accruals may adjust them.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('(b) labels a negative eclChange as a release, showing the absolute amount', async () => {
+    seedFinalizeStep(buildPreview({ eclChange: -300 }))
+
+    renderWizard()
+
+    expect(await screen.findByText(/ECL provision movement \(release\):/)).toBeInTheDocument()
+    expect(screen.getByText(formatCurrency(300))).toBeInTheDocument()
+  })
+
+  it('(c) never renders the "Journal Entries to Generate" table pre-finalize, even if preview.journalEntries is non-empty', async () => {
+    seedFinalizeStep(
+      buildPreview({
+        eclChange: 500,
+        journalEntries: [
+          {
+            type: 'ECL_CHARGE',
+            description: 'ECL provision movement',
+            debitAccount: 'ECL-EXPENSE',
+            creditAccount: 'ECL-ALLOWANCE',
+            amount: 500,
+          },
+        ],
+      })
+    )
+
+    renderWizard()
+
+    await screen.findByText('To be posted (movement basis)')
+    expect(screen.queryByText('Journal Entries to Generate')).not.toBeInTheDocument()
+  })
+
+  it('(d) the confirmation phrase states journals post on a movement basis, not that balances above are the posted amounts', async () => {
+    seedFinalizeStep(buildPreview())
+
+    const { container } = renderWizard()
+
+    await screen.findByText('To be posted (movement basis)')
+    const code = container.querySelector('code')
+    expect(code?.textContent).toMatch(/^I CONFIRM FINALIZATION OF PERIOD .+; JOURNALS WILL POST ON A MOVEMENT BASIS$/)
+  })
+
+  it('regression: the post-finalize success screen still renders the REAL journal entries from FinalizeResponse', async () => {
+    seedFinalizeStep(buildPreview({ eclChange: 500 }))
+
+    const finalizeResponse: FinalizeResponse = {
+      success: true,
+      periodDate: PERIOD,
+      finalizedAt: '2026-05-01T00:00:00.000Z',
+      totalAccounts: 10,
+      totalECLAllowance: 200,
+      totalAccruedYield: 100,
+      journalEntries: [
+        {
+          id: 'je-1',
+          type: 'ECL_CHARGE',
+          description: 'ECL provision movement',
+          debitAccount: 'ECL-EXPENSE',
+          creditAccount: 'ECL-ALLOWANCE',
+          amount: 500,
+          createdAt: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+    }
+    mockFinalizePeriodClose.mockResolvedValueOnce(finalizeResponse)
+
+    const { container } = renderWizard()
+
+    await screen.findByText('To be posted (movement basis)')
+    const code = container.querySelector('code')
+    expect(code?.textContent).toBeTruthy()
+
+    const confirmInput = screen.getByTestId('confirm-input')
+    fireEvent.change(confirmInput, { target: { value: code!.textContent as string } })
+
+    const finalizeBtn = await screen.findByTestId('finalize-btn')
+    await waitFor(() => expect(finalizeBtn).not.toBeDisabled())
+    fireEvent.click(finalizeBtn)
+
+    expect(await screen.findByRole('heading', { name: 'Period Close Complete' })).toBeInTheDocument()
+    expect(screen.getByText('Generated Journal Entries')).toBeInTheDocument()
+    expect(screen.getByText(`ECL_CHARGE: ${formatCurrency(500)}`)).toBeInTheDocument()
+  })
+})

--- a/tests/unit/components/PeriodCloseWizard.step-url.test.tsx
+++ b/tests/unit/components/PeriodCloseWizard.step-url.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * PeriodCloseWizard — URL-addressable step + sessionStorage resume (BTB-192).
+ *
+ * Navigating away from the wizard (e.g. to check something else in the CRM)
+ * used to lose all progress. The wizard now reflects `step` + `period` in
+ * the URL query string via `router.replace` (shallow, no data — privacy
+ * rule: no data in query strings) and mirrors its in-progress state
+ * (preview JSON + current step + localAnomalies) to sessionStorage under
+ * `periodClose:{period}`, so returning to the same URL resumes where the
+ * operator left off.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import React from 'react'
+import { toast } from 'sonner'
+import { PeriodCloseWizard } from '@/components/PeriodCloseView/PeriodCloseWizard'
+import type {
+  PeriodClosePreview,
+  PeriodCloseAnomaly,
+} from '@/hooks/mutations/usePeriodClosePreview'
+
+// ─── next/navigation ────────────────────────────────────────────────────
+// vitest.setup.ts globally mocks next/navigation with fresh vi.fn()s per
+// call (fine for components that don't assert on router calls). This
+// wizard needs to assert on router.replace, so it overrides with a stable
+// mock object + a mutable search string the individual tests can seed.
+const PATHNAME = '/admin/period-close'
+const mockReplace = vi.fn()
+const mockPush = vi.fn()
+const mockBack = vi.fn()
+let mockSearch = ''
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => PATHNAME,
+  useRouter: () => ({ replace: mockReplace, push: mockPush, back: mockBack }),
+  useSearchParams: () => new URLSearchParams(mockSearch),
+}))
+
+// ─── sonner ─────────────────────────────────────────────────────────────
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+// ─── Wizard's data hooks ────────────────────────────────────────────────
+const mockGeneratePreview = vi.fn()
+const mockAcknowledgeAnomaly = vi.fn()
+const mockFinalizePeriodClose = vi.fn()
+
+vi.mock('@/hooks/queries/useClosedPeriods', () => ({
+  useClosedPeriods: () => ({
+    data: { periods: [], lastClosedPeriod: undefined },
+    isLoading: false,
+    isFallback: false,
+    fallbackMessage: undefined,
+  }),
+}))
+
+vi.mock('@/hooks/mutations/usePeriodClosePreview', () => ({
+  usePeriodClosePreview: () => ({
+    generatePreview: mockGeneratePreview,
+    isPending: false,
+    error: null,
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/mutations/useAcknowledgeAnomaly', () => ({
+  useAcknowledgeAnomaly: () => ({
+    acknowledgeAnomaly: mockAcknowledgeAnomaly,
+    isPending: false,
+  }),
+}))
+
+vi.mock('@/hooks/mutations/useFinalizePeriodClose', () => ({
+  useFinalizePeriodClose: () => ({
+    finalizePeriodClose: mockFinalizePeriodClose,
+    isPending: false,
+    error: null,
+  }),
+}))
+
+const PERIOD = '2026-04-30'
+const FUTURE_EXPIRY = '2099-01-01T00:00:00.000Z'
+const PAST_EXPIRY = '2000-01-01T00:00:00.000Z'
+
+const ANOMALY: PeriodCloseAnomaly = {
+  anomalyId: 'anom-1',
+  anomalyType: 'BALANCE_MISMATCH',
+  severity: 'high',
+  accountId: 'acc-1',
+  description: 'Balance mismatch detected',
+  acknowledged: false,
+}
+
+const buildPreview = (overrides: Partial<PeriodClosePreview> = {}): PeriodClosePreview => ({
+  previewId: 'preview-1',
+  periodDate: PERIOD,
+  expiresAt: FUTURE_EXPIRY,
+  status: 'ready',
+  totalAccounts: 10,
+  totalAccruedYield: 100,
+  totalECLAllowance: 200,
+  totalCarryingAmount: 900,
+  eclByBucket: [],
+  anomalies: [ANOMALY],
+  anomalyCount: 1,
+  acknowledgedCount: 0,
+  reconciled: true,
+  journalEntries: [],
+  ...overrides,
+})
+
+const storageKey = (period: string) => `periodClose:${period}`
+
+const seedStorage = (overrides: Record<string, unknown> = {}) => {
+  sessionStorage.setItem(
+    storageKey(PERIOD),
+    JSON.stringify({
+      currentStep: 'anomalies',
+      preview: buildPreview(),
+      localAnomalies: [ANOMALY],
+      periodDate: PERIOD,
+      ...overrides,
+    })
+  )
+}
+
+const renderWizard = () => render(<PeriodCloseWizard userId="user-1" userName="Test User" />)
+
+beforeEach(() => {
+  sessionStorage.clear()
+  mockSearch = ''
+  mockReplace.mockClear()
+  mockPush.mockClear()
+  mockBack.mockClear()
+  mockGeneratePreview.mockReset()
+  mockAcknowledgeAnomaly.mockReset()
+  mockFinalizePeriodClose.mockReset()
+  vi.mocked(toast.error).mockClear()
+})
+
+describe('PeriodCloseWizard — URL-addressable step + session resume (BTB-192)', () => {
+  it('(a) mounts on the Anomaly Review step when the URL and sessionStorage agree', async () => {
+    mockSearch = `step=anomalies&period=${PERIOD}`
+    seedStorage()
+
+    renderWizard()
+
+    expect(await screen.findByRole('heading', { name: 'Anomaly Review' })).toBeInTheDocument()
+    expect(screen.getByText('Balance mismatch detected')).toBeInTheDocument()
+  })
+
+  it('(b) falls back to Select Period when the URL has step+period but no matching sessionStorage entry', async () => {
+    mockSearch = `step=anomalies&period=${PERIOD}`
+    // No sessionStorage seeded.
+
+    renderWizard()
+
+    expect(await screen.findByLabelText('Select Period End Date')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Anomaly Review' })).not.toBeInTheDocument()
+
+    // URL is cleaned (no leftover step/period query params).
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith(PATHNAME, { scroll: false }))
+  })
+
+  it('(c) advancing a step rewrites the query string', async () => {
+    mockSearch = ''
+    mockGeneratePreview.mockResolvedValueOnce(buildPreview())
+
+    renderWizard()
+
+    const select = screen.getByTestId('period-select') as HTMLSelectElement
+    const periodOption = Array.from(select.querySelectorAll('option')).find(
+      (opt) => opt.value && !opt.hasAttribute('disabled')
+    ) as HTMLOptionElement
+    expect(periodOption).toBeTruthy()
+    const periodValue = periodOption.value
+
+    fireEvent.change(select, { target: { value: periodValue } })
+
+    const generateBtn = await screen.findByTestId('generate-preview-btn')
+    await waitFor(() => expect(generateBtn).not.toBeDisabled())
+    fireEvent.click(generateBtn)
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(
+        `${PATHNAME}?step=preview&period=${encodeURIComponent(periodValue)}`,
+        { scroll: false }
+      )
+    })
+  })
+
+  it('(d) clears sessionStorage and lands on Select Period when the stored preview has expired', async () => {
+    mockSearch = `step=anomalies&period=${PERIOD}`
+    seedStorage({ preview: buildPreview({ expiresAt: PAST_EXPIRY }) })
+
+    renderWizard()
+
+    expect(await screen.findByLabelText('Select Period End Date')).toBeInTheDocument()
+    expect(sessionStorage.getItem(storageKey(PERIOD))).toBeNull()
+    expect(toast.error).toHaveBeenCalled()
+  })
+
+  it('preserves acknowledged anomalies on restore (does not revert to the original preview.anomalies)', async () => {
+    mockSearch = `step=anomalies&period=${PERIOD}`
+    const acknowledged: PeriodCloseAnomaly = {
+      ...ANOMALY,
+      acknowledged: true,
+      acknowledgedBy: 'Test User',
+      acknowledgedAt: '2026-04-29T00:00:00.000Z',
+    }
+    seedStorage({ localAnomalies: [acknowledged] })
+
+    renderWizard()
+
+    expect(await screen.findByText(/Acknowledged by Test User/)).toBeInTheDocument()
+  })
+})

--- a/tests/unit/components/PeriodCloseWizard.step-url.test.tsx
+++ b/tests/unit/components/PeriodCloseWizard.step-url.test.tsx
@@ -215,4 +215,134 @@ describe('PeriodCloseWizard — URL-addressable step + session resume (BTB-192)'
 
     expect(await screen.findByText(/Acknowledged by Test User/)).toBeInTheDocument()
   })
+
+  it('regression: a restored preview:null/localAnomalies:[] snapshot must not swallow the next real preview\'s anomaly resync (ack gate stays honest)', async () => {
+    // Reproduces the reviewer-found bug: restoring from a 'select'-step
+    // snapshot (no preview generated yet) used to arm the "skip next
+    // resync" guard on an empty localAnomalies array. When a real preview
+    // with anomalies was then generated, the sync effect's one-shot skip
+    // consumed itself on that resync instead of populating localAnomalies —
+    // leaving it empty (and the un-acknowledged-anomaly gate silently
+    // satisfied) even though the preview had a real, unacknowledged anomaly.
+    mockSearch = `step=select&period=${PERIOD}`
+    sessionStorage.setItem(
+      storageKey(PERIOD),
+      JSON.stringify({ currentStep: 'select', preview: null, localAnomalies: [], periodDate: PERIOD })
+    )
+    mockGeneratePreview.mockResolvedValueOnce(buildPreview({ anomalies: [ANOMALY], anomalyCount: 1 }))
+
+    renderWizard()
+
+    // Restored onto 'select' with the period already chosen from storage.
+    const generateBtn = await screen.findByTestId('generate-preview-btn')
+    await waitFor(() => expect(generateBtn).not.toBeDisabled())
+    fireEvent.click(generateBtn)
+
+    // preview step
+    let continueBtn = await screen.findByRole('button', { name: 'Continue →' })
+    await waitFor(() => expect(continueBtn).not.toBeDisabled())
+    fireEvent.click(continueBtn)
+
+    // movement step
+    continueBtn = await screen.findByRole('button', { name: 'Continue →' })
+    await waitFor(() => expect(continueBtn).not.toBeDisabled())
+    fireEvent.click(continueBtn)
+
+    // anomalies step — the real preview's anomaly must render...
+    expect(await screen.findByText('Balance mismatch detected')).toBeInTheDocument()
+    expect(screen.getByText('Acknowledged: 0 of 1')).toBeInTheDocument()
+
+    // ...and the ack gate must NOT be silently satisfied by the stale
+    // (empty) restored localAnomalies.
+    continueBtn = screen.getByRole('button', { name: 'Continue →' })
+    expect(continueBtn).toBeDisabled()
+  })
+
+  it('(low-1) cleans the URL when the query carries an unrecognized step id', async () => {
+    mockSearch = `step=bogus&period=${PERIOD}`
+
+    renderWizard()
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith(PATHNAME, { scroll: false }))
+  })
+
+  it('(low-2a) treats an unparsable expiresAt on a stored preview as expired (fail closed)', async () => {
+    mockSearch = `step=anomalies&period=${PERIOD}`
+    seedStorage({ preview: buildPreview({ expiresAt: 'not-a-real-date' }) })
+
+    renderWizard()
+
+    expect(await screen.findByLabelText('Select Period End Date')).toBeInTheDocument()
+    expect(sessionStorage.getItem(storageKey(PERIOD))).toBeNull()
+    expect(toast.error).toHaveBeenCalled()
+  })
+
+  it('(low-2b) treats a missing expiresAt on a stored preview as expired (fail closed)', async () => {
+    mockSearch = `step=anomalies&period=${PERIOD}`
+    // JSON.stringify drops keys whose value is `undefined`, so this
+    // genuinely omits expiresAt from the serialized preview — simulating a
+    // corrupted/older storage entry rather than merely setting it falsy.
+    const previewMissingExpiry = { ...buildPreview(), expiresAt: undefined }
+    sessionStorage.setItem(
+      storageKey(PERIOD),
+      JSON.stringify({
+        currentStep: 'anomalies',
+        preview: previewMissingExpiry,
+        localAnomalies: [ANOMALY],
+        periodDate: PERIOD,
+      })
+    )
+
+    renderWizard()
+
+    expect(await screen.findByLabelText('Select Period End Date')).toBeInTheDocument()
+    expect(sessionStorage.getItem(storageKey(PERIOD))).toBeNull()
+    expect(toast.error).toHaveBeenCalled()
+  })
+
+  it('(low-3) persists the expected shape to sessionStorage after advancing a step', async () => {
+    mockSearch = ''
+    const preview = buildPreview()
+    mockGeneratePreview.mockResolvedValueOnce(preview)
+
+    renderWizard()
+
+    const select = screen.getByTestId('period-select') as HTMLSelectElement
+    const periodOption = Array.from(select.querySelectorAll('option')).find(
+      (opt) => opt.value && !opt.hasAttribute('disabled')
+    ) as HTMLOptionElement
+    expect(periodOption).toBeTruthy()
+    const periodValue = periodOption.value
+
+    fireEvent.change(select, { target: { value: periodValue } })
+
+    const generateBtn = await screen.findByTestId('generate-preview-btn')
+    await waitFor(() => expect(generateBtn).not.toBeDisabled())
+    fireEvent.click(generateBtn)
+
+    // Wait for the transition to the 'preview' step to land.
+    await screen.findByRole('button', { name: 'Continue →' })
+
+    // The preview → localAnomalies sync runs in its own effect pass (one
+    // render behind the step transition), so poll rather than reading
+    // sessionStorage on the first write.
+    await waitFor(() => {
+      const raw = sessionStorage.getItem(storageKey(periodValue))
+      expect(raw).toBeTruthy()
+      const parsed = JSON.parse(raw as string)
+      expect(parsed.localAnomalies).toHaveLength(1)
+    })
+
+    const raw = sessionStorage.getItem(storageKey(periodValue))
+    const parsed = JSON.parse(raw as string)
+    expect(parsed).toMatchObject({
+      currentStep: 'preview',
+      periodDate: periodValue,
+      localAnomalies: [ANOMALY],
+    })
+    expect(parsed.preview).toMatchObject({
+      previewId: preview.previewId,
+      anomalyCount: preview.anomalyCount,
+    })
+  })
 })

--- a/tests/unit/hooks/useAcknowledgeAnomaly.test.tsx
+++ b/tests/unit/hooks/useAcknowledgeAnomaly.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useAcknowledgeAnomaly } from '@/hooks/mutations/useAcknowledgeAnomaly'
+
+// Mock fetch
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+// Create wrapper with QueryClient
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useAcknowledgeAnomaly', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('resolves when the gRPC response reports success', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true, allAnomaliesAcknowledged: false }),
+    })
+
+    const { result } = renderHook(() => useAcknowledgeAnomaly(), {
+      wrapper: createWrapper(),
+    })
+
+    let response: any
+    await act(async () => {
+      response = await result.current.acknowledgeAnomaly({
+        previewId: 'preview-123',
+        anomalyId: 'anomaly-1',
+        acknowledgedBy: 'user-1',
+      })
+    })
+
+    expect(response).toEqual({ success: true, allAnomaliesAcknowledged: false })
+  })
+
+  it('rejects with the gRPC errorMessage when the response reports success: false', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: false,
+          errorMessage: 'Preview not found or expired',
+          allAnomaliesAcknowledged: false,
+        }),
+    })
+
+    const { result } = renderHook(() => useAcknowledgeAnomaly(), {
+      wrapper: createWrapper(),
+    })
+
+    await expect(
+      act(async () => {
+        await result.current.acknowledgeAnomaly({
+          previewId: 'preview-123',
+          anomalyId: 'anomaly-1',
+          acknowledgedBy: 'user-1',
+        })
+      })
+    ).rejects.toThrow('Preview not found or expired')
+  })
+
+  it('rejects when the HTTP response is non-2xx', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ message: 'Internal server error' }),
+    })
+
+    const { result } = renderHook(() => useAcknowledgeAnomaly(), {
+      wrapper: createWrapper(),
+    })
+
+    await expect(
+      act(async () => {
+        await result.current.acknowledgeAnomaly({
+          previewId: 'preview-123',
+          anomalyId: 'anomaly-1',
+          acknowledgedBy: 'user-1',
+        })
+      })
+    ).rejects.toThrow('Internal server error')
+  })
+})

--- a/tests/unit/server/period-close-mapper.test.ts
+++ b/tests/unit/server/period-close-mapper.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Regression tests for src/server/period-close-mapper.ts — the gRPC → CRM
+ * mapper whose casing bug produced the original BTB-68 "$NaN" symptom on the
+ * period-close preview screen (totals rendered as NaN because the mapper read
+ * snake_case-ish/renamed fields that the gRPC response never had).
+ *
+ * These tests are regression armor for the already-shipped fix (commit
+ * 9df8b02), written after the fact — see commit body for why the red phase
+ * is intentionally skipped here.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type { Payload } from 'payload'
+import { mapPreviewResponse, mapFinalizeResponse } from '@/server/period-close-mapper'
+
+/** Minimal mock matching the shape mapPreviewResponse actually calls: payload.find(...). */
+function mockPayload(docs: any[] = []): Payload {
+  return {
+    find: vi.fn().mockResolvedValue({ docs }),
+  } as unknown as Payload
+}
+
+describe('mapPreviewResponse', () => {
+  it('maps a full realistic camelCase gRPC preview response', async () => {
+    const grpcResponse = {
+      previewId: 'prev_abc123',
+      periodDate: '2026-01-31',
+      expiresAt: '2026-01-31T14:00:00Z',
+      totalAccounts: 42,
+      totalAccruedYield: '1234.56',
+      totalEclAllowance: '9876.54',
+      totalCarryingAmount: '500000.00',
+      eclByBucket: [
+        {
+          bucket: 'current',
+          accountCount: 30,
+          totalEcl: '1000.00',
+          totalCarryingAmount: '400000.00',
+          averagePdRate: '0.0125',
+        },
+        {
+          bucket: '30-59',
+          accountCount: 12,
+          totalEcl: '8876.54',
+          totalCarryingAmount: '100000.00',
+          averagePdRate: '0.085',
+        },
+      ],
+      eclMovement: {
+        priorTotalEcl: '9000.00',
+        netChange: '876.54',
+        changePercent: '9.74',
+        byCause: [
+          { cause: 'aging_migration', amount: '600.00' },
+          { cause: 'new_originations', amount: '276.54' },
+        ],
+        byBucket: [
+          { bucket: 'current', accountsEntered: 5, accountsExited: 2, netChange: '150.00' },
+          { bucket: '30-59', accountsEntered: 2, accountsExited: 1, netChange: '726.54' },
+        ],
+      },
+      reconciliation: {
+        isReconciled: true,
+        expectedTotal: '9876.54',
+        actualTotal: '9876.54',
+      },
+      anomalies: [
+        {
+          anomalyId: 'anom_1',
+          anomalyType: 'ecl_spike',
+          severity: 'high',
+          accountId: 'acc_1',
+          accountNumber: 'LN-1001',
+          description: 'ECL increased by more than 50% period over period',
+          acknowledged: false,
+        },
+        {
+          anomalyId: 'anom_2',
+          anomalyType: 'pd_outlier',
+          severity: 'medium',
+          accountId: 'acc_2',
+          accountNumber: 'LN-1002',
+          description: 'PD rate outside expected range',
+          acknowledged: true,
+          acknowledgedBy: 'user_ops1',
+          acknowledgedAt: '2026-01-31T13:00:00Z',
+        },
+      ],
+    }
+
+    const payload = mockPayload()
+    const result = await mapPreviewResponse(grpcResponse, payload)
+
+    expect(result.previewId).toBe('prev_abc123')
+    expect(result.periodDate).toBe('2026-01-31')
+    expect(result.expiresAt).toBe('2026-01-31T14:00:00Z')
+    expect(result.status).toBe('ready')
+    expect(result.totalAccounts).toBe(42)
+    expect(result.totalAccruedYield).toBe(1234.56)
+    expect(result.totalECLAllowance).toBe(9876.54)
+    expect(result.totalCarryingAmount).toBe(500000.0)
+
+    expect(result.eclByBucket).toEqual([
+      { bucket: 'current', accountCount: 30, eclAmount: 1000.0, carryingAmount: 400000.0, pdRate: 0.0125 },
+      { bucket: '30-59', accountCount: 12, eclAmount: 8876.54, carryingAmount: 100000.0, pdRate: 0.085 },
+    ])
+
+    expect(result.priorPeriodECL).toBe(9000.0)
+    expect(result.eclChange).toBe(876.54)
+    expect(result.eclChangePercent).toBe(9.74)
+    expect(result.movementByCause).toEqual([
+      { cause: 'aging_migration', amount: 600.0, accountCount: 0 },
+      { cause: 'new_originations', amount: 276.54, accountCount: 0 },
+    ])
+    expect(result.movementByBucket).toEqual([
+      { bucket: 'current', inCount: 5, outCount: 2, netChange: 150.0 },
+      { bucket: '30-59', inCount: 2, outCount: 1, netChange: 726.54 },
+    ])
+
+    expect(result.reconciled).toBe(true)
+    expect(result.reconciliationNotes).toBeUndefined()
+    expect(result.journalEntries).toEqual([])
+
+    expect(result.anomalyCount).toBe(2)
+    expect(result.acknowledgedCount).toBe(1)
+    expect(result.anomalies).toHaveLength(2)
+    expect(result.anomalies[0]).toMatchObject({
+      anomalyId: 'anom_1',
+      anomalyType: 'ecl_spike',
+      severity: 'high',
+      acknowledged: false,
+    })
+
+    // No matching docs were returned by payload.find, so enrichment leaves
+    // customerIdString undefined rather than throwing.
+    expect(result.anomalies[0].customerIdString).toBeUndefined()
+    expect(payload.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'loan-accounts',
+        where: { loanAccountId: { in: ['acc_1', 'acc_2'] } },
+      }),
+    )
+  })
+
+  it('defaults numeric fields to 0, reconciled to false, and anomalies to [] for an empty/missing-field response', async () => {
+    // This documents the num() zero-fallback behavior: num() treats any
+    // non-finite parse (missing field, wrong casing, unexpected type) as 0,
+    // not NaN. That's what closed the original BTB-68 "$NaN" bug — but it is
+    // also the known residual risk flagged in review: a future field-name/
+    // casing drift between the gRPC proto and this mapper will silently
+    // render "$0.00" instead of failing loudly, so this fixture existing at
+    // all (rather than a thrown error) is the thing worth re-checking if the
+    // proto contract ever changes.
+    const payload = mockPayload()
+    const result = await mapPreviewResponse({}, payload)
+
+    expect(result.previewId).toBe('')
+    expect(result.periodDate).toBe('')
+    expect(result.expiresAt).toBe('')
+    expect(result.status).toBe('ready')
+    expect(result.totalAccounts).toBe(0)
+    expect(result.totalAccruedYield).toBe(0)
+    expect(result.totalECLAllowance).toBe(0)
+    expect(result.totalCarryingAmount).toBe(0)
+    expect(result.eclByBucket).toEqual([])
+
+    // No eclMovement object at all => movement fields are undefined, not 0.
+    expect(result.priorPeriodECL).toBeUndefined()
+    expect(result.eclChange).toBeUndefined()
+    expect(result.eclChangePercent).toBeUndefined()
+    expect(result.movementByCause).toEqual([])
+    expect(result.movementByBucket).toEqual([])
+
+    expect(result.reconciled).toBe(false)
+    expect(result.anomalies).toEqual([])
+    expect(result.anomalyCount).toBe(0)
+    expect(result.acknowledgedCount).toBe(0)
+    expect(result.journalEntries).toEqual([])
+
+    // No anomalies => no accountIds => payload.find must not be called at all.
+    expect(payload.find).not.toHaveBeenCalled()
+  })
+
+  it('enriches anomalies with customerIdString when payload.find returns matching loan-account docs', async () => {
+    const grpcResponse = {
+      anomalies: [
+        { anomalyId: 'anom_1', anomalyType: 'ecl_spike', severity: 'high', accountId: 'acc_1', description: 'x', acknowledged: false },
+        { anomalyId: 'anom_2', anomalyType: 'ecl_spike', severity: 'low', accountId: 'acc_2', description: 'y', acknowledged: false },
+      ],
+    }
+    const payload = mockPayload([
+      { loanAccountId: 'acc_1', customerIdString: 'cust_100' },
+      { loanAccountId: 'acc_2', customerIdString: 'cust_200' },
+    ])
+
+    const result = await mapPreviewResponse(grpcResponse, payload)
+
+    expect(result.anomalies[0].customerIdString).toBe('cust_100')
+    expect(result.anomalies[1].customerIdString).toBe('cust_200')
+    expect(payload.find).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('mapFinalizeResponse', () => {
+  it('maps totalEclAllowance and journal entry entryId/entryType fields', () => {
+    const grpcResponse = {
+      success: true,
+      periodDate: '2026-01-31',
+      finalizedAt: '2026-01-31T15:00:00Z',
+      totalAccounts: 42,
+      totalEclAllowance: '9876.54',
+      totalAccruedYield: '1234.56',
+      journalEntries: [
+        {
+          entryId: 'je_1',
+          entryType: 'ecl_provision',
+          description: 'ECL allowance movement',
+          debitAccount: 'ECL-EXPENSE',
+          creditAccount: 'ECL-ALLOWANCE',
+          amount: '876.54',
+          createdAt: '2026-01-31T15:00:01Z',
+        },
+      ],
+    }
+
+    const result = mapFinalizeResponse(grpcResponse)
+
+    expect(result.success).toBe(true)
+    expect(result.periodDate).toBe('2026-01-31')
+    expect(result.finalizedAt).toBe('2026-01-31T15:00:00Z')
+    expect(result.totalAccounts).toBe(42)
+    expect(result.totalECLAllowance).toBe(9876.54)
+    expect(result.totalAccruedYield).toBe(1234.56)
+    expect(result.journalEntries).toEqual([
+      {
+        id: 'je_1',
+        type: 'ecl_provision',
+        description: 'ECL allowance movement',
+        debitAccount: 'ECL-EXPENSE',
+        creditAccount: 'ECL-ALLOWANCE',
+        amount: 876.54,
+        createdAt: '2026-01-31T15:00:01Z',
+      },
+    ])
+  })
+
+  it('defaults to false/empty values for a missing/empty response', () => {
+    const result = mapFinalizeResponse({})
+
+    expect(result.success).toBe(false)
+    expect(result.periodDate).toBe('')
+    expect(result.finalizedAt).toBe('')
+    expect(result.totalAccounts).toBe(0)
+    expect(result.totalECLAllowance).toBe(0)
+    expect(result.totalAccruedYield).toBe(0)
+    expect(result.journalEntries).toEqual([])
+  })
+})


### PR DESCRIPTION
CRM side of the BTB-68 close-out (companion to billie-platform-services#68).

- **Severity styling**: `info`/`warning` anomaly cards + badges now styled (backend vocabulary is info/warning/critical; the new critical `gl_integrity_mismatch` anomaly from the platform PR renders with the existing critical styling)
- **useAcknowledgeAnomaly** consumes the real gRPC response shape `{success, errorMessage, allAnomaliesAcknowledged}`; `success: false` now rejects (fixes a latent bug where failed acknowledgements were shown as successful)
- **period-close-mapper regression tests**: the fix that closed the original BTB-68 $NaN bug is now mutation-verified test-armored
- **BTB-192**: wizard step + period in the URL (`?step=&period=`), session resume via sessionStorage keyed per period, fail-closed expiry handling, and a fix for a restore-path bug that could skip anomaly resync

4 commits, each task adversarially reviewed with fix loops; full unit suite 186 files / 2058 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017d7pVp8AoUJKJzwDru2e6C