### PR TITLE
feat(kill): show staff name instead of raw user id in the end-conversation banner

### DIFF
--- a/src/app/api/conversations/[conversationId]/route.ts
+++ b/src/app/api/conversations/[conversationId]/route.ts
@@ -12,6 +12,7 @@ import { getPayload } from 'payload'
 import { headers } from 'next/headers'
 import configPromise from '@payload-config'
 import { hasAnyRole } from '@/lib/access'
+import { resolveActorDisplayName } from '@/lib/users'
 
 /** Safely convert a MongoDB Date or ISO string to ISO string, or null. */
 function toIso(val: unknown): string | null {
@@ -131,6 +132,16 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     const appDataRaw = doc.applicationData as Record<string, unknown> | undefined
     const appData = (appDataRaw?.payload as Record<string, unknown> | undefined) ?? appDataRaw
 
+    // Resolve the kill record's raw "user:<id>"/"system:<agent>" actor to a
+    // display name for the banner. The raw actor stays in the record (audit);
+    // this is render-time only and never blocks the response on failure.
+    const killRecordOut = killRecord
+      ? {
+          ...killRecord,
+          actorName: await resolveActorDisplayName(payload, killRecord.actor as string),
+        }
+      : null
+
     const conversation = {
       conversationId: String(doc.conversationId ?? ''),
       applicationNumber: (doc.applicationNumber as string) ?? null,
@@ -138,7 +149,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       decisionStatus: (doc.decisionStatus as string) ?? null,
       finalDecision: (doc.finalDecision as string) ?? null,
       decisionDetail: decisionDetail ?? null,
-      killRecord: killRecord ?? null,
+      killRecord: killRecordOut,
       reapplicationBlock: block ?? null,
       sourceConversationId,
       identityVerificationReport: {

--- a/src/components/ConversationDetailView/EndConversation/index.tsx
+++ b/src/components/ConversationDetailView/EndConversation/index.tsx
@@ -234,11 +234,12 @@ export interface KillBannerProps {
 export function KillBanner({ killRecord }: KillBannerProps) {
   if (!killRecord) return null
 
-  const { actor, reason_category, killed_at } = killRecord
+  const { actor, actorName, reason_category, killed_at } = killRecord
 
   return (
     <div className={styles.killBanner} data-testid="kill-banner">
-      Ended by {actor} · {reason_category} · {killed_at ? formatDateMedium(killed_at) : '—'}
+      Ended by {actorName || actor} · {reason_category} ·{' '}
+      {killed_at ? formatDateMedium(killed_at) : '—'}
     </div>
   )
 }

--- a/src/lib/schemas/conversations.ts
+++ b/src/lib/schemas/conversations.ts
@@ -101,6 +101,8 @@ export const DecisionDetailSchema = z.object({
 export const KillRecordSchema = z.object({
   request_id: z.string().nullable().optional(),
   actor: z.string().nullable().optional(),
+  /** Render-time resolved display name for `actor` (CRM-only; not stored). */
+  actorName: z.string().nullable().optional(),
   reason_category: z.string().nullable().optional(),
   note: z.string().nullable().optional(),
   killed_at: z.string().nullable().optional(),

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -22,18 +22,23 @@ function titleCaseFallback(suffix: string): string {
  * - "user:<id>"   -> "<firstName> <lastName>" || email || the raw input
  * - "system:<x>"  -> a friendly label for known agents, else a title-cased
  *                    fallback of the suffix
- * - null/empty/unrecognised -> the input unchanged
+ * - null/undefined/blank/non-string -> null
+ * - any other unrecognised format -> the input unchanged
  *
- * Never throws — any lookup failure (including "not found") falls back to the
- * raw actor id so this can never block the caller (e.g. the conversation
- * detail response).
+ * Never throws for any input — a non-string/blank actor short-circuits before
+ * any string method runs, and any lookup failure (including "not found")
+ * falls back to the raw actor id, so this can never block the caller (e.g.
+ * the conversation detail response).
  */
 export async function resolveActorDisplayName(
   payload: Payload,
   actor: string | null | undefined,
 ): Promise<string | null> {
-  if (actor === null || actor === undefined) return null
-  if (actor === '') return ''
+  // Normalize: anything that isn't a non-blank string (missing, wrong type from
+  // malformed/legacy data, or whitespace-only) resolves to "no name" rather than
+  // reaching string methods below — this is what makes "never throws" true for
+  // any input, not just the well-typed ones.
+  if (typeof actor !== 'string' || actor.trim() === '') return null
 
   if (actor.startsWith('user:')) {
     const id = actor.slice('user:'.length)

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -1,0 +1,65 @@
+import type { Payload } from 'payload'
+
+/** Known system actors (BTB-295 etc.) mapped to a staff-friendly label. */
+const SYSTEM_ACTOR_LABELS: Record<string, string> = {
+  fraudRiskAgent: 'Fraud risk agent',
+}
+
+/** Title-case a camelCase/identifier suffix, e.g. "someNewAgent" -> "Some new agent". */
+function titleCaseFallback(suffix: string): string {
+  const spaced = suffix
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .toLowerCase()
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+/**
+ * Resolve a namespaced actor id (as stored on records like `killRecord.actor`)
+ * to a human display name for staff-facing UI.
+ *
+ * - "user:<id>"   -> "<firstName> <lastName>" || email || the raw input
+ * - "system:<x>"  -> a friendly label for known agents, else a title-cased
+ *                    fallback of the suffix
+ * - null/empty/unrecognised -> the input unchanged
+ *
+ * Never throws — any lookup failure (including "not found") falls back to the
+ * raw actor id so this can never block the caller (e.g. the conversation
+ * detail response).
+ */
+export async function resolveActorDisplayName(
+  payload: Payload,
+  actor: string | null | undefined,
+): Promise<string | null> {
+  if (actor === null || actor === undefined) return null
+  if (actor === '') return ''
+
+  if (actor.startsWith('user:')) {
+    const id = actor.slice('user:'.length)
+    try {
+      const user = await payload.findByID({
+        collection: 'users',
+        id,
+        depth: 0,
+      })
+      if (!user) return actor
+
+      const fullName = [user.firstName, user.lastName]
+        .filter((part): part is string => Boolean(part))
+        .join(' ')
+        .trim()
+
+      return fullName || user.email || actor
+    } catch {
+      return actor
+    }
+  }
+
+  if (actor.startsWith('system:')) {
+    const suffix = actor.slice('system:'.length)
+    return SYSTEM_ACTOR_LABELS[suffix] ?? titleCaseFallback(suffix)
+  }
+
+  return actor
+}

--- a/tests/unit/components/EndConversation.test.tsx
+++ b/tests/unit/components/EndConversation.test.tsx
@@ -241,7 +241,7 @@ describe('EndConversationButton', () => {
 describe('KillBanner', () => {
   afterEach(() => cleanup())
 
-  it('renders "Ended by <actor> · <reason> · <date>" when a killRecord is present', () => {
+  it('renders "Ended by <actor> · <reason> · <date>" when a killRecord is present (back-compat: no actorName)', () => {
     const killedAt = '2026-08-24T04:00:00.000Z'
     renderWithProviders(
       <KillBanner
@@ -257,6 +257,26 @@ describe('KillBanner', () => {
     expect(
       screen.getByText(`Ended by user:42 · fraud_abuse · ${formatDateMedium(killedAt)}`),
     ).toBeInTheDocument()
+  })
+
+  it('renders the resolved staff name instead of the raw actor id when actorName is present', () => {
+    const killedAt = '2026-08-24T04:00:00.000Z'
+    renderWithProviders(
+      <KillBanner
+        killRecord={{
+          request_id: 'req-1',
+          actor: 'user:95979e54-7f2e-4578-a9d0-807c8951d684',
+          actorName: 'Jane Smith',
+          reason_category: 'fraud_abuse',
+          note: null,
+          killed_at: killedAt,
+        }}
+      />,
+    )
+    expect(
+      screen.getByText(`Ended by Jane Smith · fraud_abuse · ${formatDateMedium(killedAt)}`),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/95979e54/)).not.toBeInTheDocument()
   })
 
   it('renders nothing when killRecord is absent', () => {

--- a/tests/unit/lib/users.test.ts
+++ b/tests/unit/lib/users.test.ts
@@ -1,0 +1,98 @@
+// tests/unit/lib/users.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import type { Payload } from 'payload'
+import { resolveActorDisplayName } from '@/lib/users'
+
+function mockPayload(findByID: Payload['findByID']): Payload {
+  return { findByID } as unknown as Payload
+}
+
+describe('resolveActorDisplayName', () => {
+  it('resolves "user:<id>" to "First Last" via payload.findByID', async () => {
+    const findByID = vi.fn().mockResolvedValue({
+      id: '95979e54-7f2e-4578-a9d0-807c8951d684',
+      firstName: 'Jane',
+      lastName: 'Smith',
+      email: 'jane.smith@billie.loans',
+    })
+    const payload = mockPayload(findByID)
+
+    const result = await resolveActorDisplayName(
+      payload,
+      'user:95979e54-7f2e-4578-a9d0-807c8951d684',
+    )
+
+    expect(result).toBe('Jane Smith')
+    expect(findByID).toHaveBeenCalledWith({
+      collection: 'users',
+      id: '95979e54-7f2e-4578-a9d0-807c8951d684',
+      depth: 0,
+    })
+  })
+
+  it('falls back to email when firstName/lastName are absent', async () => {
+    const findByID = vi.fn().mockResolvedValue({
+      id: 'u-2',
+      email: 'noname@billie.loans',
+    })
+    const payload = mockPayload(findByID)
+
+    const result = await resolveActorDisplayName(payload, 'user:u-2')
+
+    expect(result).toBe('noname@billie.loans')
+  })
+
+  it('falls back to the raw actor id when findByID throws', async () => {
+    const findByID = vi.fn().mockRejectedValue(new Error('boom'))
+    const payload = mockPayload(findByID)
+
+    const result = await resolveActorDisplayName(payload, 'user:missing-id')
+
+    expect(result).toBe('user:missing-id')
+  })
+
+  it('falls back to the raw actor id when the user is not found', async () => {
+    const findByID = vi.fn().mockResolvedValue(null)
+    const payload = mockPayload(findByID)
+
+    const result = await resolveActorDisplayName(payload, 'user:missing-id')
+
+    expect(result).toBe('user:missing-id')
+  })
+
+  it('maps "system:fraudRiskAgent" to a friendly label', async () => {
+    const payload = mockPayload(vi.fn())
+
+    const result = await resolveActorDisplayName(payload, 'system:fraudRiskAgent')
+
+    expect(result).toBe('Fraud risk agent')
+  })
+
+  it('title-cases an unknown system actor suffix as a fallback', async () => {
+    const payload = mockPayload(vi.fn())
+
+    const result = await resolveActorDisplayName(payload, 'system:someNewAgent')
+
+    expect(result).toBe('Some new agent')
+  })
+
+  it('returns null unchanged', async () => {
+    const payload = mockPayload(vi.fn())
+    expect(await resolveActorDisplayName(payload, null)).toBeNull()
+  })
+
+  it('returns empty string unchanged', async () => {
+    const payload = mockPayload(vi.fn())
+    expect(await resolveActorDisplayName(payload, '')).toBe('')
+  })
+
+  it('returns undefined unchanged (as null)', async () => {
+    const payload = mockPayload(vi.fn())
+    expect(await resolveActorDisplayName(payload, undefined)).toBeNull()
+  })
+
+  it('returns an unrecognised actor format unchanged', async () => {
+    const payload = mockPayload(vi.fn())
+    expect(await resolveActorDisplayName(payload, 'not-a-known-format')).toBe('not-a-known-format')
+  })
+})

--- a/tests/unit/lib/users.test.ts
+++ b/tests/unit/lib/users.test.ts
@@ -81,14 +81,31 @@ describe('resolveActorDisplayName', () => {
     expect(await resolveActorDisplayName(payload, null)).toBeNull()
   })
 
-  it('returns empty string unchanged', async () => {
+  it('returns null for an empty string', async () => {
     const payload = mockPayload(vi.fn())
-    expect(await resolveActorDisplayName(payload, '')).toBe('')
+    expect(await resolveActorDisplayName(payload, '')).toBeNull()
+  })
+
+  it('returns null for a whitespace-only string', async () => {
+    const payload = mockPayload(vi.fn())
+    expect(await resolveActorDisplayName(payload, '   ')).toBeNull()
   })
 
   it('returns undefined unchanged (as null)', async () => {
     const payload = mockPayload(vi.fn())
     expect(await resolveActorDisplayName(payload, undefined)).toBeNull()
+  })
+
+  it('returns null (never throws) for a non-string actor, e.g. a number', async () => {
+    const payload = mockPayload(vi.fn())
+    // Malformed/legacy data could plausibly hand this a non-string; the
+    // helper's "never throws" contract must hold even then.
+    expect(await resolveActorDisplayName(payload, 12345 as unknown as string)).toBeNull()
+  })
+
+  it('returns null (never throws) for a non-string actor, e.g. an object', async () => {
+    const payload = mockPayload(vi.fn())
+    expect(await resolveActorDisplayName(payload, { id: 'x' } as unknown as string)).toBeNull()
   })
 
   it('returns an unrecognised actor format unchanged', async () => {


### PR DESCRIPTION
## Summary
The "End conversation" banner rendered `Ended by user:95979e54-…-807c8951d684 · fraud_abuse · …` — the raw Payload user GUID. It now shows the staff member's name.

- New reusable helper `src/lib/users.ts` `resolveActorDisplayName(payload, actor)` — the standard pattern for referencing a user: `user:<id>` → "First Last" (email fallback, raw-id fallback), `system:<agent>` → friendly label (forward-compatible with the BTB-295 fraud-agent actor), non-string/blank/unknown → safe fallback. Never throws.
- Conversation detail API attaches a resolved `actorName` to `killRecord` (raw `actor` id retained for audit). Render-time resolution → **fixes already-stored kill records** (no backfill), reflects the current name.
- Banner renders `actorName || actor` (back-compat: older records still render the raw id, never blank).

CRM-only: no migration, no billieChat/event-processor change, no change to how the actor is stored/published.

## Test plan
- [x] helper unit 13/13 (name join, email/raw-id fallback, system labels, not-found/error fallback, non-string/blank never-throws) + banner component 13/13 = 26/26
- [x] `pnpm typecheck` clean; `pnpm lint` 0 errors
- [ ] Demo: confirm the existing killed record now resolves the actor to a name (render-time; self-verifiable, no chat needed)

Follow-ups (separate): BTB-296 (fraud-flag clear lifecycle), BTB-297 (fallback-path close delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaYmDmNDAm5mhzcZnZSHZa