### PR TITLE
BTB-249/256 follow-ups: integrity banner split (proto sync) + event-processor staleness guard

### DIFF
--- a/event-processor/src/billie_servicing/handlers/account.py
+++ b/event-processor/src/billie_servicing/handlers/account.py
@@ -136,6 +136,23 @@ async def handle_account_updated(pool: asyncpg.Pool, parsed_event: Any) -> None:
     - When a balance decrease arrives without an explicit last_payment_date,
       derive `last_payment_date`/`last_payment_amount` from the delta so the
       "Last payment" cell doesn't read "Never" forever.
+
+    Ordering (BTB-256 crm half / Task 40): account.updated.v1 carries NO
+    reliable monotonic ordering field by the time it reaches this handler.
+    ``triggered_by_transaction_id`` is an opaque ``str`` — usually the
+    ledger's globally-incrementing ``TXN-YYYY-NNNNNNNN`` id, but on the
+    disbursement path it falls back to a differently-shaped
+    ``conversation_id`` when ``disbursement_transaction_id`` is absent
+    (accountsService.event_handlers._publish_account_updated_event_from_disbursement),
+    so it isn't safely comparable across all publish sites. The chatLedger
+    envelope's ``seq`` is hardcoded to ``1`` for every domain event
+    (accountsService never passes an explicit ``seq`` for this event type),
+    so it's useless too. A hard-skip guard keyed on either would risk
+    silently dropping legitimate updates. So this only LOGS a staleness
+    warning (payload `timestamp` older than the stored projection's
+    `updated_at`) and always still applies the write — mirroring the DLQ
+    `extra_original_event_timestamp` staleness-triage convention from
+    Task 39/BTB-256 (platform half), where timestamp is informational only.
     """
     payload = parsed_event.payload
     account_id = payload.account_id
@@ -151,11 +168,37 @@ async def handle_account_updated(pool: asyncpg.Pool, parsed_event: Any) -> None:
         nonlocal existing
         if existing is None:
             existing = await pool.fetchrow(
-                "SELECT account_status, loan_terms_disbursed_date, balances_total_outstanding "
+                "SELECT account_status, loan_terms_disbursed_date, "
+                "balances_total_outstanding, updated_at "
                 "FROM loan_accounts WHERE loan_account_id = $1",
                 account_id,
             )
         return existing
+
+    # Log-only staleness warning — see the docstring's "Ordering" note for
+    # why this can't be a hard-skip guard. Never blocks/skips the write;
+    # any failure here (missing column, naive/aware datetime mismatch) is
+    # swallowed so staleness triage can never break projection updates.
+    incoming_timestamp = getattr(payload, "timestamp", None)
+    if isinstance(incoming_timestamp, datetime):
+        try:
+            row = await _load_existing()
+            stored_updated_at = row["updated_at"] if row is not None else None
+            if (
+                isinstance(stored_updated_at, datetime)
+                and incoming_timestamp < stored_updated_at
+            ):
+                log.warning(
+                    "Possible out-of-order account.updated.v1: event timestamp "
+                    "is older than the stored projection's updated_at. No "
+                    "reliable ordering field exists on this payload, so this "
+                    "is a log-only staleness warning — the write is still "
+                    "applied.",
+                    incoming_event_timestamp=incoming_timestamp.isoformat(),
+                    stored_updated_at=stored_updated_at.isoformat(),
+                )
+        except (KeyError, TypeError):
+            pass
 
     current_balance_value: float | None = None
     if payload.current_balance is not None:

--- a/event-processor/src/billie_servicing/handlers/account.py
+++ b/event-processor/src/billie_servicing/handlers/account.py
@@ -179,6 +179,9 @@ async def handle_account_updated(pool: asyncpg.Pool, parsed_event: Any) -> None:
     # why this can't be a hard-skip guard. Never blocks/skips the write;
     # any failure here (missing column, naive/aware datetime mismatch) is
     # swallowed so staleness triage can never break projection updates.
+    # Strict `<` (not `<=`) is deliberate: an incoming timestamp exactly equal
+    # to the stored projection's updated_at (e.g. same-instant redelivery of
+    # the same event) is not stale and must not warn.
     incoming_timestamp = getattr(payload, "timestamp", None)
     if isinstance(incoming_timestamp, datetime):
         try:

--- a/event-processor/tests/test_account_updated_ordering.py
+++ b/event-processor/tests/test_account_updated_ordering.py
@@ -1,0 +1,205 @@
+"""Tests for the account.updated.v1 ordering/staleness guard (BTB-256 crm half).
+
+Investigation summary (see task-40-report.md for full evidence): account.updated.v1
+carries NO reliable monotonic ordering field as it reaches the crm event-processor:
+
+- ``triggered_by_transaction_id`` is an opaque ``str`` -- usually the ledger's
+  globally-incrementing ``TXN-YYYY-NNNNNNNN`` id, but on the disbursement path
+  (accountsService.event_handlers._publish_account_updated_event_from_disbursement)
+  it falls back to a ``conversation_id`` (a completely different, non-sortable ID
+  shape) when ``disbursement_transaction_id`` is absent from the payload.
+- The chatLedger envelope's ``seq`` field is hardcoded to ``1`` for every domain
+  event (``ChatLedgerPublisher.publish_event``'s ``"seq": 1, # Always 1 for
+  domain events``) -- accountsService never passes an explicit ``seq`` when
+  publishing ``account.updated.v1``, so it is useless for ordering.
+
+Given no reliable ordering field, the guard is LOG-ONLY: it compares the
+payload's own (wall-clock, non-authoritative) ``timestamp`` against the stored
+projection's ``updated_at`` and logs a staleness warning when the incoming
+event looks older -- but ALWAYS still applies the write. This mirrors the DLQ
+``extra_original_event_timestamp`` staleness-triage convention established by
+Task 39/BTB-256 (platform half): timestamp is informational only, never
+authoritative for ordering or skip decisions.
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+from billie_servicing.handlers.account import handle_account_updated
+from structlog.testing import capture_logs
+
+
+def _make_event(
+    account_id: str = "ACC-ORDER-001",
+    current_balance=Decimal("100.00"),
+    status=None,
+    timestamp=None,
+):
+    event = MagicMock()
+    event.payload = MagicMock(
+        spec=[
+            "account_id",
+            "current_balance",
+            "status",
+            "last_payment_date",
+            "last_payment_amount",
+            "timestamp",
+        ]
+    )
+    event.payload.account_id = account_id
+    event.payload.current_balance = current_balance
+    event.payload.status = status
+    event.payload.last_payment_date = None
+    event.payload.last_payment_amount = None
+    event.payload.timestamp = timestamp
+    return event
+
+
+class TestAccountUpdatedStalenessWarning:
+    @pytest.mark.asyncio
+    async def test_logs_warning_when_incoming_timestamp_older_than_stored(self, mock_pool):
+        stored_updated_at = datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC)
+        mock_pool.set_fetchrow(
+            {
+                "account_status": "active",
+                "loan_terms_disbursed_date": None,
+                "balances_total_outstanding": 50.0,
+                "updated_at": stored_updated_at,
+            }
+        )
+        incoming_timestamp = datetime(2026, 7, 30, 10, 0, 0, tzinfo=UTC)  # older
+        event = _make_event(
+            current_balance=Decimal("50.00"),  # unchanged -- isolate the staleness path
+            timestamp=incoming_timestamp,
+        )
+
+        with capture_logs() as captured:
+            await handle_account_updated(mock_pool, event)
+
+        warnings = [e for e in captured if e.get("log_level") == "warning"]
+        assert warnings, f"expected a staleness warning to be logged, got: {captured}"
+        warning = warnings[0]
+        assert warning["incoming_event_timestamp"] == incoming_timestamp.isoformat()
+        assert warning["stored_updated_at"] == stored_updated_at.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_still_applies_write_when_incoming_timestamp_older_than_stored(self, mock_pool):
+        """Log-only means log-only -- the projection write must still happen."""
+        stored_updated_at = datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC)
+        mock_pool.set_fetchrow(
+            {
+                "account_status": "active",
+                "loan_terms_disbursed_date": None,
+                "balances_total_outstanding": 50.0,
+                "updated_at": stored_updated_at,
+            }
+        )
+        incoming_timestamp = datetime(2026, 7, 30, 10, 0, 0, tzinfo=UTC)  # older
+        event = _make_event(
+            current_balance=Decimal("42.00"),
+            timestamp=incoming_timestamp,
+        )
+
+        await handle_account_updated(mock_pool, event)
+
+        update = mock_pool.last_update("loan_accounts")
+        assert update is not None
+        assert update["balances_current_balance"] == 42.00
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_incoming_timestamp_newer_than_stored(self, mock_pool):
+        stored_updated_at = datetime(2026, 7, 30, 10, 0, 0, tzinfo=UTC)
+        mock_pool.set_fetchrow(
+            {
+                "account_status": "active",
+                "loan_terms_disbursed_date": None,
+                "balances_total_outstanding": 50.0,
+                "updated_at": stored_updated_at,
+            }
+        )
+        incoming_timestamp = datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC)  # newer
+        event = _make_event(
+            current_balance=Decimal("50.00"),
+            timestamp=incoming_timestamp,
+        )
+
+        with capture_logs() as captured:
+            await handle_account_updated(mock_pool, event)
+
+        warnings = [e for e in captured if e.get("log_level") == "warning"]
+        assert not warnings, f"unexpected staleness warning for a newer event: {warnings}"
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_no_existing_row(self, mock_pool):
+        """New account (no prior projection row) -- nothing to compare against."""
+        mock_pool.set_fetchrow(None)
+        event = _make_event(
+            current_balance=Decimal("50.00"),
+            timestamp=datetime(2026, 7, 30, 10, 0, 0, tzinfo=UTC),
+        )
+
+        with capture_logs() as captured:
+            await handle_account_updated(mock_pool, event)
+
+        warnings = [e for e in captured if e.get("log_level") == "warning"]
+        assert not warnings
+
+    @pytest.mark.asyncio
+    async def test_no_crash_when_payload_has_no_timestamp_field(self, mock_pool):
+        """Older SDK payloads without `timestamp` must not break the handler."""
+        mock_pool.set_fetchrow(
+            {
+                "account_status": "active",
+                "loan_terms_disbursed_date": None,
+                "balances_total_outstanding": 50.0,
+                "updated_at": datetime(2026, 7, 30, 12, 0, 0, tzinfo=UTC),
+            }
+        )
+        event = MagicMock()
+        event.payload = MagicMock(
+            spec=[
+                "account_id",
+                "current_balance",
+                "status",
+                "last_payment_date",
+                "last_payment_amount",
+            ]
+        )
+        event.payload.account_id = "ACC-NO-TS"
+        event.payload.current_balance = Decimal("50.00")
+        event.payload.status = None
+        event.payload.last_payment_date = None
+        event.payload.last_payment_amount = None
+
+        with capture_logs() as captured:
+            await handle_account_updated(mock_pool, event)
+
+        warnings = [e for e in captured if e.get("log_level") == "warning"]
+        assert not warnings
+        assert mock_pool.last_update("loan_accounts") is not None
+
+    @pytest.mark.asyncio
+    async def test_no_crash_when_stored_updated_at_missing_from_row(self, mock_pool):
+        """Existing rows selected before this guard shipped may lack the column
+        in test doubles / older query shapes -- must degrade gracefully."""
+        mock_pool.set_fetchrow(
+            {
+                "account_status": "active",
+                "loan_terms_disbursed_date": None,
+                "balances_total_outstanding": 50.0,
+                # no "updated_at" key
+            }
+        )
+        event = _make_event(
+            current_balance=Decimal("50.00"),
+            timestamp=datetime(2026, 7, 30, 10, 0, 0, tzinfo=UTC),
+        )
+
+        with capture_logs() as captured:
+            await handle_account_updated(mock_pool, event)
+
+        warnings = [e for e in captured if e.get("log_level") == "warning"]
+        assert not warnings
+        assert mock_pool.last_update("loan_accounts") is not None

--- a/proto/accounting_ledger.proto
+++ b/proto/accounting_ledger.proto
@@ -1200,6 +1200,8 @@ message ReconciliationResult {
   repeated string accrual_only = 5;  // Account IDs only in accruals (max 100)
   bool is_reconciled = 6;        // True if all accounts match
   int32 discrepancy_count = 7;   // Total discrepancy count
+  bool integrity_passed = 8;     // True if dollar-level GL integrity check passed
+  int32 integrity_discrepancy_count = 9;  // Count of dollar-mismatch discrepancies
 }
 
 // Period close preview response

--- a/src/components/PeriodCloseView/PeriodCloseWizard.tsx
+++ b/src/components/PeriodCloseView/PeriodCloseWizard.tsx
@@ -562,11 +562,42 @@ export const PeriodCloseWizard: React.FC<PeriodCloseWizardProps> = ({
               </div>
             )}
 
-            {/* Reconciliation Status */}
-            <div className={preview.reconciled ? styles.successBox : styles.warningBox}>
-              {preview.reconciled ? '✓ Reconciliation check passed' : '⚠️ Reconciliation check pending'}
-              {preview.reconciliationNotes && <p className={styles.notes}>{preview.reconciliationNotes}</p>}
-            </div>
+            {/* Reconciliation Status (BTB-249). When the platform reports the
+                dollar-integrity result (preview.integrity is defined), split it
+                from account-set parity: integrity is the authoritative
+                pass/fail signal, parity drift is informational-only routine
+                noise (accrual rows are removed when fee accrual completes).
+                Against a platform server that predates BTB-249,
+                preview.integrity is undefined and we fall back to today's
+                single banner. */}
+            {preview.integrity ? (
+              <>
+                <div
+                  className={preview.integrity.passed ? styles.integrityPassedBox : styles.integrityFailedBox}
+                >
+                  {preview.integrity.passed
+                    ? '✓ Dollar integrity: PASSED'
+                    : `Dollar integrity: FAILED (${preview.integrity.discrepancyCount} discrepanc${
+                        preview.integrity.discrepancyCount === 1 ? 'y' : 'ies'
+                      })`}
+                </div>
+                {(preview.accountSetDiscrepancyCount ?? 0) > 0 && (
+                  <div className={styles.accountSetParityBox}>
+                    Account-set parity: {preview.accountSetDiscrepancyCount} account-set discrepanc
+                    {preview.accountSetDiscrepancyCount === 1 ? 'y' : 'ies'}
+                    <p className={styles.notes}>
+                      Informational only — accrual rows are removed once fee accrual completes, so this drifts
+                      routinely and does not indicate a dollar-level problem.
+                    </p>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className={preview.reconciled ? styles.successBox : styles.warningBox}>
+                {preview.reconciled ? '✓ Reconciliation check passed' : '⚠️ Reconciliation check pending'}
+                {preview.reconciliationNotes && <p className={styles.notes}>{preview.reconciliationNotes}</p>}
+              </div>
+            )}
           </div>
         )
 

--- a/src/components/PeriodCloseView/styles.module.css
+++ b/src/components/PeriodCloseView/styles.module.css
@@ -399,6 +399,43 @@
   opacity: 0.9;
 }
 
+/* Dollar-integrity vs account-set-parity boxes (BTB-249) ------------------
+   `.errorBox` already is exactly the "critical" style the failed-integrity
+   case needs (opaque #fef2f2/#7f1d1d pair, ✕ glyph via ::before) — composed
+   here under a domain-specific name for call-site clarity. `.infoBox`
+   likewise already fits the parity note (opaque pale blue, non-alarming).
+   `.integrityPassedBox` is new: the operator is red/green colour-blind
+   (see the .changePositive/.changeNegative note above), so PASSED must NOT
+   use `.successBox`'s green. It uses a neutral pale-grey opaque background —
+   the same #f5f5f5 value documented as Payload's real light-theme
+   elevation-50 token in the dark-theme-overrides comment near the bottom of
+   this file — with dark, desaturated text, fixed regardless of theme like
+   the other alert boxes (no rgba-over-theme-bg, so no dark-mode override is
+   needed). Contrast ratios (WCAG relative-luminance formula, background vs
+   text):
+     .integrityPassedBox  #f5f5f5 / #1f2937  -> 13.46:1 (AAA)
+     .integrityFailedBox  #fef2f2 / #7f1d1d  ->  9.16:1 (AAA, pre-existing .errorBox pair)
+     .accountSetParityBox #eff6ff / #1e3a8a  ->  9.52:1 (AAA, pre-existing .infoBox pair)
+   All three clear WCAG AA (4.5:1 normal text) with margin. */
+.integrityPassedBox {
+  padding: 1rem;
+  background: #f5f5f5;
+  color: #1f2937;
+  border: none;
+  border-left: 4px solid #6b7280;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.integrityFailedBox {
+  composes: errorBox;
+}
+
+.accountSetParityBox {
+  composes: infoBox;
+}
+
 /* Movement Summary */
 .movementSummary {
   display: grid;

--- a/src/hooks/mutations/usePeriodClosePreview.ts
+++ b/src/hooks/mutations/usePeriodClosePreview.ts
@@ -68,9 +68,42 @@ export interface PeriodClosePreview {
   anomalyCount: number
   acknowledgedCount: number
 
-  // Reconciliation
+  // Reconciliation — split per BTB-249 into two independent signals that the
+  // platform's ReconciliationResult proto now reports separately:
+  //   1. `integrity` — dollar-level GL integrity (Σ customer sub-ledger balances
+  //      vs portfolio control accounts). This is the AUTHORITATIVE correctness
+  //      signal: a real integrity failure means the books don't balance.
+  //   2. `accountSetDiscrepancyCount` — account-SET parity (accounts present in
+  //      the ECL index but not the accrual index, or vice versa). This drifts
+  //      routinely and is informational only — accrual rows are removed once fee
+  //      accrual completes, so a nonzero count here does not imply a dollar
+  //      problem.
   reconciled: boolean
   reconciliationNotes?: string
+  /**
+   * Account-set parity discrepancy count (see field 2 above). The mapper always
+   * populates this (defaults to 0) — this field predates BTB-249 and existing
+   * platform servers already send it. Optional on the type only so
+   * hand-constructed fixtures/back-compat callers that predate this field don't
+   * need updating; treat a missing value as 0.
+   */
+  accountSetDiscrepancyCount?: number
+  /**
+   * Dollar-level GL integrity result (see field 1 above). `undefined` when the
+   * platform server predates BTB-249: `integrity_passed`/
+   * `integrity_discrepancy_count` are plain proto3 scalars with no presence
+   * tracking, so an old server's absent fields are wire-indistinguishable from
+   * an explicit `integrityPassed=false, integrityDiscrepancyCount=0`. The
+   * platform guarantees a genuine integrity failure always carries
+   * `discrepancyCount >= 1` (IntegrityResult.is_valid=False requires at least
+   * one discrepancy), so `passed !== true && discrepancyCount === 0` can only be
+   * the legacy/unset case — never a real failure — and is mapped to `undefined`
+   * here so the wizard falls back to the single legacy banner.
+   */
+  integrity?: {
+    passed: boolean
+    discrepancyCount: number
+  }
 
   // Journal preview
   journalEntries: {

--- a/src/server/grpc-client.ts
+++ b/src/server/grpc-client.ts
@@ -660,6 +660,15 @@ export interface ReconciliationResult {
   accrualOnly: string[]
   isReconciled: boolean
   discrepancyCount: number
+  // BTB-249: dollar-level GL integrity check (Σ customer sub-ledger balances vs
+  // portfolio control accounts), distinct from the account-SET parity captured by
+  // isReconciled/discrepancyCount above. Plain proto3 scalars — no presence
+  // tracking, so a pre-BTB-249 platform server's unset fields decode identically
+  // to explicit integrityPassed=false/integrityDiscrepancyCount=0. See the
+  // legacy-discriminator comment in period-close-mapper.ts before reading these
+  // directly.
+  integrityPassed: boolean
+  integrityDiscrepancyCount: number
 }
 
 export interface PreviewPeriodCloseResponse {

--- a/src/server/period-close-mapper.ts
+++ b/src/server/period-close-mapper.ts
@@ -15,6 +15,7 @@ const num = (v: unknown): number => {
  */
 export async function mapPreviewResponse(r: any, payload: Payload): Promise<PeriodClosePreview> {
   const m = r?.eclMovement
+  const recon = r?.reconciliation
   const anomalies = Array.isArray(r?.anomalies) ? r.anomalies : []
 
   // Enrich each anomaly with its account's customerIdString so the UI can link to the
@@ -38,6 +39,28 @@ export async function mapPreviewResponse(r: any, payload: Payload): Promise<Peri
     ...a,
     customerIdString: customerByAccount[a?.accountId] ?? undefined,
   }))
+
+  // BTB-249 dollar-integrity vs account-set-parity discriminator.
+  //
+  // `integrity_passed` / `integrity_discrepancy_count` (ReconciliationResult
+  // proto fields 8/9) are plain proto3 scalars with NO presence tracking, so a
+  // platform server that predates BTB-249 is wire-indistinguishable from one
+  // that explicitly reports integrityPassed=false, integrityDiscrepancyCount=0.
+  //
+  // The platform invariant (verified in the platform review) is: a genuine
+  // integrity failure always carries discrepancyCount >= 1 — integrity_passed
+  // is derived from IntegrityResult.is_valid, which is False only when there is
+  // at least one discrepancy, and the platform sets
+  // integrity_discrepancy_count = len(discrepancies). So a real failure can
+  // never report a count of 0.
+  //
+  // Therefore: `integrityPassed !== true && integrityDiscrepancyCount === 0` is
+  // only reachable via the legacy/unset default (old server, or field omitted
+  // in a hand-built response) — never a genuine failure — and is treated as
+  // LEGACY/UNKNOWN here (`integrity: undefined`), so the wizard falls back to
+  // today's single reconciliation banner instead of asserting a false failure.
+  const integrityDiscrepancyCount = num(recon?.integrityDiscrepancyCount)
+  const isKnownIntegrityResult = recon?.integrityPassed === true || integrityDiscrepancyCount > 0
 
   return {
     previewId: r?.previewId ?? '',
@@ -72,8 +95,12 @@ export async function mapPreviewResponse(r: any, payload: Payload): Promise<Peri
     anomalies: enrichedAnomalies, // gRPC anomaly objects already use anomalyId/anomalyType (matches PeriodCloseAnomaly)
     anomalyCount: anomalies.length,
     acknowledgedCount: anomalies.filter((a: any) => a?.acknowledged).length,
-    reconciled: r?.reconciliation?.isReconciled ?? false,
+    reconciled: recon?.isReconciled ?? false,
     reconciliationNotes: undefined,
+    accountSetDiscrepancyCount: num(recon?.discrepancyCount),
+    integrity: isKnownIntegrityResult
+      ? { passed: recon?.integrityPassed === true, discrepancyCount: integrityDiscrepancyCount }
+      : undefined,
     journalEntries: [], // ledger returns journal entries only at finalize, not preview
   }
 }

--- a/tests/unit/components/PeriodCloseWizard.integrity-banner.test.tsx
+++ b/tests/unit/components/PeriodCloseWizard.integrity-banner.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * PeriodCloseWizard — dollar-integrity vs account-set-parity banner split
+ * (BTB-249 crm half).
+ *
+ * The preview step used to render a single reconciliation banner sourced
+ * from `preview.reconciled` (which folds together two independent platform
+ * signals: dollar-level GL integrity and account-set parity). The platform
+ * now reports them separately (ReconciliationResult.integrity_passed /
+ * integrity_discrepancy_count, mapped by period-close-mapper.ts into
+ * `preview.integrity`). This suite locks in the wizard's rendering of the
+ * split banners:
+ *   - integrity known + passed  -> neutral "Dollar integrity: PASSED" banner
+ *   - integrity known + failed  -> critical "Dollar integrity: FAILED (N
+ *     discrepancies)" banner (the authoritative signal)
+ *   - account-set parity drifted -> an additional informational note,
+ *     independent of the integrity outcome
+ *   - integrity unknown (legacy platform server, preview.integrity
+ *     undefined) -> falls back to today's single reconciled/pending banner
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { toast } from 'sonner'
+import { PeriodCloseWizard } from '@/components/PeriodCloseView/PeriodCloseWizard'
+import type { PeriodClosePreview } from '@/hooks/mutations/usePeriodClosePreview'
+
+// ─── next/navigation ────────────────────────────────────────────────────
+const PATHNAME = '/admin/period-close'
+const mockReplace = vi.fn()
+const mockPush = vi.fn()
+const mockBack = vi.fn()
+let mockSearch = ''
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => PATHNAME,
+  useRouter: () => ({ replace: mockReplace, push: mockPush, back: mockBack }),
+  useSearchParams: () => new URLSearchParams(mockSearch),
+}))
+
+// ─── sonner ─────────────────────────────────────────────────────────────
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+// ─── Wizard's data hooks ────────────────────────────────────────────────
+const mockGeneratePreview = vi.fn()
+const mockAcknowledgeAnomaly = vi.fn()
+const mockFinalizePeriodClose = vi.fn()
+
+vi.mock('@/hooks/queries/useClosedPeriods', () => ({
+  useClosedPeriods: () => ({
+    data: { periods: [], lastClosedPeriod: undefined },
+    isLoading: false,
+    isFallback: false,
+    fallbackMessage: undefined,
+  }),
+}))
+
+vi.mock('@/hooks/mutations/usePeriodClosePreview', () => ({
+  usePeriodClosePreview: () => ({
+    generatePreview: mockGeneratePreview,
+    isPending: false,
+    error: null,
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/mutations/useAcknowledgeAnomaly', () => ({
+  useAcknowledgeAnomaly: () => ({
+    acknowledgeAnomaly: mockAcknowledgeAnomaly,
+    isPending: false,
+  }),
+}))
+
+vi.mock('@/hooks/mutations/useFinalizePeriodClose', () => ({
+  useFinalizePeriodClose: () => ({
+    finalizePeriodClose: mockFinalizePeriodClose,
+    isPending: false,
+    error: null,
+  }),
+}))
+
+const PERIOD = '2026-04-30'
+const FUTURE_EXPIRY = '2099-01-01T00:00:00.000Z'
+
+const buildPreview = (overrides: Partial<PeriodClosePreview> = {}): PeriodClosePreview => ({
+  previewId: 'preview-1',
+  periodDate: PERIOD,
+  expiresAt: FUTURE_EXPIRY,
+  status: 'ready',
+  totalAccounts: 10,
+  totalAccruedYield: 100,
+  totalECLAllowance: 200,
+  totalCarryingAmount: 900,
+  eclByBucket: [],
+  anomalies: [],
+  anomalyCount: 0,
+  acknowledgedCount: 0,
+  reconciled: true,
+  journalEntries: [],
+  ...overrides,
+})
+
+const storageKey = (period: string) => `periodClose:${period}`
+
+const seedPreviewStep = (preview: PeriodClosePreview) => {
+  sessionStorage.setItem(
+    storageKey(PERIOD),
+    JSON.stringify({
+      currentStep: 'preview',
+      preview,
+      localAnomalies: [],
+      periodDate: PERIOD,
+    })
+  )
+}
+
+const renderWizard = () => render(<PeriodCloseWizard userId="user-1" userName="Test User" />)
+
+beforeEach(() => {
+  sessionStorage.clear()
+  mockSearch = `step=preview&period=${PERIOD}`
+  mockReplace.mockClear()
+  mockPush.mockClear()
+  mockBack.mockClear()
+  mockGeneratePreview.mockReset()
+  mockAcknowledgeAnomaly.mockReset()
+  mockFinalizePeriodClose.mockReset()
+  vi.mocked(toast.error).mockClear()
+})
+
+describe('PeriodCloseWizard — dollar-integrity vs account-set-parity banners (BTB-249)', () => {
+  it('passed: renders the neutral "Dollar integrity: PASSED" banner and no parity note when parity is clean', async () => {
+    seedPreviewStep(
+      buildPreview({
+        integrity: { passed: true, discrepancyCount: 0 },
+        accountSetDiscrepancyCount: 0,
+      })
+    )
+
+    renderWizard()
+
+    expect(await screen.findByText('✓ Dollar integrity: PASSED')).toBeInTheDocument()
+    expect(screen.queryByText(/Account-set parity:/)).not.toBeInTheDocument()
+    // The legacy single-banner text must not also render.
+    expect(screen.queryByText('✓ Reconciliation check passed')).not.toBeInTheDocument()
+    expect(screen.queryByText('⚠️ Reconciliation check pending')).not.toBeInTheDocument()
+  })
+
+  it('failed: renders the critical "Dollar integrity: FAILED (N discrepancies)" banner — the authoritative signal', async () => {
+    seedPreviewStep(
+      buildPreview({
+        reconciled: false,
+        integrity: { passed: false, discrepancyCount: 3 },
+        accountSetDiscrepancyCount: 0,
+      })
+    )
+
+    renderWizard()
+
+    expect(await screen.findByText('Dollar integrity: FAILED (3 discrepancies)')).toBeInTheDocument()
+    expect(screen.queryByText('✓ Dollar integrity: PASSED')).not.toBeInTheDocument()
+    expect(screen.queryByText('⚠️ Reconciliation check pending')).not.toBeInTheDocument()
+  })
+
+  it('failed: singularizes the count when there is exactly one discrepancy', async () => {
+    seedPreviewStep(
+      buildPreview({
+        reconciled: false,
+        integrity: { passed: false, discrepancyCount: 1 },
+        accountSetDiscrepancyCount: 0,
+      })
+    )
+
+    renderWizard()
+
+    expect(await screen.findByText('Dollar integrity: FAILED (1 discrepancy)')).toBeInTheDocument()
+  })
+
+  it('drifted parity: renders the informational account-set parity note alongside a PASSED integrity banner', async () => {
+    seedPreviewStep(
+      buildPreview({
+        integrity: { passed: true, discrepancyCount: 0 },
+        accountSetDiscrepancyCount: 5,
+      })
+    )
+
+    renderWizard()
+
+    await screen.findByText('✓ Dollar integrity: PASSED')
+    expect(screen.getByText(/Account-set parity: 5 account-set discrepancies/)).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /Informational only — accrual rows are removed once fee accrual completes/
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('drifted parity: also renders alongside a FAILED integrity banner (the two signals are independent)', async () => {
+    seedPreviewStep(
+      buildPreview({
+        reconciled: false,
+        integrity: { passed: false, discrepancyCount: 2 },
+        accountSetDiscrepancyCount: 1,
+      })
+    )
+
+    renderWizard()
+
+    await screen.findByText('Dollar integrity: FAILED (2 discrepancies)')
+    expect(screen.getByText(/Account-set parity: 1 account-set discrepancy\b/)).toBeInTheDocument()
+  })
+
+  it('legacy fallback: preview.integrity undefined -> renders today\'s single "passed" banner, not the split banners', async () => {
+    seedPreviewStep(buildPreview({ integrity: undefined, reconciled: true }))
+
+    renderWizard()
+
+    expect(await screen.findByText('✓ Reconciliation check passed')).toBeInTheDocument()
+    expect(screen.queryByText(/Dollar integrity:/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Account-set parity:/)).not.toBeInTheDocument()
+  })
+
+  it('legacy fallback: preview.integrity undefined + reconciled=false -> renders today\'s "pending" banner', async () => {
+    seedPreviewStep(buildPreview({ integrity: undefined, reconciled: false }))
+
+    renderWizard()
+
+    expect(await screen.findByText('⚠️ Reconciliation check pending')).toBeInTheDocument()
+    expect(screen.queryByText(/Dollar integrity:/)).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/server/period-close-mapper.test.ts
+++ b/tests/unit/server/period-close-mapper.test.ts
@@ -10,6 +10,9 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
+import * as protoLoader from '@grpc/proto-loader'
+import * as grpc from '@grpc/grpc-js'
+import path from 'path'
 import type { Payload } from 'payload'
 import { mapPreviewResponse, mapFinalizeResponse } from '@/server/period-close-mapper'
 
@@ -19,6 +22,127 @@ function mockPayload(docs: any[] = []): Payload {
     find: vi.fn().mockResolvedValue({ docs }),
   } as unknown as Payload
 }
+
+// =============================================================================
+// I1 post-review fix (whole-branch review blocker): the mapper tests above all
+// feed mapPreviewResponse hand-built camelCase objects directly — they never
+// cross the actual gRPC wire boundary. src/server/grpc-client.ts loads the
+// CRM's OWN copy of proto/accounting_ledger.proto at runtime, and that copy's
+// ReconciliationResult had drifted from the platform's BTB-249 change: it was
+// missing `integrity_passed = 8` / `integrity_discrepancy_count = 9`.
+// protobufjs silently drops wire fields absent from the loaded schema, so
+// those two fields would decode as `undefined` on a real server response even
+// though the platform sent them — no exception, no visible failure. This test
+// loads the REAL .proto with the exact protoLoader.loadSync options
+// grpc-client.ts uses, serializes a response object carrying the new fields
+// through the actual proto descriptor, deserializes it back (exactly what a
+// gRPC client callback receives), and feeds THAT decoded object into the
+// mapper. It fails against a stale proto (fields dropped -> mapper falls back
+// to the legacy/undefined branch) and passes once ReconciliationResult
+// declares fields 8/9.
+// =============================================================================
+
+const PROTO_PATH = path.resolve(process.cwd(), 'proto/accounting_ledger.proto')
+
+// Mirror the EXACT protoLoader.loadSync options used by src/server/grpc-client.ts.
+const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+  keepCase: false,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+})
+
+const protoDescriptor = grpc.loadPackageDefinition(packageDefinition) as any
+const PreviewPeriodCloseResponseType = protoDescriptor.billie.ledger.v1.PreviewPeriodCloseResponse
+
+/** Builds a minimally-valid PreviewPeriodCloseResponse wire object, with the given reconciliation. */
+function buildPreviewWireResponse(reconciliation: Record<string, unknown>) {
+  return {
+    success: true,
+    errorMessage: '',
+    previewId: 'prev_wiretest',
+    periodDate: '2026-01-31',
+    createdAt: '2026-01-31T00:00:00Z',
+    expiresAt: '2026-01-31T14:00:00Z',
+    totalAccounts: 10,
+    totalAccruedYield: '100.00',
+    totalEclAllowance: '50.00',
+    totalCarryingAmount: '1000.00',
+    eclByBucket: [],
+    anomalies: [],
+    allAnomaliesAcknowledged: true,
+    eclMovement: {
+      priorTotalEcl: '0',
+      currentTotalEcl: '50.00',
+      netChange: '50.00',
+      changePercent: '0',
+      byCause: [],
+      byBucket: [],
+      priorPeriodDate: '',
+      isFirstClose: true,
+    },
+    processingTimeSeconds: 1.2,
+    reconciliation,
+  }
+}
+
+describe('mapPreviewResponse — BTB-249 integrity fields survive the real proto wire (I1)', () => {
+  it('sanity: ReconciliationResult declares integrity_passed (8) and integrity_discrepancy_count (9)', () => {
+    const reconFields = protoDescriptor.billie.ledger.v1.ReconciliationResult.type.field.map(
+      (f: { name: string }) => f.name,
+    )
+    expect(reconFields).toContain('integrityPassed')
+    expect(reconFields).toContain('integrityDiscrepancyCount')
+  })
+
+  it('genuine FAILURE round-trips through the real proto: integrity_passed=false, count=3 -> preview.integrity = {passed:false, discrepancyCount:3}', async () => {
+    const wireResponse = buildPreviewWireResponse({
+      eclCount: 10,
+      accrualCount: 10,
+      inBoth: 10,
+      eclOnly: [],
+      accrualOnly: [],
+      isReconciled: false,
+      discrepancyCount: 0,
+      integrityPassed: false,
+      integrityDiscrepancyCount: 3,
+    })
+
+    // Real wire-serialization boundary: encode with the actual proto descriptor,
+    // then decode it back — exactly what happens between the platform gRPC
+    // server and this client process.
+    const wire = PreviewPeriodCloseResponseType.serialize(wireResponse)
+    const decoded = PreviewPeriodCloseResponseType.deserialize(wire)
+
+    const payload = mockPayload()
+    const preview = await mapPreviewResponse(decoded, payload)
+
+    expect(preview.integrity).toEqual({ passed: false, discrepancyCount: 3 })
+  })
+
+  it('genuine PASS round-trips through the real proto: integrity_passed=true, count=0 -> preview.integrity = {passed:true, discrepancyCount:0}', async () => {
+    const wireResponse = buildPreviewWireResponse({
+      eclCount: 10,
+      accrualCount: 10,
+      inBoth: 10,
+      eclOnly: [],
+      accrualOnly: [],
+      isReconciled: true,
+      discrepancyCount: 0,
+      integrityPassed: true,
+      integrityDiscrepancyCount: 0,
+    })
+
+    const wire = PreviewPeriodCloseResponseType.serialize(wireResponse)
+    const decoded = PreviewPeriodCloseResponseType.deserialize(wire)
+
+    const payload = mockPayload()
+    const preview = await mapPreviewResponse(decoded, payload)
+
+    expect(preview.integrity).toEqual({ passed: true, discrepancyCount: 0 })
+  })
+})
 
 describe('mapPreviewResponse', () => {
   it('maps a full realistic camelCase gRPC preview response', async () => {

--- a/tests/unit/server/period-close-mapper.test.ts
+++ b/tests/unit/server/period-close-mapper.test.ts
@@ -121,6 +121,12 @@ describe('mapPreviewResponse', () => {
     expect(result.reconciliationNotes).toBeUndefined()
     expect(result.journalEntries).toEqual([])
 
+    // This fixture's `reconciliation` object predates BTB-249 (no
+    // integrityPassed/integrityDiscrepancyCount keys) — the legacy
+    // discriminator must map `integrity` to undefined, not assert a failure.
+    expect(result.integrity).toBeUndefined()
+    expect(result.accountSetDiscrepancyCount).toBe(0)
+
     expect(result.anomalyCount).toBe(2)
     expect(result.acknowledgedCount).toBe(1)
     expect(result.anomalies).toHaveLength(2)
@@ -198,6 +204,98 @@ describe('mapPreviewResponse', () => {
     expect(result.anomalies[0].customerIdString).toBe('cust_100')
     expect(result.anomalies[1].customerIdString).toBe('cust_200')
     expect(payload.find).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('mapPreviewResponse — BTB-249 dollar-integrity vs account-set-parity split', () => {
+  const baseReconciliation = {
+    eclCount: 100,
+    accrualCount: 100,
+    inBoth: 100,
+    eclOnly: [] as string[],
+    accrualOnly: [] as string[],
+    isReconciled: true,
+    discrepancyCount: 0,
+  }
+
+  it('maps a genuine PASS: integrityPassed=true, count=0 -> integrity.passed=true', async () => {
+    const payload = mockPayload()
+    const result = await mapPreviewResponse(
+      { reconciliation: { ...baseReconciliation, integrityPassed: true, integrityDiscrepancyCount: 0 } },
+      payload,
+    )
+
+    expect(result.integrity).toEqual({ passed: true, discrepancyCount: 0 })
+  })
+
+  it('maps a genuine FAILURE: integrityPassed=false, count>=1 -> integrity.passed=false with the count carried through', async () => {
+    const payload = mockPayload()
+    const result = await mapPreviewResponse(
+      {
+        reconciliation: {
+          ...baseReconciliation,
+          isReconciled: false,
+          integrityPassed: false,
+          integrityDiscrepancyCount: 3,
+        },
+      },
+      payload,
+    )
+
+    expect(result.integrity).toEqual({ passed: false, discrepancyCount: 3 })
+  })
+
+  it('treats integrityPassed=false + count=0 as the legacy/unset discriminator -> integrity undefined', async () => {
+    // Per the platform invariant, a genuine integrity failure always carries
+    // discrepancyCount >= 1 (IntegrityResult.is_valid=False requires >= 1
+    // discrepancy; the platform sets count=len(discrepancies)). integrityPassed
+    // === false && integrityDiscrepancyCount === 0 is therefore only reachable
+    // via a pre-BTB-249 platform server whose absent proto3 scalar fields decode
+    // to their zero-values (no presence tracking) — never a real failure.
+    const payload = mockPayload()
+    const result = await mapPreviewResponse(
+      { reconciliation: { ...baseReconciliation, integrityPassed: false, integrityDiscrepancyCount: 0 } },
+      payload,
+    )
+
+    expect(result.integrity).toBeUndefined()
+  })
+
+  it('treats a reconciliation object entirely missing the new fields as legacy -> integrity undefined', async () => {
+    const payload = mockPayload()
+    const result = await mapPreviewResponse({ reconciliation: { ...baseReconciliation } }, payload)
+
+    expect(result.integrity).toBeUndefined()
+  })
+
+  it('treats a response with no reconciliation object at all as legacy -> integrity undefined, reconciled false', async () => {
+    const payload = mockPayload()
+    const result = await mapPreviewResponse({}, payload)
+
+    expect(result.integrity).toBeUndefined()
+    expect(result.reconciled).toBe(false)
+    expect(result.accountSetDiscrepancyCount).toBe(0)
+  })
+
+  it('maps accountSetDiscrepancyCount from reconciliation.discrepancyCount independently of integrity', async () => {
+    const payload = mockPayload()
+    const result = await mapPreviewResponse(
+      {
+        reconciliation: {
+          ...baseReconciliation,
+          isReconciled: false,
+          discrepancyCount: 5,
+          integrityPassed: true,
+          integrityDiscrepancyCount: 0,
+        },
+      },
+      payload,
+    )
+
+    // Set-parity drifted (5 account-set discrepancies) even though the dollar
+    // integrity check passed cleanly — these two signals are independent.
+    expect(result.accountSetDiscrepancyCount).toBe(5)
+    expect(result.integrity).toEqual({ passed: true, discrepancyCount: 0 })
   })
 })
 


### PR DESCRIPTION
# BTB-249 + BTB-256 follow-ups (crm half)

Rebased onto `main` @ `89819c8` (clean — zero file overlap with PR #73). Three commits, each per-task reviewed with mutation testing plus a whole-branch final review.

## Changes

- **BTB-249 — reconciliation banner split** (`7870823` + `2df4878`): the single ambiguous "reconciled" banner becomes two: **Dollar integrity: PASSED/FAILED** (authoritative) and **Account-set parity: N discrepancies** (informational, with the completion-deletion explanation). Graceful degradation: against a backend predating the fields, the legacy single banner renders (proto3 scalars have no wire presence; the discriminator treats `false && count==0` as legacy — grounded against the platform servicer, which can never emit a genuine failure with count 0).
  - **`2df4878` is load-bearing:** the crm vendors its own `proto/accounting_ledger.proto` and it was missing fields 8/9 — protobufjs silently drops unknown wire fields, so without this commit the split banners would never render in production. Caught by the whole-branch final review; now guarded by a wire-boundary regression test that round-trips through the real proto descriptor (fails if the schema drifts again). Consider a CI proto-sync check longer-term.
  - Colour-blind-safe by construction: PASSED is neutral grey + ✓ + label, FAILED is red-family + ✕ + label (no red/green pair); all three boxes independently recomputed at WCAG **AAA** (13.46:1 / 9.16:1 / 9.52:1), opaque and theme-independent.
- **BTB-256 — event-processor staleness guard** (`3ef551e`): log-only staleness warning on `account.updated.v1` (payload timestamp vs stored `updated_at`), write always still applied. Log-only is deliberate and evidence-based: the payload has **no reliable monotonic ordering field** (envelope `seq` is hardcoded `1` for domain events; `triggered_by_transaction_id` shape-shifts to `conversation_id` on the disbursement fallback path) — a hard skip could drop legitimate writes. Strict `<` on equal timestamps is deliberate (same-instant redelivery isn't stale). Mutation-tested: making it hard-skip fails a test.

## Gates (final, on the rebased HEAD)

- vitest: **192 files / 2156 tests passed, 2 skipped** (reconciles exactly: base 2064 + 13 banner tests + 3 wire tests + PR #73's 76)
- `pnpm lint`: 0 errors (135 warnings, all pre-existing/warn-tier from PR #73's new rules; none of the six new error-tier a11y rules fire on the new JSX)
- event-processor pytest: **293 passed**

## Deploy note

Requires the platform half (BillieLoans/billie-platform-services `fix/btb68-followups`) deployed for the new fields to flow; until then the wizard falls back to the legacy banner by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017d7pVp8AoUJKJzwDru2e6C
