### PR TITLE
fix(llm-cost): never price a row that has no token usage (BTB-302)

### DIFF
--- a/event-processor/src/billie_servicing/handlers/llm_cost.py
+++ b/event-processor/src/billie_servicing/handlers/llm_cost.py
@@ -45,6 +45,15 @@ async def handle_llm_log(pool: Any, stream_id: str, fields: dict[str, Any]) -> N
     service_tier = str(fields.get("service_tier") or "")
     logged_cost = _num(fields.get("llm_cost"), cast=float, default=0.0)
 
+    # A row can only be costed from tokens if it HAS tokens. billieChat's
+    # streaming path logged usage-less records (cost present, all token
+    # counts zero) — recording those priced=true at $0.00 silently
+    # under-reports every consumer that sums computed cost. That is the same
+    # failure BTB-302 guards for an unknown model, reached via absent usage,
+    # so it gets the same treatment: never priced, counted as unpriced, and
+    # logged_cost_usd left as the only valid figure for the row.
+    has_usage = (prompt_tokens + completion_tokens) > 0
+
     computed_cost, priced = recompute_cost(
         model,
         agent_name,
@@ -53,6 +62,8 @@ async def handle_llm_log(pool: Any, stream_id: str, fields: dict[str, Any]) -> N
         cached_tokens,
         service_tier=service_tier,
     )
+    if not has_usage:
+        computed_cost, priced = 0.0, False
 
     # Stream ids are "<ms>-<seq>" — the ms half is the call timestamp.
     try:
@@ -85,6 +96,7 @@ async def handle_llm_log(pool: Any, stream_id: str, fields: dict[str, Any]) -> N
             "computed_cost_usd": computed_cost,
             "rate_version": RATE_VERSION,
             "priced": priced,
+            "has_usage": has_usage,
             "called_at": called_at,
             "updated_at": now,
             "created_at": now,
@@ -96,7 +108,16 @@ async def handle_llm_log(pool: Any, stream_id: str, fields: dict[str, Any]) -> N
         logger.debug("llm_costs row already projected", stream_id=stream_id)
         return
 
-    if not priced:
+    if not has_usage:
+        logger.warning(
+            "llm_logs row carries cost but no token usage — cannot recompute "
+            "(upstream telemetry gap); logged cost retained",
+            model=model,
+            agent_name=agent_name,
+            stream_id=stream_id,
+            logged_cost_usd=logged_cost,
+        )
+    elif not priced:
         logger.warning(
             "Unpriced model in llm_logs — rate table needs updating",
             model=model,

--- a/event-processor/tests/test_llm_cost_handler.py
+++ b/event-processor/tests/test_llm_cost_handler.py
@@ -221,3 +221,93 @@ class TestLlmCostProjection:
         assert called_at == datetime.fromtimestamp(
             1756260000, tz=timezone.utc
         )
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Absent token data must never be costed as $0.00 (deployment finding)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# Verifying the deployed projection against live demo data found 1,529 rows
+# ($32.92 of logged spend) arriving with prompt_tokens=0 / completion_tokens=0
+# but a real llm_cost — billieChat's streaming path logged no usage. Those
+# rows were stored priced=true with computed_cost_usd=0.0, so anyone summing
+# computed cost silently under-reported. BTB-302 guards the unknown-MODEL
+# case; this is the same failure via absent TOKENS.
+
+
+def _no_usage_fields(**over) -> dict:
+    """A streamed row as it actually arrives: cost present, tokens absent."""
+    f = _fields(
+        prompt_tokens="0",
+        completion_tokens="0",
+        cached_tokens="0",
+        total_tokens="0",
+        llm_cost="0.04224",
+        model="gpt-5.6-terra",
+    )
+    f.update(over)
+    return f
+
+
+class TestRowsWithoutUsage:
+    @pytest.mark.asyncio
+    async def test_zero_token_row_is_not_marked_priced(self, mock_pool):
+        """A row with no token data cannot be costed — recording it
+        priced=true at $0.00 is the silent-zero failure this ticket exists
+        to prevent. The logged figure is kept as the only valid number."""
+        await handle_llm_log(mock_pool, "1787793364510-0", _no_usage_fields())
+
+        (ins,) = _cost_inserts(mock_pool)
+        v = ins.values
+        assert v["priced"] is False, "token-less row must not claim to be priced"
+        assert v["computed_cost_usd"] == 0.0
+        assert v["logged_cost_usd"] == pytest.approx(0.04224)
+        assert v["has_usage"] is False
+
+    @pytest.mark.asyncio
+    async def test_zero_token_row_counts_as_unpriced_on_the_conversation(
+        self, mock_pool
+    ):
+        """It must show up in llm_unpriced_count so a reader can see the
+        conversation's computed total is incomplete."""
+        await handle_llm_log(mock_pool, "1787793364510-0", _no_usage_fields())
+        rollups = [
+            c
+            for c in mock_pool.calls_against("conversations")
+            if c.op == "UPDATE" and "llm_unpriced_count" in c.sql
+        ]
+        assert len(rollups) == 1
+        assert 1 in rollups[0].args, "unpriced increment not applied"
+
+    @pytest.mark.asyncio
+    async def test_normal_row_still_reports_usage_present(self, mock_pool):
+        """Regression: a row WITH tokens keeps priced=true and has_usage."""
+        await handle_llm_log(mock_pool, "1756260000000-0", _fields())
+        (ins,) = _cost_inserts(mock_pool)
+        assert ins.values["priced"] is True
+        assert ins.values["has_usage"] is True
+        assert ins.values["computed_cost_usd"] > 0
+
+    @pytest.mark.asyncio
+    async def test_completion_only_row_still_prices(self, mock_pool):
+        """A genuinely cheap call (prompt cached to 0 but output tokens
+        present) still has usable usage — must not be swept up."""
+        await handle_llm_log(
+            mock_pool,
+            "1756260000001-0",
+            _fields(prompt_tokens="0", completion_tokens="120"),
+        )
+        (ins,) = _cost_inserts(mock_pool)
+        assert ins.values["has_usage"] is True
+        assert ins.values["priced"] is True
+        assert ins.values["computed_cost_usd"] > 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_model_without_usage_is_still_unpriced(self, mock_pool):
+        """Both failure modes at once — stays unpriced, never $0.00 priced."""
+        await handle_llm_log(
+            mock_pool, "1787793364511-0", _no_usage_fields(model="gpt-9-unknown")
+        )
+        (ins,) = _cost_inserts(mock_pool)
+        assert ins.values["priced"] is False
+        assert ins.values["has_usage"] is False

--- a/src/collections/LlmCosts.ts
+++ b/src/collections/LlmCosts.ts
@@ -84,6 +84,15 @@ export const LlmCosts: CollectionConfig = {
       admin: { readOnly: true, description: 'Rate table version in force at ingest' },
     },
     {
+      name: 'hasUsage',
+      type: 'checkbox',
+      admin: {
+        readOnly: true,
+        description:
+          'False = the source llm_logs row carried a cost but no token counts (upstream telemetry gap) — computed cost is not derivable; use loggedCostUsd',
+      },
+    },
+    {
       name: 'priced',
       type: 'checkbox',
       admin: {

--- a/src/migrations/20260827_131500_llm_costs.ts
+++ b/src/migrations/20260827_131500_llm_costs.ts
@@ -46,6 +46,8 @@ export async function up({ db }: MigrateUpArgs): Promise<void> {
   ALTER TABLE "conversations" ADD COLUMN IF NOT EXISTS "llm_unpriced_count" numeric;`)
   await db.execute(sql`
   ALTER TABLE "conversations" ADD COLUMN IF NOT EXISTS "data_quality_alert" jsonb;`)
+  await db.execute(sql`
+  ALTER TABLE "llm_costs" ADD COLUMN IF NOT EXISTS "has_usage" boolean;`)
 }
 
 export async function down({ db }: MigrateDownArgs): Promise<void> {
@@ -59,4 +61,6 @@ export async function down({ db }: MigrateDownArgs): Promise<void> {
   ALTER TABLE "conversations" DROP COLUMN IF EXISTS "llm_unpriced_count";`)
   await db.execute(sql`
   ALTER TABLE "conversations" DROP COLUMN IF EXISTS "data_quality_alert";`)
+  await db.execute(sql`
+  ALTER TABLE "llm_costs" DROP COLUMN IF EXISTS "has_usage";`)
 }


### PR DESCRIPTION
## Why

Verifying the freshly-deployed cost projection against **live demo data** found **1,529 rows carrying $32.92 of logged spend with all token counts zero** — billieChat's streaming path logs no usage (root cause fixed in **billieChat#183**).

The handler stored those `priced=true, computed_cost_usd=0.0`. Anyone summing computed cost silently under-reports — the precise failure mode BTB-302 exists to prevent for an unknown **model**, reached instead via absent **tokens**. It also skewed the projection's own assurance signal: every agent reconciled computed-vs-logged at 1.000x except `customerLiaisonAgent` at 0.61x.

## Change

A row with no usable usage is now:
- `priced = false`, `computed_cost_usd = 0.0`
- `has_usage = false` — **new column**, surfaced read-only in the CRM with an explanation
- counted in the conversation's `llm_unpriced_count`, so a reader can see the computed total is incomplete
- logged with a **distinct warning** naming the telemetry gap rather than blaming the rate table
- `logged_cost_usd` retained as the only valid figure for the row

Deliberately narrow: "has usage" is `prompt + completion > 0`, so a genuinely cheap call with output tokens and a fully-cached prompt still prices normally (pinned by test).

## Verification

- Tests written first, watched fail: token-less row not priced; it increments `llm_unpriced_count`; **normal rows unaffected** (regression); completion-only row still prices; unknown-model-plus-no-usage stays unpriced.
- Suite **390 passed**; `pnpm typecheck` clean.
- Migration extends the existing BTB-302 file in both `up` and `down`.

## Sequencing

Independent of billieChat#183 — this one stops bad rows being *recorded*, that one stops them being *produced*. Once #183 is live, new streamed rows carry usage and price normally; historical rows keep `has_usage=false` and their logged figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3toZy36tzQuFe8ETWTHSH