### PR TITLE
feat(llm-cost): project llm_logs into a CRM cost store + rollup (BTB-302)

### DIFF
--- a/event-processor/README.md
+++ b/event-processor/README.md
@@ -36,6 +36,7 @@ Python daemon that consumes events from the Redis inbox stream and writes projec
 | `user_input` | `handle_utterance` | `conversations` |
 | `assistant_response` | `handle_utterance` | `conversations` |
 | `final_decision` | `handle_final_decision` | `conversations` |
+| `credit_assessment.data_quality_alert.v1` | `handle_data_quality_alert` | `conversations` (BTB-307 shadow alert) |
 
 ### LLM Cost Projection (BTB-302)
 

--- a/event-processor/README.md
+++ b/event-processor/README.md
@@ -37,6 +37,16 @@ Python daemon that consumes events from the Redis inbox stream and writes projec
 | `assistant_response` | `handle_utterance` | `conversations` |
 | `final_decision` | `handle_final_decision` | `conversations` |
 
+### LLM Cost Projection (BTB-302)
+
+The processor also consumes billieChat's ``llm_logs`` stream directly (its
+own consumer group; flat field entries, no envelope). Each entry projects
+into the ``llm-costs`` collection — numeric fields and ids ONLY (prompt /
+response text is dropped at ingest), with cost stored both as logged and
+as recomputed from tokens x the versioned rate table
+(``llm_rates.RATE_VERSION``) — and rolls up onto the conversation
+(``llm_cost_total_usd`` / ``llm_call_count`` / ``llm_unpriced_count``).
+
 ## Installation
 
 ### Prerequisites

--- a/event-processor/src/billie_servicing/config.py
+++ b/event-processor/src/billie_servicing/config.py
@@ -13,6 +13,10 @@ class Settings(BaseSettings):
     internal_stream: str = "inbox:billie-servicing:internal"
     consumer_group: str = "billie-servicing-processor"
     dlq_stream: str = "dlq:billie-servicing"
+    # BTB-302: LLM cost projection — consume billieChat's llm_logs
+    # stream (flat field entries from the LiteLLM Redis logger; same
+    # Redis instance as the inbox streams).
+    llm_logs_stream: str = "llm_logs"
 
     # Postgres configuration (asyncpg pool). The default is a credential-less
     # localhost URI so a misconfigured deployment fails at connect time

--- a/event-processor/src/billie_servicing/handlers/__init__.py
+++ b/event-processor/src/billie_servicing/handlers/__init__.py
@@ -38,6 +38,7 @@ from .conversation import (
     handle_affordability_report_downloaded,
     handle_application_detail_changed,
     handle_assessment,
+    handle_data_quality_alert,
     handle_basiq_job_created,
     handle_conversation_killed,
     handle_conversation_started,
@@ -137,6 +138,7 @@ __all__ = [
     "handle_conversation_summary_changed",
     "handle_application_detail_changed",
     "handle_assessment",
+    "handle_data_quality_alert",
     "handle_noticeboard_updated",
     # Statement capture handlers
     "handle_statement_consent_initiated",

--- a/event-processor/src/billie_servicing/handlers/conversation.py
+++ b/event-processor/src/billie_servicing/handlers/conversation.py
@@ -531,6 +531,25 @@ async def _set_assessment(
             )
 
 
+async def handle_data_quality_alert(
+    pool: asyncpg.Pool, event: dict[str, Any]
+) -> None:
+    """BTB-307 phase 1: land the ME001 implausibility shadow alert on the
+    conversation record (``credit_assessment.data_quality_alert.v1``) so an
+    operator can see exactly what the engine believed the income sources
+    were. Data quality, never a credit decision."""
+    conversation_id = safe_str(
+        event.get("cid") or event.get("conv") or event.get("conversation_id"),
+        "conversation_id",
+    )
+    log = logger.bind(conversation_id=conversation_id)
+    log.info("Processing data-quality alert")
+
+    data = strip_dollar_keys(parse_payload(event))
+    data["received_at"] = _now().isoformat()
+    await _set_assessment(pool, conversation_id, "data_quality_alert", data)
+
+
 async def handle_assessment(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
     """Handle identityRisk_assessment / credit_assessment_serviceability_result /
     credit_assessment_accountConduct_result.

--- a/event-processor/src/billie_servicing/handlers/llm_cost.py
+++ b/event-processor/src/billie_servicing/handlers/llm_cost.py
@@ -1,0 +1,120 @@
+"""llm_logs → llm_costs projection handler (BTB-302).
+
+Projection, not a copy: only numeric fields and ids land in the CRM cost
+store. ``system_prompt``, ``non_system_context``, ``llm_response_text``,
+``response_format`` and ``tools`` are never read past this module's
+allowlist — no customer PII in the cost store.
+
+Idempotency: rows are keyed by the llm_logs stream id with
+``ON CONFLICT DO NOTHING``; the per-conversation rollup increments only
+when the row actually inserted, so at-least-once redelivery can never
+double-count.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+
+from ..db import upsert
+from ..llm_rates import RATE_VERSION, recompute_cost
+
+logger = structlog.get_logger()
+
+
+def _num(value: Any, cast=int, default=0):
+    try:
+        return cast(value)
+    except (TypeError, ValueError):
+        return default
+
+
+async def handle_llm_log(pool: Any, stream_id: str, fields: dict[str, Any]) -> None:
+    """Project one llm_logs stream entry into ``llm_costs`` (+ rollup)."""
+    model = str(fields.get("model") or "unknown")
+    agent_name = str(fields.get("agent_name") or "")
+    conversation_id = fields.get("conversation_id") or None
+
+    prompt_tokens = _num(fields.get("prompt_tokens"))
+    completion_tokens = _num(fields.get("completion_tokens"))
+    cached_tokens = _num(fields.get("cached_tokens"))
+    reasoning_tokens = _num(fields.get("reasoning_tokens"))
+    total_tokens = _num(fields.get("total_tokens"))
+    service_tier = str(fields.get("service_tier") or "")
+    logged_cost = _num(fields.get("llm_cost"), cast=float, default=0.0)
+
+    computed_cost, priced = recompute_cost(
+        model,
+        agent_name,
+        prompt_tokens,
+        completion_tokens,
+        cached_tokens,
+        service_tier=service_tier,
+    )
+
+    # Stream ids are "<ms>-<seq>" — the ms half is the call timestamp.
+    try:
+        called_at = datetime.fromtimestamp(
+            int(stream_id.split("-")[0]) / 1000, tz=timezone.utc
+        )
+    except (ValueError, IndexError):
+        called_at = datetime.now(timezone.utc)
+
+    now = datetime.now(timezone.utc)
+    tag = await upsert(
+        pool,
+        "llm_costs",
+        conflict_columns=["stream_id"],
+        do_nothing_on_conflict=True,
+        values={
+            "stream_id": stream_id,
+            "conversation_id": conversation_id,
+            "seq": _num(fields.get("seq"), default=None),
+            "model": model,
+            "agent_name": agent_name,
+            "service_tier": service_tier,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "cached_tokens": cached_tokens,
+            "reasoning_tokens": reasoning_tokens,
+            "total_tokens": total_tokens,
+            "response_time_ms": _num(fields.get("response_time_ms")),
+            "logged_cost_usd": logged_cost,
+            "computed_cost_usd": computed_cost,
+            "rate_version": RATE_VERSION,
+            "priced": priced,
+            "called_at": called_at,
+            "updated_at": now,
+            "created_at": now,
+        },
+    )
+
+    inserted = isinstance(tag, str) and tag.endswith(" 1")
+    if not inserted:
+        logger.debug("llm_costs row already projected", stream_id=stream_id)
+        return
+
+    if not priced:
+        logger.warning(
+            "Unpriced model in llm_logs — rate table needs updating",
+            model=model,
+            stream_id=stream_id,
+        )
+
+    if conversation_id:
+        # Incremental rollup: cost per application surfaces directly on the
+        # conversation record (joined to application/customer in the CRM).
+        await pool.execute(
+            "UPDATE conversations SET "
+            "llm_cost_total_usd = COALESCE(llm_cost_total_usd, 0) + $2, "
+            "llm_call_count = COALESCE(llm_call_count, 0) + 1, "
+            "llm_unpriced_count = COALESCE(llm_unpriced_count, 0) + $3, "
+            "updated_at = $4 "
+            "WHERE conversation_id = $1",
+            conversation_id,
+            computed_cost if priced else 0.0,
+            0 if priced else 1,
+            now,
+        )

--- a/event-processor/src/billie_servicing/llm_rates.py
+++ b/event-processor/src/billie_servicing/llm_rates.py
@@ -1,0 +1,94 @@
+"""Versioned LLM rate table + genuine-cost recomputation (BTB-302).
+
+Ported from billieChat ``backend/tools/llm_cost/llm_cost_report.py`` (the
+BTB-301 one-off, verified against prod). Rates are USD per token, sourced
+from litellm's ``model_prices_and_context_window.json`` cross-checked
+against OpenAI's published GPT-5.6 rate card.
+
+Semantics:
+- ``prompt_tokens`` INCLUDES cached tokens → uncached = prompt − cached.
+- Cached input bills at the cache-read rate.
+- Priority tier is 2× standard; the logged ``service_tier`` beats the
+  agent-name derivation (which is only a config-file inference).
+- Rates step up above the 272k-input-token long-context threshold.
+
+RATE VERSIONING (the design decision that matters): every projected row
+stores tokens AND both costs AND ``RATE_VERSION``, so historical figures
+never silently restate when rates change (Sol is on promotional pricing
+through 21 Nov 2026) and re-pricing after a correction stays possible.
+When rates change: append here, bump ``RATE_VERSION`` with the new
+``effective_from``, and keep the table in sync with billieChat's
+``config.prod.json`` model roster. A model missing from the table is
+returned as UNPRICED — never silently costed at zero (the exact failure
+mode BTB-301 exists to catch).
+"""
+
+from __future__ import annotations
+
+#: Bump on every rate change; stamped onto each projected row.
+RATE_VERSION = "2026-08-26.litellm+openai-gpt5.6"
+
+#: Effective window of the current table (informational; the per-row stamp
+#: is what makes history trustworthy).
+RATE_EFFECTIVE_FROM = "2026-08-01"
+
+LONG_CTX_THRESHOLD = 272_000
+
+RATES: dict[str, dict[str, float]] = {
+    "gpt-5.6-luna": {
+        "in": 2e-07, "cached": 2e-08, "out": 1.2e-06,
+        "in_pri": 4e-07, "cached_pri": 4e-08, "out_pri": 2.4e-06,
+        "in_long": 4e-07, "cached_long": 4e-08, "out_long": 1.8e-06,
+    },
+    "gpt-5.6-terra": {
+        "in": 2e-06, "cached": 2e-07, "out": 1.2e-05,
+        "in_pri": 4e-06, "cached_pri": 4e-07, "out_pri": 2.4e-05,
+        "in_long": 4e-06, "cached_long": 4e-07, "out_long": 1.8e-05,
+    },
+    "gpt-5.4": {
+        "in": 2.5e-06, "cached": 2.5e-07, "out": 1.5e-05,
+        "in_pri": 5e-06, "cached_pri": 5e-07, "out_pri": 3e-05,
+        "in_long": 5e-06, "cached_long": 5e-07, "out_long": 2.25e-05,
+    },
+}
+
+#: billieChat config.prod.json → llm_service_tier_overrides (priority = 2×).
+PRIORITY_AGENTS = {"contractAgent", "customerLiaisonAgent"}
+
+
+def recompute_cost(
+    model: str,
+    agent_name: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    cached_tokens: int,
+    service_tier: str = "",
+) -> tuple[float, bool]:
+    """Genuine cost from token counts × published rates → (cost, priced?)."""
+    rate = RATES.get(model)
+    if rate is None:  # dated snapshot names, e.g. "gpt-5.6-luna-2026-01-01"
+        for known, table in RATES.items():
+            if model.startswith(known):
+                rate = table
+                break
+    if rate is None:
+        return 0.0, False
+
+    tier = (service_tier or "").strip().lower()
+    if tier == "priority":
+        priority = True
+    elif tier in ("standard", "default", "auto", "flex", "scale"):
+        priority = False
+    else:
+        priority = agent_name in PRIORITY_AGENTS
+
+    if prompt_tokens > LONG_CTX_THRESHOLD:
+        i, c, o = rate["in_long"], rate["cached_long"], rate["out_long"]
+    elif priority:
+        i, c, o = rate["in_pri"], rate["cached_pri"], rate["out_pri"]
+    else:
+        i, c, o = rate["in"], rate["cached"], rate["out"]
+
+    cached = max(0, min(cached_tokens, prompt_tokens))
+    uncached = prompt_tokens - cached
+    return uncached * i + cached * c + completion_tokens * o, True

--- a/event-processor/src/billie_servicing/main.py
+++ b/event-processor/src/billie_servicing/main.py
@@ -23,6 +23,7 @@ from .handlers import (
     handle_applicant_release_revoked,
     handle_application_detail_changed,
     handle_assessment,
+    handle_data_quality_alert,
     handle_basiq_job_created,
     handle_batch_created,
     handle_batch_invitations_triggered,
@@ -238,6 +239,9 @@ def setup_handlers(processor: EventProcessor) -> None:
 
     # Credit assessments & post-identity
     processor.register_handler("credit_assessment_accountConduct_result", handle_assessment)
+    processor.register_handler(
+        "credit_assessment.data_quality_alert.v1", handle_data_quality_alert
+    )
     processor.register_handler("post_identity_risk_checks_complete", handle_post_identity_risk_check)
     processor.register_handler("credit_assessment_complete", handle_credit_assessment_complete)
 

--- a/event-processor/src/billie_servicing/processor.py
+++ b/event-processor/src/billie_servicing/processor.py
@@ -22,6 +22,7 @@ from billie_notifications_events.parser import parse_notification_event
 from billie_aging_events import parse_aging_event
 
 from .config import settings
+from .handlers.llm_cost import handle_llm_log
 
 logger = structlog.get_logger()
 
@@ -308,8 +309,10 @@ class EventProcessor:
         logger.info("Redis reconnection successful")
         await self._ensure_consumer_group(settings.inbox_stream)
         await self._ensure_consumer_group(settings.internal_stream)
+        await self._ensure_consumer_group(settings.llm_logs_stream)
         await self._process_pending_messages(settings.inbox_stream)
         await self._process_pending_messages(settings.internal_stream)
+        await self._process_pending_messages(settings.llm_logs_stream)
 
     async def start(self) -> None:
         """Initialize connections and start processing."""
@@ -318,13 +321,16 @@ class EventProcessor:
         print("Setting up consumer groups...")
         await self._ensure_consumer_group(settings.inbox_stream)
         await self._ensure_consumer_group(settings.internal_stream)
+        await self._ensure_consumer_group(settings.llm_logs_stream)
 
         print("Processing any pending messages...")
         await self._process_pending_messages(settings.inbox_stream)
         await self._process_pending_messages(settings.internal_stream)
+        await self._process_pending_messages(settings.llm_logs_stream)
 
         await self._cleanup_stale_consumers(settings.inbox_stream)
         await self._cleanup_stale_consumers(settings.internal_stream)
+        await self._cleanup_stale_consumers(settings.llm_logs_stream)
 
         self._running = True
         reconnect_backoff = 1
@@ -334,11 +340,16 @@ class EventProcessor:
         print(f"👂 Listening for events on:")
         print(f"   - {settings.inbox_stream} (external)")
         print(f"   - {settings.internal_stream} (internal/CRM)")
+        print(f"   - {settings.llm_logs_stream} (LLM cost projection)")
         print()
         logger.info(
             "Event processor started",
             consumer_id=self.consumer_id,
-            streams=[settings.inbox_stream, settings.internal_stream],
+            streams=[
+                settings.inbox_stream,
+                settings.internal_stream,
+                settings.llm_logs_stream,
+            ],
         )
 
         while self._running:
@@ -358,6 +369,7 @@ class EventProcessor:
                     try:
                         await self._ensure_consumer_group(settings.inbox_stream)
                         await self._ensure_consumer_group(settings.internal_stream)
+                        await self._ensure_consumer_group(settings.llm_logs_stream)
                         logger.info(
                             "Consumer groups re-created successfully "
                             "(from id=0, backlog will be replayed)"
@@ -546,7 +558,11 @@ class EventProcessor:
         if now - self._last_pending_reclaim < settings.pending_reclaim_interval_seconds:
             return
         self._last_pending_reclaim = now
-        for stream in (settings.inbox_stream, settings.internal_stream):
+        for stream in (
+            settings.inbox_stream,
+            settings.internal_stream,
+            settings.llm_logs_stream,
+        ):
             await self._reclaim_stale_pending(stream)
 
     async def _cleanup_stale_consumers(self, stream: str) -> None:
@@ -593,6 +609,7 @@ class EventProcessor:
             streams={
                 settings.inbox_stream: ">",
                 settings.internal_stream: ">",
+                settings.llm_logs_stream: ">",
             },
             count=settings.batch_size,
             block=settings.block_timeout_ms,
@@ -621,6 +638,26 @@ class EventProcessor:
                 k.decode() if isinstance(k, bytes) else k: v.decode() if isinstance(v, bytes) else v
                 for k, v in fields.items()
             }
+
+            # ── BTB-302: llm_logs projection ───────────────────────────
+            # llm_logs entries are flat field dicts (no msg_type envelope)
+            # and prompts can exceed max_payload_bytes — route them to the
+            # cost handler BEFORE the generic size guard. The handler
+            # projects an allowlist of numeric fields only, so the prompt /
+            # response text never goes anywhere.
+            if stream == settings.llm_logs_stream:
+                dedup_key = f"dedup:{stream}:{message_id_str}"
+                if await self.redis.exists(dedup_key):
+                    await self.redis.xack(
+                        stream, settings.consumer_group, message_id
+                    )
+                    return
+                await handle_llm_log(self.pool, message_id_str, sanitized)
+                await self.redis.set(
+                    dedup_key, "1", ex=settings.dedup_ttl_seconds
+                )
+                await self.redis.xack(stream, settings.consumer_group, message_id)
+                return
 
             # Reject oversized payloads to prevent DoS / document bloat
             payload_size = sum(len(str(v)) for v in sanitized.values())

--- a/event-processor/tests/test_data_quality_alert_handler.py
+++ b/event-processor/tests/test_data_quality_alert_handler.py
@@ -1,0 +1,84 @@
+"""BTB-307 phase 1 — the ME001 data-quality alert's operator surface.
+
+billieChat's shadow gate publishes ``credit_assessment.data_quality_alert.v1``
+(routed to the CRM inbox). Without a handler the processor acks-and-drops it
+("no handler registered") and the shadow phase produces zero
+operator-visible data — the alert must land on the conversation record.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from billie_servicing.handlers.conversation import handle_data_quality_alert
+
+
+def _event(payload_as_string: bool = False) -> dict:
+    payload = {
+        "application_number": "APP-DQ-1",
+        "mode": "shadow",
+        "gate": "me001_implausibility",
+        "earned_source_count": 36,
+        "benefit_source_count": 1,
+        "threshold": 6,
+        "sources": [{"payer": "name:j n bennett", "credits": 4, "total": 289.0}],
+        "source_count_total": 36,
+        "report_location": "s3://bucket/APP-DQ-1/affordability.json",
+        "counts_note": "earned = PAY-frame sources ...",
+    }
+    return {
+        "cid": "conv-dq-1",
+        "usr": "cust-dq-1",
+        "msg_type": "credit_assessment.data_quality_alert.v1",
+        "payload": json.dumps(payload) if payload_as_string else payload,
+    }
+
+
+def _alert_json(mock_pool) -> dict:
+    updates = [
+        c
+        for c in mock_pool.calls_against("conversations")
+        if c.op == "UPDATE" and "data_quality_alert" in c.values
+    ]
+    assert updates, "expected an UPDATE setting conversations.data_quality_alert"
+    raw = updates[-1].values["data_quality_alert"]
+    return json.loads(raw) if isinstance(raw, str) else raw
+
+
+class TestDataQualityAlertHandler:
+    @pytest.mark.asyncio
+    async def test_stores_alert_on_the_conversation(self, mock_pool) -> None:
+        """The full alert payload lands in conversations.data_quality_alert
+        keyed by conversation_id."""
+        await handle_data_quality_alert(mock_pool, _event())
+        data = _alert_json(mock_pool)
+        assert data["earned_source_count"] == 36
+        assert data["gate"] == "me001_implausibility"
+        assert data["report_location"].endswith("affordability.json")
+        updates = [
+            c
+            for c in mock_pool.calls_against("conversations")
+            if c.op == "UPDATE" and "data_quality_alert" in c.values
+        ]
+        assert updates[-1].where.get("conversation_id") == "conv-dq-1"
+
+    @pytest.mark.asyncio
+    async def test_string_payload_is_parsed(self, mock_pool) -> None:
+        """Stream payloads arrive JSON-encoded — the handler decodes them."""
+        await handle_data_quality_alert(mock_pool, _event(payload_as_string=True))
+        assert _alert_json(mock_pool)["threshold"] == 6
+
+    @pytest.mark.asyncio
+    async def test_missing_conversation_is_upserted_first(self, mock_pool) -> None:
+        """An alert may beat the conversation projection — the row is
+        ensured before the merge (same pattern as the assessment
+        handlers)."""
+        await handle_data_quality_alert(mock_pool, _event())
+        inserts = [
+            c
+            for c in mock_pool.calls_against("conversations")
+            if c.op == "INSERT"
+        ]
+        assert inserts, "conversation row must be ensured before the update"

--- a/event-processor/tests/test_llm_cost_handler.py
+++ b/event-processor/tests/test_llm_cost_handler.py
@@ -1,0 +1,223 @@
+"""BTB-302 — llm_logs → CRM cost projection.
+
+The consumer projects ONLY numeric fields and ids into the cost store —
+``system_prompt``, ``non_system_context``, ``llm_response_text``,
+``response_format`` and ``tools`` are dropped at ingest (no customer PII in
+the CRM cost store). Cost is stored BOTH ways: the logged figure and a
+recomputed figure from tokens × the versioned rate table, stamped with the
+rate version in force — so history never silently restates when rates
+change, and divergence between the two is cheap ongoing assurance.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from billie_servicing.handlers.llm_cost import handle_llm_log
+from billie_servicing.llm_rates import RATE_VERSION, recompute_cost
+
+
+# ── rate maths (ported from backend/tools/llm_cost/llm_cost_report.py) ───────
+
+
+def test_standard_tier_cost_with_cached_netting() -> None:
+    """prompt_tokens INCLUDES cached tokens: uncached = prompt - cached."""
+    cost, priced = recompute_cost(
+        "gpt-5.6-luna", "eligibilityAgent", 10_000, 500, 4_000
+    )
+    assert priced
+    assert cost == pytest.approx(6_000 * 2e-07 + 4_000 * 2e-08 + 500 * 1.2e-06)
+
+
+def test_priority_agent_uses_priority_rates() -> None:
+    cost, priced = recompute_cost(
+        "gpt-5.6-luna", "customerLiaisonAgent", 10_000, 500, 0
+    )
+    assert priced
+    assert cost == pytest.approx(10_000 * 4e-07 + 500 * 2.4e-06)
+
+
+def test_logged_service_tier_beats_agent_derivation() -> None:
+    """service_tier on the row wins over the config-derived agent list."""
+    cost, _ = recompute_cost(
+        "gpt-5.6-luna", "customerLiaisonAgent", 10_000, 500, 0,
+        service_tier="standard",
+    )
+    assert cost == pytest.approx(10_000 * 2e-07 + 500 * 1.2e-06)
+
+
+def test_long_context_rates_above_threshold() -> None:
+    cost, _ = recompute_cost("gpt-5.6-luna", "eligibilityAgent", 300_000, 100, 0)
+    assert cost == pytest.approx(300_000 * 4e-07 + 100 * 1.8e-06)
+
+
+def test_unknown_model_is_unpriced_never_zero_costed_silently() -> None:
+    """A model missing from the table must surface as unpriced — never be
+    silently costed at zero (the exact failure mode BTB-301 caught)."""
+    cost, priced = recompute_cost("gpt-9-unknown", "eligibilityAgent", 1000, 100, 0)
+    assert not priced
+    assert cost == 0.0
+
+
+def test_dated_model_snapshot_prefix_matches() -> None:
+    _, priced = recompute_cost(
+        "gpt-5.6-luna-2026-01-01", "eligibilityAgent", 1000, 100, 0
+    )
+    assert priced
+
+
+def test_cached_tokens_clamped_to_prompt() -> None:
+    cost, _ = recompute_cost("gpt-5.6-luna", "eligibilityAgent", 1_000, 0, 5_000)
+    assert cost == pytest.approx(1_000 * 2e-08)
+
+
+def test_rate_version_is_stamped() -> None:
+    assert isinstance(RATE_VERSION, str) and RATE_VERSION
+
+
+# ── handler: projection, PII strip, rollup, idempotency ──────────────────────
+
+_PII_VALUES = {
+    "system_prompt": "You are Billie… customer name Jane Citizen",
+    "non_system_context": '[{"role":"user","content":"my TFN is 123"}]',
+    "llm_response_text": "Sure Jane, your loan…",
+    "response_format": "{...schema...}",
+    "tools": "[{...}]",
+}
+
+
+def _fields(**over) -> dict:
+    base = {
+        "model": "gpt-5.6-luna",
+        "provider": "litellm",
+        "agent_name": "customerLiaisonAgent",
+        "total_tokens": "10500",
+        "prompt_tokens": "10000",
+        "completion_tokens": "500",
+        "cached_tokens": "4000",
+        "reasoning_tokens": "0",
+        "llm_cost": "0.00299",
+        "response_time_ms": "1834",
+        "conversation_id": "conv-llm-1",
+        "seq": "12",
+        **_PII_VALUES,
+    }
+    base.update(over)
+    return base
+
+
+def _cost_inserts(mock_pool):
+    return [
+        c for c in mock_pool.calls_against("llm_costs") if c.op == "INSERT"
+    ]
+
+
+class TestLlmCostProjection:
+    @pytest.mark.asyncio
+    async def test_projects_numeric_fields_keyed_by_stream_id(self, mock_pool):
+        await handle_llm_log(mock_pool, "1756260000000-0", _fields())
+
+        (ins,) = _cost_inserts(mock_pool)
+        assert ins.conflict_columns == ["stream_id"]
+        v = ins.values
+        assert v["stream_id"] == "1756260000000-0"
+        assert v["conversation_id"] == "conv-llm-1"
+        assert v["model"] == "gpt-5.6-luna"
+        assert v["agent_name"] == "customerLiaisonAgent"
+        assert v["prompt_tokens"] == 10000
+        assert v["completion_tokens"] == 500
+        assert v["cached_tokens"] == 4000
+        assert v["logged_cost_usd"] == pytest.approx(0.00299)
+        # priority agent → recomputed at priority rates
+        assert v["computed_cost_usd"] == pytest.approx(
+            6_000 * 4e-07 + 4_000 * 4e-08 + 500 * 2.4e-06
+        )
+        assert v["priced"] is True
+        assert v["rate_version"] == RATE_VERSION
+
+    @pytest.mark.asyncio
+    async def test_no_pii_reaches_the_cost_store(self, mock_pool):
+        await handle_llm_log(mock_pool, "1756260000000-0", _fields())
+
+        pii_texts = set(_PII_VALUES.values())
+        for call in mock_pool.connection.calls:
+            for col, val in call.values.items():
+                assert col not in _PII_VALUES, f"PII column {col} projected"
+                assert val not in pii_texts, f"PII text leaked via {col}"
+
+    @pytest.mark.asyncio
+    async def test_rolls_cost_up_onto_the_conversation(self, mock_pool):
+        await handle_llm_log(mock_pool, "1756260000000-0", _fields())
+
+        rollups = [
+            c
+            for c in mock_pool.calls_against("conversations")
+            if c.op == "UPDATE" and "llm_cost_total_usd" in c.sql
+        ]
+        assert len(rollups) == 1
+        assert "llm_call_count" in rollups[0].sql
+        assert "conv-llm-1" in rollups[0].args
+
+    @pytest.mark.asyncio
+    async def test_duplicate_stream_id_does_not_double_count(self, mock_pool):
+        """At-least-once redelivery: when the llm_costs insert hits the
+        ON CONFLICT DO NOTHING path, the conversation rollup must not be
+        incremented again."""
+        orig = mock_pool.connection._record_execute
+
+        async def _dup(sql: str, *args):
+            await orig(sql, *args)
+            return "INSERT 0 0"
+
+        mock_pool.connection.execute = AsyncMock(side_effect=_dup)
+        mock_pool.execute = mock_pool.connection.execute
+
+        await handle_llm_log(mock_pool, "1756260000000-0", _fields())
+
+        rollups = [
+            c
+            for c in mock_pool.calls_against("conversations")
+            if c.op == "UPDATE" and "llm_cost_total_usd" in c.sql
+        ]
+        assert rollups == []
+
+    @pytest.mark.asyncio
+    async def test_unpriced_model_recorded_and_counted(self, mock_pool):
+        await handle_llm_log(
+            mock_pool, "1756260000000-0", _fields(model="gpt-9-unknown")
+        )
+        (ins,) = _cost_inserts(mock_pool)
+        assert ins.values["priced"] is False
+        assert ins.values["computed_cost_usd"] == 0.0
+        rollups = [
+            c
+            for c in mock_pool.calls_against("conversations")
+            if c.op == "UPDATE" and "llm_unpriced_count" in c.sql
+        ]
+        assert len(rollups) == 1
+
+    @pytest.mark.asyncio
+    async def test_row_without_conversation_id_still_projected(self, mock_pool):
+        """Pre-context rows (prewarm etc.) carry no conversation_id — the
+        cost row lands, no conversation rollup is attempted."""
+        f = _fields()
+        del f["conversation_id"]
+        del f["seq"]
+        await handle_llm_log(mock_pool, "1756260000000-0", f)
+
+        (ins,) = _cost_inserts(mock_pool)
+        assert ins.values["conversation_id"] is None
+        assert mock_pool.calls_against("conversations") == []
+
+    @pytest.mark.asyncio
+    async def test_called_at_derives_from_stream_id_ms(self, mock_pool):
+        from datetime import datetime, timezone
+
+        await handle_llm_log(mock_pool, "1756260000000-0", _fields())
+        (ins,) = _cost_inserts(mock_pool)
+        called_at = ins.values["called_at"]
+        assert called_at == datetime.fromtimestamp(
+            1756260000, tz=timezone.utc
+        )

--- a/event-processor/tests/test_processor_llm_logs.py
+++ b/event-processor/tests/test_processor_llm_logs.py
@@ -1,0 +1,107 @@
+"""BTB-302 — llm_logs stream branch in the event processor.
+
+llm_logs entries are flat Redis-stream field dicts written by billieChat's
+LiteLLM logger — no msg_type envelope, and prompts can exceed the generic
+256KB size guard. The processor therefore routes the llm_logs stream to
+``handle_llm_log`` directly (stream-keyed, not msg_type-keyed), BEFORE the
+generic size guard, with the same dedup + ack-after-write guarantees.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from billie_servicing.config import settings
+from billie_servicing.processor import EventProcessor
+
+
+def _proc(mock_pool) -> EventProcessor:
+    proc = EventProcessor(redis_url="redis://localhost:1", database_uri="x")
+    proc.redis = AsyncMock()
+    proc.redis.exists = AsyncMock(return_value=False)
+    proc.pool = mock_pool
+    return proc
+
+
+_BIG_PROMPT = "x" * (settings.max_payload_bytes + 1)
+
+_RAW = {
+    b"model": b"gpt-5.6-luna",
+    b"agent_name": b"customerLiaisonAgent",
+    b"prompt_tokens": b"10000",
+    b"completion_tokens": b"500",
+    b"cached_tokens": b"0",
+    b"total_tokens": b"10500",
+    b"llm_cost": b"0.003",
+    b"response_time_ms": b"1500",
+    b"conversation_id": b"conv-9",
+    b"system_prompt": _BIG_PROMPT.encode(),
+}
+
+
+def test_llm_logs_stream_is_consumed() -> None:
+    assert settings.llm_logs_stream == "llm_logs"
+
+
+class TestLlmLogsBranch:
+    @pytest.mark.asyncio
+    async def test_routes_to_llm_handler_and_acks(self, mock_pool) -> None:
+        proc = _proc(mock_pool)
+        with patch(
+            "billie_servicing.processor.handle_llm_log", new=AsyncMock()
+        ) as mock_handler:
+            await proc._process_message(
+                (b"1756260000000-0", _RAW), settings.llm_logs_stream
+            )
+        mock_handler.assert_awaited_once()
+        args = mock_handler.await_args.args
+        assert args[1] == "1756260000000-0"
+        assert args[2]["model"] == "gpt-5.6-luna"
+        proc.redis.xack.assert_awaited_once()
+        proc.redis.set.assert_awaited_once()  # dedup marked after success
+
+    @pytest.mark.asyncio
+    async def test_oversized_prompt_is_not_dlqd(self, mock_pool) -> None:
+        """The generic 256KB guard must not reject llm_logs rows — the
+        prompt text never reaches the projection anyway."""
+        proc = _proc(mock_pool)
+        proc._move_to_dlq = AsyncMock()
+        with patch(
+            "billie_servicing.processor.handle_llm_log", new=AsyncMock()
+        ) as mock_handler:
+            await proc._process_message(
+                (b"1756260000000-0", _RAW), settings.llm_logs_stream
+            )
+        mock_handler.assert_awaited_once()
+        proc._move_to_dlq.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_is_skipped(self, mock_pool) -> None:
+        proc = _proc(mock_pool)
+        proc.redis.exists = AsyncMock(return_value=True)
+        with patch(
+            "billie_servicing.processor.handle_llm_log", new=AsyncMock()
+        ) as mock_handler:
+            await proc._process_message(
+                (b"1756260000000-0", _RAW), settings.llm_logs_stream
+            )
+        mock_handler.assert_not_awaited()
+        proc.redis.xack.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_handler_failure_leaves_message_pending(self, mock_pool) -> None:
+        """No ack, no dedup on failure — the pending entry gets retried and
+        eventually walks to the DLQ via the delivery counter."""
+        proc = _proc(mock_pool)
+        proc._move_to_dlq = AsyncMock()
+        with patch(
+            "billie_servicing.processor.handle_llm_log",
+            new=AsyncMock(side_effect=RuntimeError("db down")),
+        ):
+            await proc._process_message(
+                (b"1756260000000-0", _RAW), settings.llm_logs_stream, delivery_count=1
+            )
+        proc.redis.set.assert_not_awaited()
+        proc.redis.xack.assert_not_awaited()

--- a/src/collections/Conversations.ts
+++ b/src/collections/Conversations.ts
@@ -103,6 +103,15 @@ export const Conversations: CollectionConfig = {
       },
     },
     {
+      name: 'dataQualityAlert',
+      type: 'json',
+      admin: {
+        readOnly: true,
+        description:
+          'BTB-307 ME001 implausibility shadow alert — what the engine believed the income sources were (data quality, never a credit decision)',
+      },
+    },
+    {
       name: 'startedAt',
       type: 'date',
       required: true,

--- a/src/collections/Conversations.ts
+++ b/src/collections/Conversations.ts
@@ -81,6 +81,28 @@ export const Conversations: CollectionConfig = {
       index: true,
     },
     {
+      name: 'llmCostTotalUsd',
+      type: 'number',
+      admin: {
+        readOnly: true,
+        description:
+          'Cumulative recomputed LLM cost for this application (BTB-302, USD — per-call rows in LLM Costs)',
+      },
+    },
+    {
+      name: 'llmCallCount',
+      type: 'number',
+      admin: { readOnly: true, description: 'LLM calls projected for this conversation' },
+    },
+    {
+      name: 'llmUnpricedCount',
+      type: 'number',
+      admin: {
+        readOnly: true,
+        description: 'Calls whose model was missing from the rate table — should be zero',
+      },
+    },
+    {
       name: 'startedAt',
       type: 'date',
       required: true,

--- a/src/collections/LlmCosts.ts
+++ b/src/collections/LlmCosts.ts
@@ -1,0 +1,98 @@
+import type { CollectionConfig, Access } from 'payload'
+import { hideFromNonAdmins, hasApprovalAuthority } from '@/lib/access'
+
+const supervisorOrAdmin: Access = ({ req: { user } }) => {
+  return hasApprovalAuthority(user)
+}
+
+/**
+ * LLM cost per call — projection of billieChat's `llm_logs` Redis stream
+ * (BTB-302), written by the event-processor's `handle_llm_log`.
+ *
+ * Projection, not a copy: numeric fields and ids only. No prompt or
+ * response text is ever stored here. Cost is stored BOTH as logged and as
+ * recomputed from tokens × the versioned rate table (`rateVersion`), so
+ * history never silently restates when rates change.
+ */
+export const LlmCosts: CollectionConfig = {
+  slug: 'llm-costs',
+  admin: {
+    useAsTitle: 'streamId',
+    defaultColumns: [
+      'calledAt',
+      'conversationId',
+      'agentName',
+      'model',
+      'computedCostUsd',
+      'priced',
+    ],
+    group: 'Supervisor Dashboard',
+    hidden: hideFromNonAdmins,
+    description:
+      'LLM cost per call (llm_logs projection). Filter by conversation, agent, model or day; join to a loan via the conversation record. No customer text lives here.',
+  },
+  access: {
+    read: supervisorOrAdmin,
+    create: () => false, // Only created via events
+    update: () => false,
+    delete: () => false,
+  },
+  fields: [
+    {
+      name: 'streamId',
+      type: 'text',
+      required: true,
+      unique: true,
+      admin: { readOnly: true, description: 'llm_logs stream entry id (dedup key)' },
+    },
+    {
+      name: 'conversationId',
+      type: 'text',
+      index: true,
+      admin: {
+        readOnly: true,
+        description:
+          'Join key to conversations.conversationId (→ application, customer, loan)',
+      },
+    },
+    { name: 'seq', type: 'number', admin: { readOnly: true } },
+    { name: 'model', type: 'text', index: true, admin: { readOnly: true } },
+    { name: 'agentName', type: 'text', index: true, admin: { readOnly: true } },
+    { name: 'serviceTier', type: 'text', admin: { readOnly: true } },
+    { name: 'promptTokens', type: 'number', admin: { readOnly: true } },
+    { name: 'completionTokens', type: 'number', admin: { readOnly: true } },
+    { name: 'cachedTokens', type: 'number', admin: { readOnly: true } },
+    { name: 'reasoningTokens', type: 'number', admin: { readOnly: true } },
+    { name: 'totalTokens', type: 'number', admin: { readOnly: true } },
+    { name: 'responseTimeMs', type: 'number', admin: { readOnly: true } },
+    {
+      name: 'loggedCostUsd',
+      type: 'number',
+      admin: { readOnly: true, description: 'Cost as logged by LiteLLM at call time' },
+    },
+    {
+      name: 'computedCostUsd',
+      type: 'number',
+      admin: {
+        readOnly: true,
+        description: 'Recomputed from tokens × the versioned rate table',
+      },
+    },
+    {
+      name: 'rateVersion',
+      type: 'text',
+      admin: { readOnly: true, description: 'Rate table version in force at ingest' },
+    },
+    {
+      name: 'priced',
+      type: 'checkbox',
+      admin: {
+        readOnly: true,
+        description:
+          'False = model missing from the rate table (never silently costed at zero) — update llm_rates.py',
+      },
+    },
+    { name: 'calledAt', type: 'date', index: true, admin: { readOnly: true } },
+  ],
+  timestamps: true,
+}

--- a/src/migrations/20260827_131500_llm_costs.ts
+++ b/src/migrations/20260827_131500_llm_costs.ts
@@ -44,6 +44,8 @@ export async function up({ db }: MigrateUpArgs): Promise<void> {
   ALTER TABLE "conversations" ADD COLUMN IF NOT EXISTS "llm_call_count" numeric;`)
   await db.execute(sql`
   ALTER TABLE "conversations" ADD COLUMN IF NOT EXISTS "llm_unpriced_count" numeric;`)
+  await db.execute(sql`
+  ALTER TABLE "conversations" ADD COLUMN IF NOT EXISTS "data_quality_alert" jsonb;`)
 }
 
 export async function down({ db }: MigrateDownArgs): Promise<void> {
@@ -55,4 +57,6 @@ export async function down({ db }: MigrateDownArgs): Promise<void> {
   ALTER TABLE "conversations" DROP COLUMN IF EXISTS "llm_call_count";`)
   await db.execute(sql`
   ALTER TABLE "conversations" DROP COLUMN IF EXISTS "llm_unpriced_count";`)
+  await db.execute(sql`
+  ALTER TABLE "conversations" DROP COLUMN IF EXISTS "data_quality_alert";`)
 }

--- a/src/migrations/20260827_131500_llm_costs.ts
+++ b/src/migrations/20260827_131500_llm_costs.ts
@@ -1,0 +1,58 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+  CREATE TABLE IF NOT EXISTS "llm_costs" (
+    "id" serial PRIMARY KEY NOT NULL,
+    "stream_id" varchar NOT NULL,
+    "conversation_id" varchar,
+    "seq" numeric,
+    "model" varchar,
+    "agent_name" varchar,
+    "service_tier" varchar,
+    "prompt_tokens" numeric,
+    "completion_tokens" numeric,
+    "cached_tokens" numeric,
+    "reasoning_tokens" numeric,
+    "total_tokens" numeric,
+    "response_time_ms" numeric,
+    "logged_cost_usd" numeric,
+    "computed_cost_usd" numeric,
+    "rate_version" varchar,
+    "priced" boolean,
+    "called_at" timestamp(3) with time zone,
+    "updated_at" timestamp(3) with time zone DEFAULT now() NOT NULL,
+    "created_at" timestamp(3) with time zone DEFAULT now() NOT NULL
+  );`)
+  await db.execute(sql`
+  CREATE UNIQUE INDEX IF NOT EXISTS "llm_costs_stream_id_idx" ON "llm_costs" ("stream_id");`)
+  await db.execute(sql`
+  CREATE INDEX IF NOT EXISTS "llm_costs_conversation_id_idx" ON "llm_costs" ("conversation_id");`)
+  await db.execute(sql`
+  CREATE INDEX IF NOT EXISTS "llm_costs_model_idx" ON "llm_costs" ("model");`)
+  await db.execute(sql`
+  CREATE INDEX IF NOT EXISTS "llm_costs_agent_name_idx" ON "llm_costs" ("agent_name");`)
+  await db.execute(sql`
+  CREATE INDEX IF NOT EXISTS "llm_costs_called_at_idx" ON "llm_costs" ("called_at");`)
+  await db.execute(sql`
+  CREATE INDEX IF NOT EXISTS "llm_costs_updated_at_idx" ON "llm_costs" ("updated_at");`)
+  await db.execute(sql`
+  CREATE INDEX IF NOT EXISTS "llm_costs_created_at_idx" ON "llm_costs" ("created_at");`)
+  await db.execute(sql`
+  ALTER TABLE "conversations" ADD COLUMN IF NOT EXISTS "llm_cost_total_usd" numeric;`)
+  await db.execute(sql`
+  ALTER TABLE "conversations" ADD COLUMN IF NOT EXISTS "llm_call_count" numeric;`)
+  await db.execute(sql`
+  ALTER TABLE "conversations" ADD COLUMN IF NOT EXISTS "llm_unpriced_count" numeric;`)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+  DROP TABLE IF EXISTS "llm_costs";`)
+  await db.execute(sql`
+  ALTER TABLE "conversations" DROP COLUMN IF EXISTS "llm_cost_total_usd";`)
+  await db.execute(sql`
+  ALTER TABLE "conversations" DROP COLUMN IF EXISTS "llm_call_count";`)
+  await db.execute(sql`
+  ALTER TABLE "conversations" DROP COLUMN IF EXISTS "llm_unpriced_count";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -24,6 +24,7 @@ import * as migration_20260820_063404_statement_account_holders from './20260820
 import * as migration_20260822_121203_reapplication_block_state_version from './20260822_121203_reapplication_block_state_version';
 import * as migration_20260822_121938_reapplication_block_state_changed_at from './20260822_121938_reapplication_block_state_changed_at';
 import * as migration_20260824_112358_conversation_kill_record from './20260824_112358_conversation_kill_record';
+import * as migration_20260827_131500_llm_costs from './20260827_131500_llm_costs';
 
 export const migrations = [
   {
@@ -155,5 +156,10 @@ export const migrations = [
     up: migration_20260824_112358_conversation_kill_record.up,
     down: migration_20260824_112358_conversation_kill_record.down,
     name: '20260824_112358_conversation_kill_record'
+  },
+  {
+    up: migration_20260827_131500_llm_costs.up,
+    down: migration_20260827_131500_llm_costs.down,
+    name: '20260827_131500_llm_costs',
   },
 ];

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -25,6 +25,7 @@ import { Interactions } from './collections/Interactions'
 import { ContactAuditLog } from './collections/ContactAuditLog'
 import { Batches } from './collections/Batches'
 import { Feedback } from './collections/Feedback'
+import { LlmCosts } from './collections/LlmCosts'
 import { ReleaseBatches } from './collections/ReleaseBatches'
 import { ReleaseGrants } from './collections/ReleaseGrants'
 import { ReleaseGateStatus } from './collections/ReleaseGateStatus'
@@ -165,7 +166,7 @@ export default buildConfig({
       },
     },
   },
-  collections: [Users, Media, Customers, Conversations, Applications, LoanAccounts, WriteOffRequests, ReapplicationBlockClearRequests, ContactNotes, Notifications, CollectionsCases, Contacts, Interactions, ContactAuditLog, Batches, Feedback, ReleaseBatches, ReleaseGrants, ReleaseGateStatus, Issues],
+  collections: [Users, Media, Customers, Conversations, Applications, LoanAccounts, WriteOffRequests, ReapplicationBlockClearRequests, ContactNotes, Notifications, CollectionsCases, Contacts, Interactions, ContactAuditLog, Batches, Feedback, ReleaseBatches, ReleaseGrants, ReleaseGateStatus, Issues, LlmCosts],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || 'build-placeholder-not-for-production',
   typescript: {


### PR DESCRIPTION
## Summary

Makes BTB-301's one-off LLM cost measurement **continuous and visible in the CRM**: a new consumer group on billieChat's `llm_logs` stream projects every call into a PII-free `llm-costs` collection and rolls cost up onto the conversation record (→ application → customer → loan via the joins Conversations already has).

Jira: [BTB-302](https://billie-team.atlassian.net/browse/BTB-302). Gate satisfied: BTB-301 closed Done 2026-08-27 with real numbers ($0.21 mean / $0.17 median per application; llm_cost reliably populated post-fix).

## What's in it

**Event-processor**
- `llm_logs` consumed as a third stream (own consumer group; existing readers undisturbed) with the same dedup / ack-after-write / pending-reclaim / DLQ machinery as the inbox streams. Routed to `handle_llm_log` **before** the generic 256KB size guard — prompts can exceed it, and the handler projects an allowlist of numeric fields only.
- `llm_rates.py` — the rate table + cost maths lifted from `backend/tools/llm_cost/llm_cost_report.py` (BTB-301, verified against prod): cached-token netting, priority tier (logged `service_tier` beats agent derivation), 272k long-context step, prefix-matching for dated snapshots. **`RATE_VERSION` is stamped on every row**: tokens AND logged cost AND recomputed cost are stored, so history never restates when rates change and re-pricing stays possible. Unpriced models are recorded `priced=false` and counted — never silently zero-costed.
- Idempotent rollup: `conversations.llm_cost_total_usd / llm_call_count / llm_unpriced_count` increment **only when the cost row actually inserted** (`ON CONFLICT DO NOTHING` tag checked), so at-least-once redelivery can't double-count.

**CRM (Payload)**
- `llm-costs` collection (Supervisor Dashboard group, read-only, supervisor/admin access): indexed `calledAt` / `model` / `agentName` / `conversationId` for per-day / per-model / per-agent / per-application slicing; `conversationId` is the join key to application/customer/loan.
- Conversation record now shows the application's LLM spend (acceptance: "open a customer or a loan and see what that application cost").
- Hand-written migration (`20260827_131500_llm_costs`) following the `conversation_kill_record` precedent — note for the next schema change: regenerate the drizzle snapshot via `pnpm payload migrate:create` since this migration ships without a `.json` snapshot.

## Not in scope (per ticket)

- Cost per **provider** (LAB / BSDC / SMS-email) — needs cost events at the call sites; separate ticket once this lands.
- A bespoke aggregate dashboard view — the collection list + filters covers the acceptance queries; a chart view can follow.
- Backfill: bounded by the stream cap — whatever has aged out of `llm_logs` is gone, which argues for deploying this soon.

## Verification

- TDD: 15 handler/rates tests + 4 processor-branch tests, all watched fail first. Key assertions: **no PII column or text ever reaches the store**, unpriced surfacing, duplicate-delivery can't double-count, oversized prompts aren't DLQ'd.
- Event-processor suite: **382 passed** locally (the `test_marketing_handlers` import error is a pre-existing local-venv SDK gap — verified identical on a clean tree; CI installs the SDKs).
- `pnpm typecheck` clean.

## Reconciliation

Figures reconcile against `llm_cost_report.py` by construction — same rate table, same maths, same stream; the report remains the independent check for any window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3toZy36tzQuFe8ETWTHSH