### PR TITLE
feat(kill): reveal the kill audit note + full detail via a drawer on the ended banner

### DIFF
--- a/src/components/ConversationDetailView/EndConversation/index.tsx
+++ b/src/components/ConversationDetailView/EndConversation/index.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react'
 import { useAuth } from '@payloadcms/ui'
 import { hasApprovalAuthority } from '@/lib/access'
 import { Modal } from '@/components/ui/Modal'
+import { ContextDrawer } from '@/components/ui/ContextDrawer'
 import { useKillConversation } from '@/hooks/mutations/useKillConversation'
 import { formatDateMedium } from '@/lib/formatters'
 import type { ConversationDetail } from '@/lib/schemas/conversations'
@@ -20,6 +21,14 @@ const REASON_OPTIONS: { value: ReasonCategory; label: string }[] = [
   { value: 'operational', label: 'Operational cleanup' },
   { value: 'compliance', label: 'Compliance / customer request' },
 ]
+
+/**
+ * Friendly label for a kill reason category, falling back to the raw value
+ * for anything not in REASON_OPTIONS (e.g. a category added server-side
+ * before the CRM picks up a matching label) rather than hiding it.
+ */
+const reasonLabel = (category: string | null | undefined): string =>
+  REASON_OPTIONS.find((o) => o.value === category)?.label ?? category ?? '—'
 
 /**
  * The single neutral message every kill shows the customer (billieChat config
@@ -230,16 +239,64 @@ export interface KillBannerProps {
  * Audit banner shown above the split panel once a conversation has been
  * ended: "Ended by <actor> · <reason> · <date>". Nothing renders while
  * `killRecord` is absent.
+ *
+ * The compact line is a fixed one-line layout (never reflows by content —
+ * the kill note is variable length and belongs in the drawer, not inline).
+ * Clicking it opens a ContextDrawer with the full audit detail, including
+ * the note entered in the end-conversation modal.
  */
 export function KillBanner({ killRecord }: KillBannerProps) {
+  const [open, setOpen] = useState(false)
+
   if (!killRecord) return null
 
-  const { actor, actorName, reason_category, killed_at } = killRecord
+  const { actor, actorName, reason_category, note, killed_at } = killRecord
+  const displayActor = actorName || actor || '—'
+  const displayReason = reasonLabel(reason_category)
+  const displayDate = killed_at ? formatDateMedium(killed_at) : '—'
+  const hasNote = Boolean(note?.trim())
 
   return (
-    <div className={styles.killBanner} data-testid="kill-banner">
-      Ended by {actorName || actor} · {reason_category} ·{' '}
-      {killed_at ? formatDateMedium(killed_at) : '—'}
-    </div>
+    <>
+      <button
+        type="button"
+        className={styles.killBanner}
+        onClick={() => setOpen(true)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        data-testid="kill-banner"
+      >
+        <span className={styles.killBannerText}>
+          Ended by {displayActor} · {displayReason} · {displayDate}
+        </span>
+        <span className={styles.killBannerAffordance} aria-hidden="true">
+          Details
+        </span>
+      </button>
+      <ContextDrawer isOpen={open} onClose={() => setOpen(false)} title="Conversation ended">
+        <div className={styles.killDrawerRow}>
+          <span className={styles.killDrawerLabel}>Ended by</span>
+          <span className={styles.killDrawerValue}>{displayActor}</span>
+        </div>
+        <div className={styles.killDrawerRow}>
+          <span className={styles.killDrawerLabel}>Reason</span>
+          <span className={styles.killDrawerValue}>{displayReason}</span>
+        </div>
+        <div className={styles.killDrawerRow}>
+          <span className={styles.killDrawerLabel}>Ended at</span>
+          <span className={styles.killDrawerValue}>{displayDate}</span>
+        </div>
+        <div className={styles.killDrawerNoteBlock}>
+          <span className={styles.killDrawerLabel}>Note</span>
+          {hasNote ? (
+            <p className={styles.killDrawerNote} data-testid="kill-note">
+              {note}
+            </p>
+          ) : (
+            <p className={styles.killDrawerNoteEmpty}>No note recorded.</p>
+          )}
+        </div>
+      </ContextDrawer>
+    </>
   )
 }

--- a/src/components/ConversationDetailView/styles.module.css
+++ b/src/components/ConversationDetailView/styles.module.css
@@ -144,6 +144,11 @@
 }
 
 .killBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
   margin: 0 24px 12px;
   padding: 10px 14px;
   border-radius: 8px;
@@ -152,7 +157,83 @@
   color: var(--theme-elevation-600, #6b7280);
   font-size: 13px;
   font-weight: 500;
+  font-family: inherit;
   flex-shrink: 0;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+
+.killBanner:hover {
+  background: var(--theme-elevation-100, #f3f4f6);
+}
+
+.killBanner:focus-visible {
+  outline: 2px solid var(--theme-success-400, #3b82f6);
+  outline-offset: 2px;
+}
+
+.killBannerText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.killBannerAffordance {
+  flex-shrink: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--theme-success-700, #0369a1);
+  text-decoration: underline;
+}
+
+/* ===== End conversation — kill detail drawer ===== */
+
+.killDrawerRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--theme-elevation-100, #f3f4f6);
+  font-size: 13px;
+}
+
+.killDrawerLabel {
+  color: var(--theme-elevation-600, #666);
+  flex-shrink: 0;
+}
+
+.killDrawerValue {
+  font-weight: 500;
+  color: var(--theme-elevation-800, #222);
+  text-align: right;
+}
+
+.killDrawerNoteBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 12px;
+}
+
+.killDrawerNote {
+  margin: 0;
+  padding: 12px;
+  border-radius: 6px;
+  background: var(--theme-elevation-50, #f9fafb);
+  color: var(--theme-elevation-800, #222);
+  font-size: 14px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.killDrawerNoteEmpty {
+  margin: 0;
+  font-size: 14px;
+  font-style: italic;
+  color: var(--theme-elevation-400, #aaa);
 }
 
 /* ===== End conversation — confirm modal ===== */

--- a/tests/unit/components/EndConversation.test.tsx
+++ b/tests/unit/components/EndConversation.test.tsx
@@ -241,7 +241,7 @@ describe('EndConversationButton', () => {
 describe('KillBanner', () => {
   afterEach(() => cleanup())
 
-  it('renders "Ended by <actor> · <reason> · <date>" when a killRecord is present (back-compat: no actorName)', () => {
+  it('renders "Ended by <actor> · <friendly reason> · <date>" when a killRecord is present (back-compat: no actorName)', () => {
     const killedAt = '2026-08-24T04:00:00.000Z'
     renderWithProviders(
       <KillBanner
@@ -255,7 +255,7 @@ describe('KillBanner', () => {
       />,
     )
     expect(
-      screen.getByText(`Ended by user:42 · fraud_abuse · ${formatDateMedium(killedAt)}`),
+      screen.getByText(`Ended by user:42 · Fraud / abuse · ${formatDateMedium(killedAt)}`),
     ).toBeInTheDocument()
   })
 
@@ -274,7 +274,7 @@ describe('KillBanner', () => {
       />,
     )
     expect(
-      screen.getByText(`Ended by Jane Smith · fraud_abuse · ${formatDateMedium(killedAt)}`),
+      screen.getByText(`Ended by Jane Smith · Fraud / abuse · ${formatDateMedium(killedAt)}`),
     ).toBeInTheDocument()
     expect(screen.queryByText(/95979e54/)).not.toBeInTheDocument()
   })
@@ -282,5 +282,164 @@ describe('KillBanner', () => {
   it('renders nothing when killRecord is absent', () => {
     const { container } = renderWithProviders(<KillBanner killRecord={null} />)
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('falls back to the raw reason category when it does not match a known REASON_OPTIONS value', () => {
+    renderWithProviders(
+      <KillBanner
+        killRecord={{
+          request_id: 'req-1',
+          actor: 'user:42',
+          reason_category: 'some_future_category',
+          note: null,
+          killed_at: '2026-08-24T04:00:00.000Z',
+        }}
+      />,
+    )
+    expect(screen.getByText(/some_future_category/)).toBeInTheDocument()
+  })
+
+  it('renders the compact line as a button that opens a "Conversation ended" drawer on click', () => {
+    renderWithProviders(
+      <KillBanner
+        killRecord={{
+          request_id: 'req-1',
+          actor: 'user:42',
+          actorName: 'Jane Smith',
+          reason_category: 'fraud_abuse',
+          note: 'Confirmed fraud ring across three linked accounts.',
+          killed_at: '2026-08-24T04:00:00.000Z',
+        }}
+      />,
+    )
+
+    const banner = screen.getByTestId('kill-banner')
+    expect(banner.tagName).toBe('BUTTON')
+    expect(banner).toHaveAttribute('aria-haspopup', 'dialog')
+    expect(banner).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('Conversation ended')).not.toBeInTheDocument()
+
+    fireEvent.click(banner)
+
+    expect(banner).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Conversation ended')).toBeInTheDocument()
+  })
+
+  it('shows the staff name, friendly reason, timestamp, and note in the drawer', () => {
+    const killedAt = '2026-08-24T04:00:00.000Z'
+    renderWithProviders(
+      <KillBanner
+        killRecord={{
+          request_id: 'req-1',
+          actor: 'user:42',
+          actorName: 'Jane Smith',
+          reason_category: 'compliance',
+          note: 'Customer requested account closure via phone.',
+          killed_at: killedAt,
+        }}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('kill-banner'))
+
+    const drawer = screen.getByTestId('context-drawer')
+    expect(drawer).toHaveTextContent('Jane Smith')
+    expect(drawer).toHaveTextContent('Compliance / customer request')
+    expect(drawer).toHaveTextContent(formatDateMedium(killedAt))
+    expect(drawer).toHaveTextContent('Customer requested account closure via phone.')
+  })
+
+  it('renders multi-line notes with line breaks preserved', () => {
+    renderWithProviders(
+      <KillBanner
+        killRecord={{
+          request_id: 'req-1',
+          actor: 'user:42',
+          actorName: 'Jane Smith',
+          reason_category: 'operational',
+          note: 'Line one\nLine two',
+          killed_at: '2026-08-24T04:00:00.000Z',
+        }}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('kill-banner'))
+
+    const note = screen.getByTestId('kill-note')
+    expect(note.textContent).toBe('Line one\nLine two')
+    expect(note).toHaveStyle({ whiteSpace: 'pre-wrap' })
+  })
+
+  it('shows "No note recorded." (and no empty note area) when the killRecord note is null', () => {
+    renderWithProviders(
+      <KillBanner
+        killRecord={{
+          request_id: 'req-1',
+          actor: 'user:42',
+          actorName: 'Jane Smith',
+          reason_category: 'operational',
+          note: null,
+          killed_at: '2026-08-24T04:00:00.000Z',
+        }}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('kill-banner'))
+
+    expect(screen.getByText('No note recorded.')).toBeInTheDocument()
+    expect(screen.queryByTestId('kill-note')).not.toBeInTheDocument()
+  })
+
+  it('shows "No note recorded." when the killRecord note is an empty/whitespace-only string', () => {
+    renderWithProviders(
+      <KillBanner
+        killRecord={{
+          request_id: 'req-1',
+          actor: 'user:42',
+          actorName: 'Jane Smith',
+          reason_category: 'operational',
+          note: '   ',
+          killed_at: '2026-08-24T04:00:00.000Z',
+        }}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('kill-banner'))
+
+    expect(screen.getByText('No note recorded.')).toBeInTheDocument()
+    expect(screen.queryByTestId('kill-note')).not.toBeInTheDocument()
+  })
+
+  it('back-compat: shows the raw actor (never blank) in both the banner and the drawer when actorName is absent', () => {
+    renderWithProviders(
+      <KillBanner
+        killRecord={{
+          request_id: 'req-1',
+          actor: 'user:xyz',
+          reason_category: 'fraud_abuse',
+          note: 'Some note',
+          killed_at: '2026-08-24T04:00:00.000Z',
+        }}
+      />,
+    )
+    expect(screen.getByText(/Ended by user:xyz/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('kill-banner'))
+    expect(screen.getByTestId('context-drawer')).toHaveTextContent('user:xyz')
+  })
+
+  it('closes the drawer when its close button is clicked', () => {
+    renderWithProviders(
+      <KillBanner
+        killRecord={{
+          request_id: 'req-1',
+          actor: 'user:42',
+          reason_category: 'fraud_abuse',
+          note: null,
+          killed_at: '2026-08-24T04:00:00.000Z',
+        }}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('kill-banner'))
+    expect(screen.getByTestId('context-drawer')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('context-drawer-close'))
+    expect(screen.queryByTestId('context-drawer')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
The kill audit `note` (entered in the End-conversation modal, "Internal note for the audit trail") was stored and served but never shown — invisible to staff. The "conversation ended" banner is now a button that opens a `ContextDrawer` with the full audit detail: staff name, friendly reason label, timestamp, and the **note** (with a "No note recorded." fallback, multi-line preserved).

- Compact banner stays a fixed one-line button; the variable-length note lives in the drawer (no inline reflow).
- Reason shown as the friendly `REASON_OPTIONS` label ("Fraud / abuse") in both banner and drawer, not the raw `fraud_abuse`.
- Reuses the app's existing `ContextDrawer` (keyboard/Escape/focus handled); back-compat: raw `user:<id>` still shown when a name can't be resolved; nothing renders when there's no killRecord.

Frontend-only: the note is already in the served `killRecord` — no API, schema, migration, or billieChat change.

## Test plan
- [x] vitest 21/21 (9 RED → GREEN): drawer opens, note text renders, empty/whitespace note → fallback with no stray node, friendly reason (+ unknown fallback), multi-line pre-wrap, raw-actor back-compat
- [x] `pnpm typecheck` clean; eslint + prettier clean
- [ ] Demo: confirm the drawer shows the real note on the existing killed record (self-verifiable)

Deferred minor: an `sr-only` "view details" cue on the affordance (non-blocking — button already has an accessible name + aria-haspopup). Pre-existing: `ContextDrawer` hardcodes `id="drawer-title"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaYmDmNDAm5mhzcZnZSHZa