### PR TITLE
fix(test-harness): stop pnpm test:int silently passing with zero tests

### DIFF
--- a/.github/workflows/crm-ci.yml
+++ b/.github/workflows/crm-ci.yml
@@ -49,7 +49,13 @@ jobs:
       - run: pnpm install --frozen-lockfile
       # globalSetup spins up Postgres via testcontainers (Docker is available
       # on ubuntu-latest) and runs Payload's push schema sync before tests.
+      # Writes vitest-int-report.json (vitest's json reporter) alongside the
+      # human-readable output — the next step asserts a minimum test count
+      # against it so a run that silently exits 0 having tested nothing
+      # cannot pass CI. See scripts/check-test-count.mjs.
       - run: pnpm test:int
+      - name: Guard against a silent zero-test run
+        run: pnpm test:int:check-count
 
   e2e:
     name: playwright (marketing module)

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # testing
 /coverage
+/vitest-int-report.json
 
 # next.js
 /.next/

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "cross-env NODE_OPTIONS=--no-deprecation next start",
     "test": "pnpm run test:int && pnpm run test:e2e",
     "test:e2e": "cross-env NODE_OPTIONS=\"--no-deprecation --no-experimental-strip-types\" pnpm exec playwright test",
-    "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.mts",
+    "test:int": "cross-env NODE_OPTIONS=--no-deprecation vitest run --config ./vitest.config.mts --reporter=default --reporter=json --outputFile=./vitest-int-report.json",
+    "test:int:check-count": "node scripts/check-test-count.mjs",
     "e2e:auth": "node scripts/e2e-auth.mjs"
   },
   "dependencies": {

--- a/scripts/check-test-count.mjs
+++ b/scripts/check-test-count.mjs
@@ -1,0 +1,58 @@
+/**
+ * Guards CI against a silent zero-test `pnpm test:int` run passing green.
+ *
+ * Background: tests/utils/globalSetup.ts's dynamic `import()` of
+ * src/payload.config.ts intermittently (~40% of local runs, root-caused to
+ * an upstream Vite/vitest module-runner stall — see
+ * .superpowers/sdd/2026-07-31-aria-live-announcements/ci-harness-report.md)
+ * never settled, and with nothing else holding the event loop open, Node's
+ * idle-exit detection quietly exited the whole process with code 0 before
+ * any test file loaded. `.github/workflows/crm-ci.yml` had no floor on test
+ * count, so a genuinely broken branch could merge with a green tick. That
+ * root cause is now guarded against directly in globalSetup.ts, but this
+ * check stays as defence in depth against *any* mechanism that produces a
+ * clean exit with few or no tests (e.g. an `include` glob regression).
+ *
+ * `pnpm test:int` writes a JSON report (vitest-int-report.json, via
+ * vitest's built-in `json` reporter) alongside its human-readable output.
+ * Asserting a minimum test count against that structured report is more
+ * durable than grepping the human-readable summary line.
+ *
+ * Floor of 2000: the suite currently runs ~2158 tests on main. 2000 leaves
+ * ~7% headroom for normal churn (tests added/removed between deploys) while
+ * still catching catastrophic loss — e.g. globalSetup dying before any file
+ * loads, or the `include` glob in vitest.config.mts matching far fewer
+ * files than expected.
+ */
+import { readFileSync } from 'node:fs'
+
+const REPORT_PATH = process.argv[2] ?? './vitest-int-report.json'
+const MIN_TESTS = Number(process.env.MIN_TEST_COUNT ?? 2000)
+
+let raw
+try {
+  raw = readFileSync(REPORT_PATH, 'utf8')
+} catch {
+  console.error(
+    `[check-test-count] No JSON report found at "${REPORT_PATH}".\n` +
+      '  This usually means the vitest process exited before any test file was collected — ' +
+      'a silent globalSetup failure rather than a normal test failure. Treating as a hard ' +
+      'failure rather than letting the build pass with an unknown number of tests run.',
+  )
+  process.exit(1)
+}
+
+const report = JSON.parse(raw)
+const total = report.numTotalTests ?? 0
+
+if (total < MIN_TESTS) {
+  console.error(
+    `[check-test-count] Only ${total} tests ran (floor is ${MIN_TESTS}).\n` +
+      '  The suite currently runs ~2158 tests on main — this large a drop almost certainly ' +
+      'means the run aborted early or the test include glob regressed, not that ~2000 tests ' +
+      'were legitimately deleted. Failing the build.',
+  )
+  process.exit(1)
+}
+
+console.log(`[check-test-count] ${total} tests ran (floor ${MIN_TESTS}) — OK.`)

--- a/tests/utils/globalSetup.ts
+++ b/tests/utils/globalSetup.ts
@@ -11,6 +11,58 @@ import type { GlobalSetupContext } from 'vitest/node'
 
 let pg: StartedPostgreSqlContainer | undefined
 
+/**
+ * Races `promise` against an explicit, ref'd `setTimeout` that rejects with
+ * a clear error if it fires first. Deliberately never calls `.unref()` on
+ * the timer.
+ *
+ * Why this exists: investigation of a ~40%-reproducible bug where
+ * `pnpm test:int` silently exited 0 having run zero tests (see
+ * `.superpowers/sdd/2026-07-31-aria-live-announcements/ci-harness-report.md`)
+ * traced it to the dynamic `import()` calls below. Vite's SSR module runner
+ * (which vitest uses to load this file's dynamic imports of first-party
+ * source — unlike `payload`, `src/payload.config.ts`'s ~15 transitive
+ * collection imports all go through Vite's transform pipeline rather than
+ * being externalised) intermittently never settles the returned promise —
+ * it neither resolves nor rejects, confirmed to still be pending after 500+
+ * seconds of wall-clock time when kept alive artificially. Nothing in the
+ * vitest/vite stack holds a ref'd timer during this window, so when it
+ * happens, Node's ordinary "no more work scheduled" idle-exit detection
+ * wins the race and the whole `vitest run` process exits cleanly with code
+ * 0 before any test file ever loads or any error is printed.
+ *
+ * A plain ref'd `setTimeout` fixes the *silent* half of that failure mode
+ * unconditionally: merely having it pending keeps the event loop from ever
+ * looking idle during the vulnerable window, and if the import genuinely
+ * never settles it throws a loud, attributable error comfortably inside
+ * vitest's `hookTimeout` (120_000ms) — naming exactly which step stalled,
+ * rather than surfacing as vitest's generic hook-timeout message.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `[globalSetup] ${label} did not settle within ${ms}ms. This matches a known ` +
+            `intermittent Vite module-runner stall rather than a real code defect — see ` +
+            `ci-harness-report.md. Rerunning the job usually clears it.`,
+        ),
+      )
+    }, ms)
+    // Deliberately NOT unref()'d — see function doc above.
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
+}
+
 export async function setup({ provide }: GlobalSetupContext) {
   console.log('[globalSetup] Starting Postgres container…')
   pg = await new PostgreSqlContainer('postgres:16-alpine')
@@ -28,10 +80,15 @@ export async function setup({ provide }: GlobalSetupContext) {
   }
 
   // Trigger Payload init so push:true materialises the schema before tests run.
-  // Lazy import — must happen after DATABASE_URI is set.
-  const { getPayload } = await import('payload')
-  const { default: config } = await import('../../src/payload.config')
-  const payload = await getPayload({ config })
+  // Lazy import — must happen after DATABASE_URI is set. Each step is
+  // wrapped in withTimeout() — see its doc comment for why.
+  const { getPayload } = await withTimeout(import('payload'), 30_000, "import('payload')")
+  const { default: config } = await withTimeout(
+    import('../../src/payload.config'),
+    45_000,
+    "import('../../src/payload.config')",
+  )
+  const payload = await withTimeout(getPayload({ config }), 30_000, 'getPayload({ config })')
   await payload.db.destroy?.()
 
   // Provide the URI to test files via vitest's inject() API.


### PR DESCRIPTION
\`pnpm test:int\` terminated with exit 0 having run **zero tests** in ~40% of invocations — output dies right after "[globalSetup] Starting Postgres container…". CI had no guard, so a genuinely broken branch could merge green.

**Root cause:** the \`await import('../../src/payload.config')\` in globalSetup gets silently orphaned under Vite 7's SSR ModuleRunner (its recovery timeout is \`.unref()\`'d), leaving Node's idle-exit to win before any test loads. Evidence-backed bisection in the session; testcontainers itself verified fine (6/6 standalone).

**Fix:** vulnerable imports wrapped in a ref'd timeout race — a live ref'd timer prevents the silent idle-exit unconditionally; a genuine stall now throws an attributable error instead of vanishing.

**Guard (defence in depth):** \`test:int\` writes vitest's JSON report; \`scripts/check-test-count.mjs\` fails CI if the report is missing or \`numTotalTests < 2000\` (suite runs ~2160+; ~7% headroom). Wired into \`crm-ci.yml\` after the vitest step.

**Verified:** guard unit-tested against missing/zero/low/healthy fixtures; end-to-end simulation of the historical zero-test exit fails the step; 20 real runs — 16 clean, 4 loud failures, **0 silent zero-test exits**.

**Known tradeoff:** the upstream Vite stall still occurs, so CI will go red (not falsely green) at roughly that rate until the upstream issue is fixed. Cache-busting retry is a ticketed follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8Dk1k9G6BpCw2wWnwrojT