### PR TITLE
fix(migrations): add has_usage in its OWN migration (BTB-302)

### DIFF
--- a/src/migrations/20260827_214500_llm_costs_has_usage.ts
+++ b/src/migrations/20260827_214500_llm_costs_has_usage.ts
@@ -1,0 +1,23 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Adds `llm_costs.has_usage` (BTB-302).
+ *
+ * This column was originally appended to 20260827_131500_llm_costs, but that
+ * migration had already been applied — Payload records migrations by name and
+ * skips them on re-run, so the appended ALTER never executed and any
+ * environment already carrying batch 24 was left with code expecting a column
+ * the schema did not have. Schema changes must always land in a NEW migration.
+ *
+ * Both statements are IF [NOT] EXISTS, so this is a no-op on a fresh database
+ * that picked the column up from the earlier migration.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+  ALTER TABLE "llm_costs" ADD COLUMN IF NOT EXISTS "has_usage" boolean;`)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+  ALTER TABLE "llm_costs" DROP COLUMN IF EXISTS "has_usage";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -25,6 +25,7 @@ import * as migration_20260822_121203_reapplication_block_state_version from './
 import * as migration_20260822_121938_reapplication_block_state_changed_at from './20260822_121938_reapplication_block_state_changed_at';
 import * as migration_20260824_112358_conversation_kill_record from './20260824_112358_conversation_kill_record';
 import * as migration_20260827_131500_llm_costs from './20260827_131500_llm_costs';
+import * as migration_20260827_214500_llm_costs_has_usage from './20260827_214500_llm_costs_has_usage';
 
 export const migrations = [
   {
@@ -161,5 +162,10 @@ export const migrations = [
     up: migration_20260827_131500_llm_costs.up,
     down: migration_20260827_131500_llm_costs.down,
     name: '20260827_131500_llm_costs',
+  },
+  {
+    up: migration_20260827_214500_llm_costs_has_usage.up,
+    down: migration_20260827_214500_llm_costs_has_usage.down,
+    name: '20260827_214500_llm_costs_has_usage',
   },
 ];


### PR DESCRIPTION
## What went wrong

I appended the `has_usage` column to `20260827_131500_llm_costs` — a migration that had **already been applied** in the previous deploy. Payload records migrations by name and skips applied ones, so the appended `ALTER` never ran. The result on demo: the app shipped code expecting a column the schema didn't have.

Symptoms observed on `billie-crm-demo`:
- Payload admin failed every `llm-costs` query — `column "has_usage" does not exist`
- any newly-arriving `llm_logs` row would have failed to insert

`migrate:status` showed the file as `Ran = Yes` (batch 24), which is exactly why it never self-corrected.

## Fix

A new migration containing only the `ADD COLUMN`. Both directions use `IF [NOT] EXISTS`, so it's a no-op on a fresh database that already picked the column up from the earlier file — the two paths converge rather than conflict.

**Rule this encodes: schema changes always land in a new migration, never as an edit to an applied one.**

## State

- Applied to demo (**batch 25**); `has_usage` confirmed present, admin queries and ingest working again.
- **No data lost** — verified rather than assumed: consumer-group `pending = 0`, and `llm_costs` row count (15,173) exactly matched the `llm_logs` stream length throughout. The backlog had fully drained before the broken deploy, and no new traffic arrived while it was broken.
- `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3toZy36tzQuFe8ETWTHSH