### PR TITLE
fix(migrations): add llm_costs_id to payload_locked_documents_rels (BTB-302)

### DIFF
--- a/src/migrations/20260827_224500_llm_costs_system_rels.ts
+++ b/src/migrations/20260827_224500_llm_costs_system_rels.ts
@@ -1,0 +1,36 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Adds the `llm_costs_id` relationship column Payload's document-locking
+ * system table keeps per registered collection (BTB-302 follow-up).
+ *
+ * Registering the `llm-costs` collection made Payload's runtime query
+ * `payload_locked_documents_rels.llm_costs_id` on EVERY admin detail view —
+ * the hand-written llm_costs migration created only the collection's own
+ * table, so every detail screen (Conversations included) failed with
+ * "column llm_costs_id does not exist" and rendered blank.
+ *
+ * Shape copied from the newest sibling (issues): typed as the collection's
+ * id type (llm_costs.id is integer), FK ON DELETE CASCADE, btree index.
+ * The FK uses a guarded DO block because ADD CONSTRAINT has no IF NOT
+ * EXISTS form.
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN IF NOT EXISTS "llm_costs_id" integer;`)
+  await db.execute(sql`
+  DO $$ BEGIN
+    ALTER TABLE "payload_locked_documents_rels"
+      ADD CONSTRAINT "payload_locked_documents_rels_llm_costs_fk"
+      FOREIGN KEY ("llm_costs_id") REFERENCES "llm_costs"("id") ON DELETE CASCADE;
+  EXCEPTION WHEN duplicate_object THEN NULL;
+  END $$;`)
+  await db.execute(sql`
+  CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_llm_costs_id_idx"
+    ON "payload_locked_documents_rels" ("llm_costs_id");`)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "llm_costs_id";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -26,6 +26,7 @@ import * as migration_20260822_121938_reapplication_block_state_changed_at from 
 import * as migration_20260824_112358_conversation_kill_record from './20260824_112358_conversation_kill_record';
 import * as migration_20260827_131500_llm_costs from './20260827_131500_llm_costs';
 import * as migration_20260827_214500_llm_costs_has_usage from './20260827_214500_llm_costs_has_usage';
+import * as migration_20260827_224500_llm_costs_system_rels from './20260827_224500_llm_costs_system_rels';
 
 export const migrations = [
   {
@@ -167,5 +168,10 @@ export const migrations = [
     up: migration_20260827_214500_llm_costs_has_usage.up,
     down: migration_20260827_214500_llm_costs_has_usage.down,
     name: '20260827_214500_llm_costs_has_usage',
+  },
+  {
+    up: migration_20260827_224500_llm_costs_system_rels.up,
+    down: migration_20260827_224500_llm_costs_system_rels.down,
+    name: '20260827_224500_llm_costs_system_rels',
   },
 ];


### PR DESCRIPTION
## What broke

Reported by the user: conversation **detail views rendered blank** (list fine). Server logs showed the mechanism — Payload's document-locking query, which runs on **every** admin detail view, referenced `payload_locked_documents_rels.llm_costs_id`:

```
error: column ... llm_costs_id does not exist
```

Registering a new collection makes Payload's system tables expect a per-collection relationship column there. My hand-written `llm_costs` migration created only the collection's own table — Payload's auto-generated migration would have included the system-table column. So the blank screens hit **all collections' detail views**, not just Conversations.

## Fix

New migration adding the column to the exact sibling pattern (copied from `issues`, the most recently added collection): `integer` (matching `llm_costs.id`), FK `ON DELETE CASCADE` (guarded `DO` block since `ADD CONSTRAINT` has no `IF NOT EXISTS`), btree index.

**Applied to demo and verified**: column present, the previously-failing locked-documents query passes, and the conversation detail URL returns HTTP 200.

## Process lesson (second in this family)

A hand-written migration for a **new collection** must also cover Payload's system tables. For collection registrations, `pnpm payload migrate:create` should be preferred — the drizzle diff generates these automatically. The earlier lesson (never append to an applied migration) is in #84; both are now encoded in migration-file comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3toZy36tzQuFe8ETWTHSH