### PR TITLE
fix(migrations): convert llm_costs ids from serial to uuid (BTB-302)

### DIFF
--- a/src/migrations/20260827_230000_llm_costs_uuid_id.ts
+++ b/src/migrations/20260827_230000_llm_costs_uuid_id.ts
@@ -1,0 +1,81 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+/**
+ * Converts llm_costs ids from serial integer to uuid (BTB-302 follow-up #3).
+ *
+ * The pg adapter runs with `idType: 'uuid'` (payload.config.ts), so Payload's
+ * runtime schema types llm_costs.id — and payload_locked_documents_rels
+ * .llm_costs_id — as uuid. The hand-written 20260827_131500_llm_costs
+ * migration created `id serial` instead, and 20260827_224500 followed suit
+ * with an integer rels column. Payload's document-lock check compares the
+ * opened record's id against EVERY rels column in one OR chain, so the lone
+ * integer column made Postgres reject the uuid parameter
+ * ("invalid input syntax for type integer") on EVERY admin detail view,
+ * for every collection — pages rendered blank.
+ *
+ * Regenerating llm_costs ids is safe: rows are a projection keyed by
+ * stream_id, and nothing references llm_costs.id except transient lock rows
+ * (deleted below before the column is rebuilt).
+ */
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+  DELETE FROM "payload_locked_documents" WHERE "id" IN (
+    SELECT "parent_id" FROM "payload_locked_documents_rels" WHERE "llm_costs_id" IS NOT NULL);`)
+  await db.execute(sql`
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_llm_costs_fk";`)
+  await db.execute(sql`
+  DROP INDEX IF EXISTS "payload_locked_documents_rels_llm_costs_id_idx";`)
+  await db.execute(sql`
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "llm_costs_id";`)
+
+  // Guarded so a schema already at uuid (push:true envs) is never re-keyed.
+  await db.execute(sql`
+  DO $$ BEGIN
+    IF (SELECT data_type FROM information_schema.columns
+        WHERE table_name = 'llm_costs' AND column_name = 'id') <> 'uuid' THEN
+      ALTER TABLE "llm_costs" ALTER COLUMN "id" DROP DEFAULT;
+      ALTER TABLE "llm_costs" ALTER COLUMN "id" SET DATA TYPE uuid USING gen_random_uuid();
+      DROP SEQUENCE IF EXISTS "llm_costs_id_seq";
+    END IF;
+  END $$;`)
+  await db.execute(sql`
+  ALTER TABLE "llm_costs" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();`)
+
+  await db.execute(sql`
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "llm_costs_id" uuid;`)
+  await db.execute(sql`
+  ALTER TABLE "payload_locked_documents_rels"
+    ADD CONSTRAINT "payload_locked_documents_rels_llm_costs_fk"
+    FOREIGN KEY ("llm_costs_id") REFERENCES "public"."llm_costs"("id") ON DELETE cascade ON UPDATE no action;`)
+  await db.execute(sql`
+  CREATE INDEX "payload_locked_documents_rels_llm_costs_id_idx"
+    ON "payload_locked_documents_rels" USING btree ("llm_costs_id");`)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+  ALTER TABLE "payload_locked_documents_rels" DROP CONSTRAINT IF EXISTS "payload_locked_documents_rels_llm_costs_fk";`)
+  await db.execute(sql`
+  DROP INDEX IF EXISTS "payload_locked_documents_rels_llm_costs_id_idx";`)
+  await db.execute(sql`
+  ALTER TABLE "payload_locked_documents_rels" DROP COLUMN IF EXISTS "llm_costs_id";`)
+  await db.execute(sql`
+  ALTER TABLE "llm_costs" ALTER COLUMN "id" DROP DEFAULT;`)
+  await db.execute(sql`
+  CREATE SEQUENCE IF NOT EXISTS "llm_costs_id_seq";`)
+  await db.execute(sql`
+  ALTER TABLE "llm_costs" ALTER COLUMN "id" SET DATA TYPE integer USING nextval('llm_costs_id_seq');`)
+  await db.execute(sql`
+  ALTER TABLE "llm_costs" ALTER COLUMN "id" SET DEFAULT nextval('llm_costs_id_seq');`)
+  await db.execute(sql`
+  ALTER SEQUENCE "llm_costs_id_seq" OWNED BY "llm_costs"."id";`)
+  await db.execute(sql`
+  ALTER TABLE "payload_locked_documents_rels" ADD COLUMN "llm_costs_id" integer;`)
+  await db.execute(sql`
+  ALTER TABLE "payload_locked_documents_rels"
+    ADD CONSTRAINT "payload_locked_documents_rels_llm_costs_fk"
+    FOREIGN KEY ("llm_costs_id") REFERENCES "llm_costs"("id") ON DELETE CASCADE;`)
+  await db.execute(sql`
+  CREATE INDEX IF NOT EXISTS "payload_locked_documents_rels_llm_costs_id_idx"
+    ON "payload_locked_documents_rels" ("llm_costs_id");`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -27,6 +27,7 @@ import * as migration_20260824_112358_conversation_kill_record from './20260824_
 import * as migration_20260827_131500_llm_costs from './20260827_131500_llm_costs';
 import * as migration_20260827_214500_llm_costs_has_usage from './20260827_214500_llm_costs_has_usage';
 import * as migration_20260827_224500_llm_costs_system_rels from './20260827_224500_llm_costs_system_rels';
+import * as migration_20260827_230000_llm_costs_uuid_id from './20260827_230000_llm_costs_uuid_id';
 
 export const migrations = [
   {
@@ -173,5 +174,10 @@ export const migrations = [
     up: migration_20260827_224500_llm_costs_system_rels.up,
     down: migration_20260827_224500_llm_costs_system_rels.down,
     name: '20260827_224500_llm_costs_system_rels',
+  },
+  {
+    up: migration_20260827_230000_llm_costs_uuid_id.up,
+    down: migration_20260827_230000_llm_costs_uuid_id.down,
+    name: '20260827_230000_llm_costs_uuid_id',
   },
 ];


### PR DESCRIPTION
## Summary
- Every admin detail view (all record types) rendered blank on demo: Payload's document-lock check compares the opened record's id against **every** `payload_locked_documents_rels` column in one OR chain, and the lone integer column (`llm_costs_id`) made Postgres reject the uuid parameter with `invalid input syntax for type integer`.
- Root cause: the pg adapter runs with `idType: 'uuid'`, but the hand-written `20260827_131500_llm_costs` migration created `id serial`, and `20260827_224500` added the rels column as `integer` (the generated `issues` sibling it claimed to copy actually used `uuid`).
- Fix: new migration `20260827_230000_llm_costs_uuid_id` converts `llm_costs.id` to `uuid DEFAULT gen_random_uuid()` and rebuilds the rels column as uuid with FK + index. Re-keying is safe — `stream_id` is the natural key, the event-processor upserts on `stream_id` without touching `id`, and only transient lock rows reference llm_costs ids (deleted first). Guarded so a `push: true` dev DB already at uuid is never re-keyed.

## Testing
- Throwaway Postgres: applied the full committed chain, reproduced the exact failing query, applied the fix, query passes; id-less inserts get uuid defaults; down/up both run clean.
- `pnpm test:int` green (2645 passed).
- Applied to demo (`make -C infra/fly pg-migrate ENV=demo`); the locked-documents query returns 200 and detail views render again (user-verified in the UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RexPwQmb737xwR3Hx5Pgum